### PR TITLE
Adding case for catching non-checking of return value for get_options array_key_exists pair

### DIFF
--- a/WordPressVIPMinimum/Sniffs/Functions/CheckReturnValueSniff.php
+++ b/WordPressVIPMinimum/Sniffs/Functions/CheckReturnValueSniff.php
@@ -246,6 +246,7 @@ class WordPressVIPminimum_Sniffs_Functions_CheckReturnValueSniff implements PHP_
 		// This allows us to check for variables which are passed as second paramt of a function. Eg.: array_key_exists.
 		$search[] = T_COMMA;
 		$search[] = T_VARIABLE; 
+		$search[] = T_CONSTANT_ENCAPSED_STRING;
 		$nextFunctionCallWithVariable = $phpcsFile->findPrevious( $search, ($nextVariableOccurrence - 1), null, true);
 
 		foreach( $callees as $callee ) {

--- a/WordPressVIPMinimum/Tests/Functions/CheckReturnValueUnitTest.inc
+++ b/WordPressVIPMinimum/Tests/Functions/CheckReturnValueUnitTest.inc
@@ -1,0 +1,27 @@
+<?php
+
+$my_theme_options = get_option( 'my_theme', false );
+
+if ( array_key_exists( 'key', $my_theme_options ) ) { // Bad.
+}
+
+$theme_settings = get_option( 'my_theme_categories_settings' );
+if ( ! array_key_exists( $key, $theme_settings ) || empty( $theme_settings[ $key ] ) ) { // Bad.
+}
+
+$my_url = wpcom_vip_get_term_link();
+
+echo '<a href="' . esc_url( $my_url ) . '">My Link</a>'; // Bad.
+
+echo '<a href="' . esc_url( get_term_link( $link ) ) . '">My term link</a>'; // Bad.
+
+$tags = get_the_tags( $post_id );
+$tags = wp_list_pluck( $tags, 'term_id' ); // Bad.
+
+$single_post_meta = get_post_meta( $post_id, 'my_meta', true );
+
+foreach( $single_post_meta as $meta ) {} // Bad.
+
+$array_post_metas = get_post_meta( $post_id, 'my_non_single_meta', false ); // We are obtaining an array here.
+
+foreach( $array_post_metas as $meta ) {} // Ok.

--- a/WordPressVIPMinimum/Tests/Functions/CheckReturnValueUnitTest.php
+++ b/WordPressVIPMinimum/Tests/Functions/CheckReturnValueUnitTest.php
@@ -1,0 +1,38 @@
+<?php
+/**
+ * Unit test class for WordPressVIPMinimum Coding Standard.
+ */
+
+/**
+ * Unit test class for the AdminBarRemoval sniff.
+ */
+class WordPressVIPMinimum_Tests_Functions_CheckReturnValueUnitTest extends AbstractSniffUnitTest {
+
+	/**
+	 * Returns the lines where errors should occur.
+	 *
+	 * @return array <int line number> => <int number of errors>
+	 */
+	public function getErrorList() {
+		return array(
+			5 => 1,
+			9 => 1,
+			14 => 1,
+			16 => 1,
+			19 => 1,
+			23 => 1,
+			29 => 1,
+		);
+	}
+
+	/**
+	 * Returns the lines where warnings should occur.
+	 *
+	 * @return array <int line number> => <int number of warnings>
+	 */
+	public function getWarningList() {
+		return array();
+
+	}
+
+} // End class.


### PR DESCRIPTION
This commit is also adding some extra comments since I found it quite hard to fingure out what's going on