### PR TITLE
Remove wpcom_vip_irc_color()

### DIFF
--- a/WordPressVIPMinimum/Sniffs/VIP/RestrictedFunctionsSniff.php
+++ b/WordPressVIPMinimum/Sniffs/VIP/RestrictedFunctionsSniff.php
@@ -41,7 +41,6 @@ class WordPressVIPMinimum_Sniffs_VIP_RestrictedFunctionsSniff extends WordPress_
 					'message' => '%1$s() is for internal use only.',
 					'functions' => array(
 						'wpcom_vip_irc',
-						'wpcom_vip_irc_color',
 					),
 				),
 			),


### PR DESCRIPTION
This function has been removed and is no longer used.

See https://github.com/Automattic/vip-go-mu-plugins/issues/464

Fixes #31