### PR TITLE
Flag `do_robotstxt` action callback

### DIFF
--- a/WordPressVIPMinimum/Sniffs/VIP/RobotstxtSniff.php
+++ b/WordPressVIPMinimum/Sniffs/VIP/RobotstxtSniff.php
@@ -1,7 +1,4 @@
 <?php
-
-namespace Sniffs\VIP;
-
 /**
  * WordPressVIPMinimum Coding Standard.
  *
@@ -9,6 +6,9 @@ namespace Sniffs\VIP;
  * @link    https://github.com/Automattic/VIP-Coding-Standards
  * @license https://github.com/Automattic/VIP-Coding-Standards/blob/master/LICENSE.md GPL v2 or later.
  */
+
+namespace Sniffs\VIP;
+
 
 /**
  * This sniff searches for `do_robotstxt` action hooked callback and thows an internal reminder

--- a/WordPressVIPMinimum/Sniffs/VIP/RobotstxtSniff.php
+++ b/WordPressVIPMinimum/Sniffs/VIP/RobotstxtSniff.php
@@ -9,7 +9,6 @@
 
 namespace Sniffs\VIP;
 
-
 /**
  * This sniff searches for `do_robotstxt` action hooked callback and thows an internal reminder
  * for VIP devs to flush related caches in order to make the change actually happen in production

--- a/WordPressVIPMinimum/Sniffs/VIP/RobotstxtSniff.php
+++ b/WordPressVIPMinimum/Sniffs/VIP/RobotstxtSniff.php
@@ -13,7 +13,7 @@ namespace WordPressVIPMinimum\Sniffs\VIP;
  * This sniff searches for `do_robotstxt` action hooked callback and thows an internal reminder
  * for VIP devs to flush related caches in order to make the change actually happen in production
  */
-class WordPressVIPMinimum_Sniffs_VIP_RobotstxtSniff implements PHP_CodeSniffer_Sniff {
+class WordPressVIPMinimum_Sniffs_VIP_RobotstxtSniff implements \PHP_CodeSniffer_Sniff {
 
 	/**
 	 * Returns the token types that this sniff is interested in.

--- a/WordPressVIPMinimum/Sniffs/VIP/RobotstxtSniff.php
+++ b/WordPressVIPMinimum/Sniffs/VIP/RobotstxtSniff.php
@@ -2,6 +2,9 @@
 /**
  * WordPressVIPMinimum Coding Standard.
  *
+ * @package Automattic/VIP-Coding-Standards
+ * @link    https://github.com/Automattic/VIP-Coding-Standards
+ * @license https://github.com/Automattic/VIP-Coding-Standards/blob/master/LICENSE.md GPL v2 or later.
  */
 
 /**
@@ -22,8 +25,10 @@ class WordPressVIPminimum_Sniffs_VIP_RobotstxtSniff implements PHP_CodeSniffer_S
 	/**
 	 * Processes the tokens that this sniff is interested in.
 	 *
-	 * @param PHP_CodeSniffer_File $phpcsFile The file where the token was found.
-	 * @param int $stackPtr  The position in the stack where the token was found.
+	 * @param PHP_CodeSniffer_File $phpcsFile The file where the token 
+	 *					  was found.
+	 * @param int                  $stackPtr  The position in the stack
+	 *					  where the token was found.
 	 *
 	 * @return void
 	 */

--- a/WordPressVIPMinimum/Sniffs/VIP/RobotstxtSniff.php
+++ b/WordPressVIPMinimum/Sniffs/VIP/RobotstxtSniff.php
@@ -64,7 +64,7 @@ class WordPressVIPMinimum_Sniffs_VIP_RobotstxtSniff implements \PHP_CodeSniffer_
 		}
 
 		if ( 'do_robotstxt' === substr( $tokens[ $actionNamePtr ]['content'], 1, -1 ) ) {
-			$phpcsFile->addWarning( 'Internal note: remember to flush robots.txt nginx cache after deploying this revision', $stackPtr );
+			$phpcsFile->addWarning( 'Internal note: remember to flush robots.txt nginx cache after deploying this revision', $stackPtr, 'RobotstxtSniff' );
 		}
 
 	}

--- a/WordPressVIPMinimum/Sniffs/VIP/RobotstxtSniff.php
+++ b/WordPressVIPMinimum/Sniffs/VIP/RobotstxtSniff.php
@@ -1,4 +1,7 @@
 <?php
+
+namespace Sniffs\VIP;
+
 /**
  * WordPressVIPMinimum Coding Standard.
  *
@@ -43,7 +46,7 @@ class WordPressVIPMinimum_Sniffs_VIP_RobotstxtSniff implements PHP_CodeSniffer_S
 		}
 
 		$actionNamePtr = $phpcsFile->findNext(
-			array_merge( PHP_CodeSniffer_Tokens::$emptyTokens, array( T_OPEN_PARENTHESIS ) ), // types
+			array_merge( PHP_CodeSniffer_Tokens::$emptyTokens, array( T_OPEN_PARENTHESIS ) ), // types.
 			$stackPtr + 1, // start.
 			null, // end.
 			true, // exclude.

--- a/WordPressVIPMinimum/Sniffs/VIP/RobotstxtSniff.php
+++ b/WordPressVIPMinimum/Sniffs/VIP/RobotstxtSniff.php
@@ -12,6 +12,7 @@ namespace WordPressVIPMinimum\Sniffs\VIP;
 use PHP_CodeSniffer\Files\File;
 use PHP_CodeSniffer\Sniffs\Sniff;
 use PHP_CodeSniffer\Util\Tokens;
+use PHP_CodeSniffer\Util;
 
 /**
  * This sniff searches for `do_robotstxt` action hooked callback and thows an internal reminder
@@ -49,7 +50,7 @@ class WordPressVIPMinimum_Sniffs_VIP_RobotstxtSniff implements \PHP_CodeSniffer_
 		}
 
 		$actionNamePtr = $phpcsFile->findNext(
-			array_merge( PHP_CodeSniffer_Tokens::$emptyTokens, array( T_OPEN_PARENTHESIS ) ), // types.
+			array_merge( Tokens::$emptyTokens, array( T_OPEN_PARENTHESIS ) ), // types.
 			$stackPtr + 1, // start.
 			null, // end.
 			true, // exclude.

--- a/WordPressVIPMinimum/Sniffs/VIP/RobotstxtSniff.php
+++ b/WordPressVIPMinimum/Sniffs/VIP/RobotstxtSniff.php
@@ -1,0 +1,56 @@
+<?php
+
+/**
+ * This sniff searches for `do_robotstxt` action hooked callback and thows an internal reminder
+ * for VIP devs to flush related caches in order to make the change actually happen in production
+ */
+class WordPressVIPminimum_Sniffs_VIP_RobotstxtSniff implements PHP_CodeSniffer_Sniff {
+	
+	/**
+	 * Returns the token types that this sniff is interested in.
+	 *
+	 * @return array(int)
+	 */
+	public function register() {
+		return PHP_CodeSniffer_Tokens::$functionNameTokens;
+	}// end register()
+
+	/**
+	 * Processes the tokens that this sniff is interested in.
+	 *
+	 * @param PHP_CodeSniffer_File $phpcsFile The file where the token was found.
+	 * @param int $stackPtr  The position in the stack where the token was found.
+	 *
+	 * @return void
+	 */
+	public function process(PHP_CodeSniffer_File $phpcsFile, $stackPtr) {
+		
+		$tokens = $phpcsFile->getTokens();
+	
+		$functionName = $tokens[$stackPtr]['content'];
+
+		if ( 'add_action' !== $functionName ) {
+			return;
+		}
+
+		$actionNamePtr = $phpcsFile->findNext(
+			array_merge( PHP_CodeSniffer_Tokens::$emptyTokens, array( T_OPEN_PARENTHESIS ) ), //types
+			$stackPtr + 1, //start
+			null, //end
+			true, //exclude
+			null, //value,
+			true //local
+		);
+
+		if ( ! $actionNamePtr ) {
+			// Something is wrong
+			return;
+		}
+
+		if ( 'do_robotstxt' === substr( $tokens[$actionNamePtr]['content'], 1, -1 ) ) {
+			$phpcsFile->addWarning( 'Internal note: remember to flush robots.txt nginx cache after deploying this revision', $stackPtr );
+		}
+
+	}// end process()
+
+}

--- a/WordPressVIPMinimum/Sniffs/VIP/RobotstxtSniff.php
+++ b/WordPressVIPMinimum/Sniffs/VIP/RobotstxtSniff.php
@@ -1,4 +1,8 @@
 <?php
+/**
+ * WordPressVIPMinimum Coding Standard.
+ *
+ */
 
 /**
  * This sniff searches for `do_robotstxt` action hooked callback and thows an internal reminder
@@ -13,7 +17,7 @@ class WordPressVIPminimum_Sniffs_VIP_RobotstxtSniff implements PHP_CodeSniffer_S
 	 */
 	public function register() {
 		return PHP_CodeSniffer_Tokens::$functionNameTokens;
-	}// end register()
+	}
 
 	/**
 	 * Processes the tokens that this sniff is interested in.
@@ -51,6 +55,5 @@ class WordPressVIPminimum_Sniffs_VIP_RobotstxtSniff implements PHP_CodeSniffer_S
 			$phpcsFile->addWarning( 'Internal note: remember to flush robots.txt nginx cache after deploying this revision', $stackPtr );
 		}
 
-	}// end process()
-
+	}
 }

--- a/WordPressVIPMinimum/Sniffs/VIP/RobotstxtSniff.php
+++ b/WordPressVIPMinimum/Sniffs/VIP/RobotstxtSniff.php
@@ -7,8 +7,6 @@
  * @license https://github.com/Automattic/VIP-Coding-Standards/blob/master/LICENSE.md GPL v2 or later.
  */
 
-namespace Sniffs\VIP;
-
 /**
  * This sniff searches for `do_robotstxt` action hooked callback and thows an internal reminder
  * for VIP devs to flush related caches in order to make the change actually happen in production

--- a/WordPressVIPMinimum/Sniffs/VIP/RobotstxtSniff.php
+++ b/WordPressVIPMinimum/Sniffs/VIP/RobotstxtSniff.php
@@ -7,6 +7,8 @@
  * @license https://github.com/Automattic/VIP-Coding-Standards/blob/master/LICENSE.md GPL v2 or later.
  */
 
+namespace WordPressVIPMinimum\Sniffs\VIP;
+
 /**
  * This sniff searches for `do_robotstxt` action hooked callback and thows an internal reminder
  * for VIP devs to flush related caches in order to make the change actually happen in production

--- a/WordPressVIPMinimum/Sniffs/VIP/RobotstxtSniff.php
+++ b/WordPressVIPMinimum/Sniffs/VIP/RobotstxtSniff.php
@@ -7,6 +7,7 @@
  * @license https://github.com/Automattic/VIP-Coding-Standards/blob/master/LICENSE.md GPL v2 or later.
  */
 
+
 namespace Sniffs\VIP;
 
 /**

--- a/WordPressVIPMinimum/Sniffs/VIP/RobotstxtSniff.php
+++ b/WordPressVIPMinimum/Sniffs/VIP/RobotstxtSniff.php
@@ -7,7 +7,6 @@
  * @license https://github.com/Automattic/VIP-Coding-Standards/blob/master/LICENSE.md GPL v2 or later.
  */
 
-
 namespace Sniffs\VIP;
 
 /**

--- a/WordPressVIPMinimum/Sniffs/VIP/RobotstxtSniff.php
+++ b/WordPressVIPMinimum/Sniffs/VIP/RobotstxtSniff.php
@@ -2,12 +2,16 @@
 /**
  * WordPressVIPMinimum Coding Standard.
  *
- * @package Automattic/VIP-Coding-Standards
+ * @package VIPCS\WordPressVIPMinimum
  * @link    https://github.com/Automattic/VIP-Coding-Standards
  * @license https://github.com/Automattic/VIP-Coding-Standards/blob/master/LICENSE.md GPL v2 or later.
  */
 
 namespace WordPressVIPMinimum\Sniffs\VIP;
+
+use PHP_CodeSniffer\Files\File;
+use PHP_CodeSniffer\Sniffs\Sniff;
+use PHP_CodeSniffer\Util\Tokens;
 
 /**
  * This sniff searches for `do_robotstxt` action hooked callback and thows an internal reminder
@@ -21,7 +25,7 @@ class WordPressVIPMinimum_Sniffs_VIP_RobotstxtSniff implements \PHP_CodeSniffer_
 	 * @return array(int)
 	 */
 	public function register() {
-		return PHP_CodeSniffer_Tokens::$functionNameTokens;
+		return Tokens::$functionNameTokens;
 	}
 
 	/**
@@ -34,7 +38,7 @@ class WordPressVIPMinimum_Sniffs_VIP_RobotstxtSniff implements \PHP_CodeSniffer_
 	 *
 	 * @return void
 	 */
-	public function process( PHP_CodeSniffer_File $phpcsFile, $stackPtr ) {
+	public function process( File $phpcsFile, $stackPtr ) {
 
 		$tokens = $phpcsFile->getTokens();
 

--- a/WordPressVIPMinimum/Sniffs/VIP/RobotstxtSniff.php
+++ b/WordPressVIPMinimum/Sniffs/VIP/RobotstxtSniff.php
@@ -11,8 +11,8 @@
  * This sniff searches for `do_robotstxt` action hooked callback and thows an internal reminder
  * for VIP devs to flush related caches in order to make the change actually happen in production
  */
-class WordPressVIPminimum_Sniffs_VIP_RobotstxtSniff implements PHP_CodeSniffer_Sniff {
-	
+class WordPressVIPMinimum_Sniffs_VIP_RobotstxtSniff implements PHP_CodeSniffer_Sniff {
+
 	/**
 	 * Returns the token types that this sniff is interested in.
 	 *
@@ -25,38 +25,38 @@ class WordPressVIPminimum_Sniffs_VIP_RobotstxtSniff implements PHP_CodeSniffer_S
 	/**
 	 * Processes the tokens that this sniff is interested in.
 	 *
-	 * @param PHP_CodeSniffer_File $phpcsFile The file where the token 
-	 *					  was found.
+	 * @param PHP_CodeSniffer_File $phpcsFile The file where the token
+	 *                                        was found.
 	 * @param int                  $stackPtr  The position in the stack
-	 *					  where the token was found.
+	 *                                        where the token was found.
 	 *
 	 * @return void
 	 */
-	public function process(PHP_CodeSniffer_File $phpcsFile, $stackPtr) {
-		
+	public function process( PHP_CodeSniffer_File $phpcsFile, $stackPtr ) {
+
 		$tokens = $phpcsFile->getTokens();
-	
-		$functionName = $tokens[$stackPtr]['content'];
+
+		$functionName = $tokens[ $stackPtr ]['content'];
 
 		if ( 'add_action' !== $functionName ) {
 			return;
 		}
 
 		$actionNamePtr = $phpcsFile->findNext(
-			array_merge( PHP_CodeSniffer_Tokens::$emptyTokens, array( T_OPEN_PARENTHESIS ) ), //types
-			$stackPtr + 1, //start
-			null, //end
-			true, //exclude
-			null, //value,
-			true //local
+			array_merge( PHP_CodeSniffer_Tokens::$emptyTokens, array( T_OPEN_PARENTHESIS ) ), // types
+			$stackPtr + 1, // start.
+			null, // end.
+			true, // exclude.
+			null, // value.
+			true // local.
 		);
 
 		if ( ! $actionNamePtr ) {
-			// Something is wrong
+			// Something is wrong.
 			return;
 		}
 
-		if ( 'do_robotstxt' === substr( $tokens[$actionNamePtr]['content'], 1, -1 ) ) {
+		if ( 'do_robotstxt' === substr( $tokens[ $actionNamePtr ]['content'], 1, -1 ) ) {
 			$phpcsFile->addWarning( 'Internal note: remember to flush robots.txt nginx cache after deploying this revision', $stackPtr );
 		}
 

--- a/WordPressVIPMinimum/Tests/VIP/RobotstxtSniff.inc
+++ b/WordPressVIPMinimum/Tests/VIP/RobotstxtSniff.inc
@@ -1,0 +1,11 @@
+<?php
+
+function my_do_robotstxt() {
+	echo 'Disallow: foo/bar2.txt';
+}
+
+add_action( 'do_robotstxt', 'my_do_robotstxt');
+
+add_action( 'do_robotstxt', function() {
+	echo 'Disallow: foo/bar.txt';
+});

--- a/WordPressVIPMinimum/Tests/VIP/RobotstxtSniff.php
+++ b/WordPressVIPMinimum/Tests/VIP/RobotstxtSniff.php
@@ -1,0 +1,31 @@
+<?php
+/**
+ * Unit test class for WordPressVIPMinimum Coding Standard.
+ */
+
+/**
+ * Unit test class for the RobotstxtSniff sniff.
+ */
+class WordPressVIPMinimum_Sniffs_VIP_RobotstxtSniffUnitTest extends AbstractSniffUnitTest {
+
+	/**
+	 * Returns the lines where errors should occur.
+	 *
+	 * @return array <int line number> => <int number of errors>
+	 */
+	public function getErrorList() {
+		return array();
+	}
+
+	/**
+	 * Returns the lines where warnings should occur.
+	 *
+	 * @return array <int line number> => <int number of warnings>
+	 */
+	public function getWarningList() {
+		return array(
+			9 => 1,
+			7 => 1,
+		);
+	}
+}

--- a/WordPressVIPMinimum/Tests/VIP/RobotstxtSniff.php
+++ b/WordPressVIPMinimum/Tests/VIP/RobotstxtSniff.php
@@ -1,6 +1,10 @@
 <?php
 /**
  * Unit test class for WordPressVIPMinimum Coding Standard.
+ *
+ * @package VIPCS\WordPressVIPMinimum
+ * @link    https://github.com/Automattic/VIP-Coding-Standards
+ * @license https://github.com/Automattic/VIP-Coding-Standards/blob/master/LICENSE.md GPL v2 or later.
  */
 
 namespace WordPressVIPMinimum\Sniffs\VIP;

--- a/WordPressVIPMinimum/Tests/VIP/RobotstxtSniff.php
+++ b/WordPressVIPMinimum/Tests/VIP/RobotstxtSniff.php
@@ -3,6 +3,10 @@
  * Unit test class for WordPressVIPMinimum Coding Standard.
  */
 
+namespace WordPressVIPMinimum\Sniffs\VIP;
+
+use PHP_CodeSniffer\Tests\Standards\AbstractSniffUnitTest;
+
 /**
  * Unit test class for the RobotstxtSniff sniff.
  */


### PR DESCRIPTION
Since we need to flush NginX cache in production in order to make the change taking effect after the code is deployed, we should remind this to deployers and PHPCS is an easy enough path for surfacing this information.

Fixes #25