### PR TITLE
Adding sniff for catching suspicious str_replace calls

### DIFF
--- a/WordPressVIPMinimum/Sniffs/VIP/StaticStrreplaceSniff.php
+++ b/WordPressVIPMinimum/Sniffs/VIP/StaticStrreplaceSniff.php
@@ -1,0 +1,82 @@
+<?php
+/**
+ * WordPress-VIP-Minimum Coding Standard.
+ *
+ * @package VIPCS\WordPressVIPMinimum
+ * @link https://github.com/Automattic/VIP-Coding-Standards
+ */
+
+/**
+ * Restricts usage of str_replace with all 3 params being static.
+ *
+ *  @package VIPCS\WordPressVIPMinimum
+ */
+class WordPressVIPMinimum_Sniffs_VIP_StaticStrreplaceSniff implements PHP_CodeSniffer_Sniff {
+
+	/**
+	 * Returns an array of tokens this test wants to listen for.
+	 *
+	 * @return array
+	 */
+	public function register() {
+		return PHP_CodeSniffer_Tokens::$functionNameTokens;
+	}
+
+	/**
+	 * Process this test when one of its tokens is encountered
+	 *
+	 * @param PHP_CodeSniffer_File $phpcsFile The file being scanned.
+	 * @param int				   $stackPtr  The position of the current token in the stack passed in $tokens.
+	 *
+	 * @return void
+	 */
+	public function process( PHP_CodeSniffer_File $phpcsFile, $stackPtr ) {
+
+		$tokens = $phpcsFile->getTokens();
+
+		if ( 'str_replace' !== $tokens[ $stackPtr ]['content'] ) {
+			return;
+		}
+
+		$openBracket = $phpcsFile->findNext( PHP_CodeSniffer_Tokens::$emptyTokens, ($stackPtr + 1), null, true );
+
+		if ( T_OPEN_PARENTHESIS !== $tokens[ $openBracket ]['code'] ) {
+			return;
+		}
+
+		$next_start_ptr = $openBracket + 1;
+		for ( $i = 0; $i < 3; $i++ ) {
+			$param_ptr = $phpcsFile->findNext( array_merge( PHP_CodeSniffer_Tokens::$emptyTokens, array( T_COMMA ) ), $next_start_ptr, null, true );
+
+			if ( T_ARRAY === $tokens[ $param_ptr ]['code'] ) {
+				$openBracket = $phpcsFile->findNext( PHP_CodeSniffer_Tokens::$emptyTokens, ($param_ptr + 1), null, true );
+				if ( T_OPEN_PARENTHESIS !== $tokens[ $openBracket ]['code'] ) {
+					return;
+				}
+
+				// Find the closing bracket.
+				$closeBracket = $tokens[ $openBracket ]['parenthesis_closer'];
+
+				$array_item_ptr = $phpcsFile->findNext( array_merge( PHP_CodeSniffer_Tokens::$emptyTokens, array( T_COMMA ) ), ( $openBracket + 1 ), $closeBracket, true );
+				while ( false !== $array_item_ptr ) {
+
+					if ( T_CONSTANT_ENCAPSED_STRING !== $tokens[ $array_item_ptr ]['code'] ) {
+						return;
+					}
+					$array_item_ptr = $phpcsFile->findNext( array_merge( PHP_CodeSniffer_Tokens::$emptyTokens, array( T_COMMA ) ), ( $array_item_ptr + 1 ), $closeBracket, true );
+				}
+
+				$next_start_ptr = $closeBracket + 1;
+				continue;
+
+			} else if ( T_CONSTANT_ENCAPSED_STRING !== $tokens[ $param_ptr ]['code'] ) {
+				return;
+			}
+
+			$next_start_ptr = $param_ptr + 1;
+
+		}
+
+		$phpcsFile->addError( sprintf( 'This code pattern is often used to run a very dangerous shell programs on your server. The code in these files needs to be reviewed, and possibly cleaned.', $tokens[ $stackPtr ]['content'] ), $stackPtr );
+	}//end process()
+}

--- a/WordPressVIPMinimum/Tests/VIP/StaticStrreplaceUnitTest.inc
+++ b/WordPressVIPMinimum/Tests/VIP/StaticStrreplaceUnitTest.inc
@@ -1,0 +1,13 @@
+<?php
+
+str_replace( 'foo', 'bar', 'foobar' ); // Bad.
+
+str_replace( 'foo', 'bar', $foobar ); // Ok.
+
+str_replace( array( 'foo', 'bar' ), array( 'bar', 'foo' ), 'foobar' ); // Bad.
+
+str_replace( array( 'foo', 'bar' ), array( 'bar', 'foo' ), $foobar ); // Ok.
+
+str_replace( array( 'foo', 'bar' ), array( $foo, $bar ), $foobar ); // Ok.
+
+str_replace( array( $foo, $bar ), array( 'bar', 'foo' ), $foobar ); // Ok.

--- a/WordPressVIPMinimum/Tests/VIP/StaticStrreplaceUnitTest.php
+++ b/WordPressVIPMinimum/Tests/VIP/StaticStrreplaceUnitTest.php
@@ -1,0 +1,37 @@
+<?php
+/**
+ * Unit test class for WordPressVIPMinimum Coding Standard.
+ *
+ * @package VIPCS\WordPressVIPMinimum
+ */
+
+/**
+ * Unit test class for the StaticStrreplace sniff.
+ *
+ * @package VIPCS\WordPressVIPMinimum
+ */
+class WordPressVIPMinimum_Tests_VIP_StaticStrreplaceUnitTest extends AbstractSniffUnitTest {
+
+	/**
+	 * Returns the lines where errors should occur.
+	 *
+	 * @return array <int line number> => <int number of errors>
+	 */
+	public function getErrorList() {
+		return array(
+			3 => 1,
+			7 => 1,
+		);
+	}
+
+	/**
+	 * Returns the lines where warnings should occur.
+	 *
+	 * @return array <int line number> => <int number of warnings>
+	 */
+	public function getWarningList() {
+		return array();
+
+	}
+
+} // End class.

--- a/ruleset_test.inc
+++ b/ruleset_test.inc
@@ -129,3 +129,5 @@ wpcom_vip_irc(); // Bad. Error.
 get_children(); // Bad. Warning. Message.
 
 attachment_url_to_postid(); // Bad. Error.
+
+str_replace( 'foo', 'bar', 'foobar' ); // Bad. Error.

--- a/ruleset_test.php
+++ b/ruleset_test.php
@@ -44,6 +44,7 @@ $expected = array(
 		127 => 1,
 		129 => 1,
 		131 => 1,
+		133 => 1,
 	),
 	'warnings' => array(
 		9 => 1,


### PR DESCRIPTION
eg.: `str_replace( 'foo', 'bar', 'foobar' );`

Fixes #55