### PR TITLE
Flag strip_tags and suggest wp_strip_all_tags instead

### DIFF
--- a/WordPressVIPMinimum/Sniffs/VIP/RestrictedFunctionsSniff.php
+++ b/WordPressVIPMinimum/Sniffs/VIP/RestrictedFunctionsSniff.php
@@ -44,6 +44,13 @@ class WordPressVIPMinimum_Sniffs_VIP_RestrictedFunctionsSniff extends WordPress_
 					),
 				),
 			),
+			'strip_tags' => array(
+				'type' => 'error',
+				'message' => '%s does not strip CSS and JS in between the script and style tags. `wp_strip_all_tags` should be used instead.',
+				'functions' => array(
+					'strip_tags'
+				),
+			),
 		);
 
 		$original_groups['get_posts']['functions'] = array_filter( $original_groups['get_posts']['functions'], function( $v ) {


### PR DESCRIPTION
Since the `strip_tags` function is not removing CSS and JS in between the script and style tags, the `wp_strip_all_tags` should be used instead.

Fixes #24