### PR TITLE
Removing `wpcom_vip_irc_color` from the internal group of restricted functions

### DIFF
--- a/WordPressVIPMinimum/Sniffs/VIP/RestrictedFunctionsSniff.php
+++ b/WordPressVIPMinimum/Sniffs/VIP/RestrictedFunctionsSniff.php
@@ -41,7 +41,6 @@ class WordPressVIPMinimum_Sniffs_VIP_RestrictedFunctionsSniff extends WordPress_
 					'message' => '%1$s() is for internal use only.',
 					'functions' => array(
 						'wpcom_vip_irc',
-						'wpcom_vip_irc_color',
 					),
 				),
 			),


### PR DESCRIPTION
The `wpcom_vip_irc_color` function is about to be removed from the codebase via https://github.com/Automattic/vip-go-mu-plugins/pull/467

Let's wait with merging this on the referenced PR.

Fixes #31