### PR TITLE
Add more resticted constants

### DIFF
--- a/WordPressVIPMinimum/Sniffs/Constants/ConstantRestrictionsSniff.php
+++ b/WordPressVIPMinimum/Sniffs/Constants/ConstantRestrictionsSniff.php
@@ -28,6 +28,16 @@ class ConstantRestrictionsSniff implements \PHP_CodeSniffer_Sniff {
 	);
 
 	/**
+	 * List of restricted constant declarations.
+	 *
+	 * @var array
+	 */
+	public $restrictedConstantDeclaration = array(
+		'JETPACK_DEV_DEBUG',
+		'WP_CRON_CONTROL_SECRET',
+	);
+
+	/**
 	 * Returns an array of tokens this test wants to listen for.
 	 *
 	 * @return array
@@ -57,12 +67,14 @@ class ConstantRestrictionsSniff implements \PHP_CodeSniffer_Sniff {
 			$constantName = trim( $tokens[ $stackPtr ]['content'], "\"'" );
 		}
 
-		if ( false === in_array( $constantName, $this->restrictedConstantNames, true ) ) {
+		if ( false === in_array( $constantName, $this->restrictedConstantNames, true )
+		     && false == in_array( $constantName, $this->restrictedConstantDeclaration, true )
+		) {
 			// Not the constant we are looking for.
 			return;
 		}
 
-		if ( T_STRING === $tokens[ $stackPtr ]['code'] ) {
+		if ( T_STRING === $tokens[ $stackPtr ]['code'] && true === in_array( $constantName, $this->restrictedConstantNames, true ) ) {
 			$phpcsFile->addWarning( sprintf( 'Code is touching the %s constant. Make sure it\'s used appropriately.', $constantName ), $stackPtr, 'ConstantRestrictions' );
 			return;
 		}
@@ -92,7 +104,7 @@ class ConstantRestrictionsSniff implements \PHP_CodeSniffer_Sniff {
 		if ( true === in_array( $tokens[ $previous ]['code'], Tokens::$functionNameTokens, true ) ) {
 			if ( 'define' === $tokens[ $previous ]['content'] ) {
 				$phpcsFile->addError( sprintf( 'The definition of %s constant is prohibited. Please use a different name.', $constantName ), $previous, 'ConstantRestrictions' );
-			} else {
+			} elseif ( true === in_array( $constantName, $this->restrictedConstantNames, true ) ) {
 				$phpcsFile->addWarning( sprintf( 'Code is touching the %s constant. Make sure it\'s used appropriately.', $constantName ), $previous, 'ConstantRestrictions' );
 			}
 		}

--- a/WordPressVIPMinimum/Sniffs/Constants/ConstantRestrictionsSniff.php
+++ b/WordPressVIPMinimum/Sniffs/Constants/ConstantRestrictionsSniff.php
@@ -67,9 +67,7 @@ class ConstantRestrictionsSniff implements \PHP_CodeSniffer_Sniff {
 			$constantName = trim( $tokens[ $stackPtr ]['content'], "\"'" );
 		}
 
-		if ( false === in_array( $constantName, $this->restrictedConstantNames, true )
-		     && false == in_array( $constantName, $this->restrictedConstantDeclaration, true )
-		) {
+		if ( false === in_array( $constantName, $this->restrictedConstantNames, true ) && false === in_array( $constantName, $this->restrictedConstantDeclaration, true ) ) {
 			// Not the constant we are looking for.
 			return;
 		}

--- a/WordPressVIPMinimum/Tests/Constants/ConstantRestrictionsUnitTest.inc
+++ b/WordPressVIPMinimum/Tests/Constants/ConstantRestrictionsUnitTest.inc
@@ -8,4 +8,16 @@ if ( defined( 'A8C_PROXIED_REQUEST' ) && true === constant( 'A8C_PROXIED_REQUEST
 
 }
 
-define( 'A8C_PROXIED_REQUEST', false ); // Bad. Should never try to define this.
+define( 'A8C_PROXIED_REQUEST', false ); // Bad. Should never attempt to define this.
+
+define( 'JETPACK_DEV_DEBUG', true ); // Bad. Should never attempt to define this.
+
+define( 'WP_CRON_CONTROL_SECRET', true ); // Bad. Should never attempt to define this.
+
+if ( defined( 'JETPACK_DEV_DEBUG' ) ) { // Okay. Can touch.
+
+}
+
+if ( constant( 'WP_CRON_CONTROL_SECRET' ) ) { // Okay. Can touch.
+
+}

--- a/WordPressVIPMinimum/Tests/Constants/ConstantRestrictionsUnitTest.php
+++ b/WordPressVIPMinimum/Tests/Constants/ConstantRestrictionsUnitTest.php
@@ -24,6 +24,8 @@ class ConstantRestrictionsUnitTest extends AbstractSniffUnitTest {
 	public function getErrorList() {
 		return array(
 			11 => 1,
+			13 => 1,
+			15 => 1,
 		);
 	}
 


### PR DESCRIPTION
This commit adds JETPACK_DEV_DEBUG and WP_CRON_CONTROL_SECRET constants to the list of restricted ones.

In contrast to A8C_PROXIED_REQUEST constant, those two are good to be worked with, just should not be defined.

This new use-case prompted changes in the ConstantRestrictionsSniff itself - new conditions have been added to the code.

Unit tests have been ammended accordingly.