### PR TITLE
Adding sniff reporting on VIP in a comment

### DIFF
--- a/WordPressVIPMinimum/Sniffs/VIP/CommentSniff.php
+++ b/WordPressVIPMinimum/Sniffs/VIP/CommentSniff.php
@@ -1,0 +1,42 @@
+<?php
+/**
+ * WordPress-VIP-Minimum Coding Standard.
+ *
+ * @link https://github.com/Automattic/VIP-Coding-Standards
+ */
+
+/**
+ * Restricts usage of error control operators. Currently only the at sign
+ */
+class WordPressVIPMinimum_Sniffs_VIP_CommentSniff implements PHP_CodeSniffer_Sniff {
+
+	/**
+	 * Returns an array of tokens this test wants to listen for.
+	 *
+	 * @return array
+	 */
+	public function register() {
+		return array(
+			T_DOC_COMMENT,
+			T_COMMENT,
+		);
+	}
+
+	/**
+	 * Process this test when one of its tokens is encoutnered
+	 *
+	 * @param PHP_CodeSniffer_File $phpcsFile The file being scanned.
+	 * @param int				   $stackPtr  The position of the current token in the stack passed in $tokens
+	 *
+	 * $return void
+	 */
+	public function process( PHP_CodeSniffer_File $phpcsFile, $stackPtr ) {
+
+		$tokens = $phpcsFile->getTokens();
+
+		if ( false !== strpos( $tokens[$stackPtr]['content'], 'VIP' ) ) {
+			$phpcsFile->addWarning( sprintf( "The code contains VIP comment. Make sure the diff is not removing it w/o properly addressing any hotfixes.", $tokens[$stackPtr]['content'] ), $stackPtr );
+		}
+	}
+
+}

--- a/WordPressVIPMinimum/Tests/VIP/CommentUnitTest.inc
+++ b/WordPressVIPMinimum/Tests/VIP/CommentUnitTest.inc
@@ -1,0 +1,32 @@
+<?php
+
+/**
+ * A function
+ *
+ * @return void
+ */
+function do_something_with_terms() {
+	$terms = get_the_terms( get_post(), 'post_tag' );
+	// VIP: hotfix, check return value.
+	if ( true === is_array( $terms ) && false === empty( $terms ) ) {
+		// Do something meaningful.
+	}
+}
+
+// Some arbitrary comment.
+
+/**
+ * A function
+ *
+ * @uses wpcom_vip_get_category_by_slug
+ */
+fuction use_wpcom_vip_get_category_by_slug() {
+	wpcom_vip_get_category_by_slug( 'my-slug' );
+}
+
+/*
+ * VIP: Hotfixing something
+ */
+function vip_hotfix_something() {
+	// do something
+}

--- a/WordPressVIPMinimum/Tests/VIP/CommentUnitTest.php
+++ b/WordPressVIPMinimum/Tests/VIP/CommentUnitTest.php
@@ -1,0 +1,34 @@
+<?php
+/**
+ * Unit test class for WordPressVIPMinimum Coding Standard.
+ */
+
+/**
+ * Unit test class for the AdminBarRemoval sniff.
+ */
+class WordPressVIPMinimum_Tests_VIP_CommentUnitTest extends AbstractSniffUnitTest {
+
+	/**
+	 * Returns the lines where errors should occur.
+	 *
+	 * @return array <int line number> => <int number of errors>
+	 */
+	public function getErrorList() {
+		return array(
+		);
+	}
+
+	/**
+	 * Returns the lines where warnings should occur.
+	 *
+	 * @return array <int line number> => <int number of warnings>
+	 */
+	public function getWarningList() {
+		return array(
+			10 => 1,
+			28 => 1,
+		);
+
+	}
+
+} // End class.


### PR DESCRIPTION
It should help us to catch situations in which a VIP applied hotfix is being accidentally removed.