### PR TITLE
Report on get_childrent function call due to default -1 for posts_per_page

### DIFF
--- a/WordPressVIPMinimum/Sniffs/VIP/RestrictedFunctionsSniff.php
+++ b/WordPressVIPMinimum/Sniffs/VIP/RestrictedFunctionsSniff.php
@@ -32,7 +32,7 @@ class WordPressVIPMinimum_Sniffs_VIP_RestrictedFunctionsSniff extends WordPress_
 			),
 			'get_children' => array(
 				'type' => 'error',
-				'message' => '%s() performs a no-LIMIT query by default, make sure to set a reasonable posts_per_page. %s() will do a -1 query by default, a maximum of 100 should be used.'
+				'message' => '%s() performs a no-LIMIT query by default, make sure to set a reasonable posts_per_page. %s() will do a -1 query by default, a maximum of 100 should be used.',
 				'functions' => array(
 					'get_children',
 				),

--- a/WordPressVIPMinimum/Sniffs/VIP/RestrictedFunctionsSniff.php
+++ b/WordPressVIPMinimum/Sniffs/VIP/RestrictedFunctionsSniff.php
@@ -8,7 +8,7 @@
  * Restricts usage of some functions in VIP context.
  *
  */
-class WordPressVIPMinimum_Sniffs_VIP_RestrictedFunctionsSniff extends WordPress_AbstractFunctionRestrictionsSniff {
+class WordPressVIPMinimum_Sniffs_VIP_RestrictedFunctionsSniff extends WordPress_Sniffs_VIP_RestrictedFunctionsSniff {
 
 	/**
 	 * Groups of functions to restrict.
@@ -16,7 +16,10 @@ class WordPressVIPMinimum_Sniffs_VIP_RestrictedFunctionsSniff extends WordPress_
 	 * @return array
 	 */
 	public function getGroups() {
-		return array(
+
+		$original_groups = parent::getGroups();
+
+		$new_groups = array(
 			'wp_cache_get_multi' => array(
 				'type' => 'error',
 				'message' => '%s is not supported on the WordPress.com VIP platform.',
@@ -27,7 +30,17 @@ class WordPressVIPMinimum_Sniffs_VIP_RestrictedFunctionsSniff extends WordPress_
 				'message' => '%s is prohibited on the WordPress.com VIP platform',
 				'functions' => array( 'get_super_admins' ),
 			),
+			'get_children' => array(
+				'type' => 'error',
+				'message' => '%s() performs a no-LIMIT query by default. Make sure to set a reasonable posts_per_page, get_children will do a -1 query by default, a maximum of 100 should be used.',
+				'functions' => array(
+					'get_children',
+				),
+			),
 		);
+
+		return array_merge( $original_groups, $new_groups );
+
 	} // end getGroups().
 }
 

--- a/WordPressVIPMinimum/Sniffs/VIP/RestrictedFunctionsSniff.php
+++ b/WordPressVIPMinimum/Sniffs/VIP/RestrictedFunctionsSniff.php
@@ -32,7 +32,7 @@ class WordPressVIPMinimum_Sniffs_VIP_RestrictedFunctionsSniff extends WordPress_
 			),
 			'get_children' => array(
 				'type' => 'error',
-				'message' => '%s() performs a no-LIMIT query by default. Make sure to set a reasonable posts_per_page, get_children will do a -1 query by default, a maximum of 100 should be used.',
+				'message' => '%s() performs a no-LIMIT query by default, make sure to set a reasonable posts_per_page. %s() will do a -1 query by default, a maximum of 100 should be used.'
 				'functions' => array(
 					'get_children',
 				),

--- a/WordPressVIPMinimum/ruleset.xml
+++ b/WordPressVIPMinimum/ruleset.xml
@@ -4,6 +4,7 @@
 
 	<rule ref="WordPress.VIP">
 		<exclude name="WordPress.VIP.ValidatedSanitizedInput"/>
+		<exclude name="WordPress.VIP.RestrictedFunctions"/>
 	</rule>
 
 	<rule ref="WordPress.XSS.EscapeOutput"/>


### PR DESCRIPTION
Since the `get_children` is `setting posts_per_page` to `-1` by default, we should make sure that developers are overriding the default value to something reasonable - eg.: 100

This commit is changing the parent of the `WordPressVIPMinimum_Sniffs_VIP_RestrictedFunctionsSniff` class from `WordPress_AbstractFunctionRestrictionsSniff` to `WordPress_Sniffs_VIP_RestrictedFunctionsSniff` and takes advantage of the inheritance which should allows us to override the original mesages in future.

Further, it is adding the `get_children` group with a message about the default `-1` value for `posts_per_page`.

The changeset also excluded the original WordPress.VIP.RestrictedFunctions since we now have our own with all groups.

Fixes #10