### PR TITLE
Use `';'` in `eval()` in order to provide some more realistic data fo…

### DIFF
--- a/ruleset_test.inc
+++ b/ruleset_test.inc
@@ -121,7 +121,7 @@ wp_remote_post( $this->endpoint, array(
 );
 
 // Squiz.PHP.Eval
-eval(); // Bad. Error.
+eval( ';' ); // Bad. Error.
 
 // WordPressVIPMinimum.VIP.RestrictedFunctions
 wpcom_vip_irc(); // Bad. Error.


### PR DESCRIPTION
…r testing.