### PR TITLE
Fixing bugs introduced after merging #11

### DIFF
--- a/WordPressVIPMinimum/Sniffs/VIP/RestrictedFunctionsSniff.php
+++ b/WordPressVIPMinimum/Sniffs/VIP/RestrictedFunctionsSniff.php
@@ -32,7 +32,7 @@ class WordPressVIPMinimum_Sniffs_VIP_RestrictedFunctionsSniff extends WordPress_
 			),
 			'get_children' => array(
 				'type' => 'error',
-				'message' => '%s() performs a no-LIMIT query by default, make sure to set a reasonable posts_per_page. %s() will do a -1 query by default, a maximum of 100 should be used.',
+				'message' => '%1$s() performs a no-LIMIT query by default, make sure to set a reasonable posts_per_page. %1$s() will do a -1 query by default, a maximum of 100 should be used.',
 				'functions' => array(
 					'get_children',
 				),
@@ -42,5 +42,6 @@ class WordPressVIPMinimum_Sniffs_VIP_RestrictedFunctionsSniff extends WordPress_
 		return array_merge( $original_groups, $new_groups );
 
 	} // end getGroups().
+
 }
 

--- a/WordPressVIPMinimum/Sniffs/VIP/RestrictedFunctionsSniff.php
+++ b/WordPressVIPMinimum/Sniffs/VIP/RestrictedFunctionsSniff.php
@@ -46,6 +46,5 @@ class WordPressVIPMinimum_Sniffs_VIP_RestrictedFunctionsSniff extends WordPress_
 		return array_merge( $original_groups, $new_groups );
 
 	} // end getGroups().
-
 }
 

--- a/WordPressVIPMinimum/Sniffs/VIP/RestrictedFunctionsSniff.php
+++ b/WordPressVIPMinimum/Sniffs/VIP/RestrictedFunctionsSniff.php
@@ -39,6 +39,10 @@ class WordPressVIPMinimum_Sniffs_VIP_RestrictedFunctionsSniff extends WordPress_
 			),
 		);
 
+		$original_groups['get_posts']['functions'] = array_filter( $original_groups['get_posts']['functions'], function( $v, $k ) {
+			return ! in_array( $v, array( 'get_children' ), true );
+		} );
+
 		return array_merge( $original_groups, $new_groups );
 
 	} // end getGroups().


### PR DESCRIPTION
The merge of #11 introduced following bugs:

1) Custom reporting on get_children is not properly displayed due to printf not having enough arguments
2) PHPCS is producing duplicate reports for get_children since we are not removing it from the original grop

The PR is addressing the issues above.