### PR TITLE
Flagging `flush_rewrite_rules` in the Restricted Functions Sniff

### DIFF
--- a/WordPressVIPMinimum/Sniffs/VIP/RestrictedFunctionsSniff.php
+++ b/WordPressVIPMinimum/Sniffs/VIP/RestrictedFunctionsSniff.php
@@ -45,6 +45,13 @@ class WordPressVIPMinimum_Sniffs_VIP_RestrictedFunctionsSniff extends WordPress_
 					),
 				),
 			),
+			'rewrite_rules' => array(
+				'type' => 'error',
+				'message' => '%s should not be used in any normal circumstances in the theme code.',
+				'functions' => array(
+					'flush_rewrite_rules',
+				)
+			),
 		);
 
 		$original_groups['get_posts']['functions'] = array_filter( $original_groups['get_posts']['functions'], function( $v ) {


### PR DESCRIPTION
The `flush_rewrite_rules()` should not be used in any normal circumstances in the theme code. This commit adds the function to a new separate group of the Restricted Functions Sniff.

Fixes #30