### PR TITLE
Detect Basic Auth implementation in PHP

### DIFF
--- a/WordPressVIPMinimum/Sniffs/Variables/ServerVariablesSniff.php
+++ b/WordPressVIPMinimum/Sniffs/Variables/ServerVariablesSniff.php
@@ -1,0 +1,69 @@
+<?php
+/**
+ * WordPress-VIP-Minimum Coding Standard.
+ *
+ * @package VIPCS\WordPressVIPMinimum
+ * @link https://github.com/Automattic/VIP-Coding-Standards
+ */
+
+namespace WordPressVIPMinimum\Sniffs\Variables;
+
+use PHP_CodeSniffer_File as File;
+use PHP_CodeSniffer_Tokens as Tokens;
+
+/**
+ * Restricts usage of some server variables.
+ *
+ * @package VIPCS\WordPressVIPMinimum
+ */
+class ServerVariablesSniff implements \PHP_CodeSniffer_Sniff {
+
+	/**
+	 * List of restricted constant names.
+	 *
+	 * @var array
+	 */
+	public $restrictedVariables = array(
+		'PHP_AUTH_PW',
+	);
+
+	/**
+	 * Returns an array of tokens this test wants to listen for.
+	 *
+	 * @return array
+	 */
+	public function register() {
+		return array(
+			T_VARIABLE,
+		);
+	}//end register()
+
+	/**
+	 * Process this test when one of its tokens is encoutnered
+	 *
+	 * @param \PHP_CodeSniffer\Files\File $phpcsFile The file being scanned.
+	 * @param int                         $stackPtr  The position of the current token in the stack passed in $tokens.
+	 *
+	 * @return void
+	 */
+	public function process( File $phpcsFile, $stackPtr ) {
+
+		$tokens = $phpcsFile->getTokens();
+
+		if ( '$_SERVER' !== $tokens[ $stackPtr ]['content'] ) {
+			// Not the variable we are looking for.
+			return;
+		}
+
+		$variableNamePtr = $phpcsFile->findNext( array( T_CONSTANT_ENCAPSED_STRING ), ($stackPtr + 1), null, false, null, true );
+		$variableName = str_replace( "'", '', $tokens[$variableNamePtr]['content'] );
+
+		if ( false === in_array( $variableName, $this->restrictedVariables , true ) ) {
+			// Not the variable we are looking for.
+			return;
+		}
+
+		$phpcsFile->addError( 'Basic authentication should not be handled via PHP code.', $stackPtr, 'ServerVariables' );
+	}
+
+} // End class.

--- a/WordPressVIPMinimum/Sniffs/Variables/ServerVariablesSniff.php
+++ b/WordPressVIPMinimum/Sniffs/Variables/ServerVariablesSniff.php
@@ -56,7 +56,7 @@ class ServerVariablesSniff implements \PHP_CodeSniffer_Sniff {
 		}
 
 		$variableNamePtr = $phpcsFile->findNext( array( T_CONSTANT_ENCAPSED_STRING ), ($stackPtr + 1), null, false, null, true );
-		$variableName = str_replace( "'", '', $tokens[$variableNamePtr]['content'] );
+		$variableName = str_replace( "'", '', $tokens[ $variableNamePtr ]['content'] );
 
 		if ( false === in_array( $variableName, $this->restrictedVariables , true ) ) {
 			// Not the variable we are looking for.

--- a/WordPressVIPMinimum/Sniffs/Variables/ServerVariablesSniff.php
+++ b/WordPressVIPMinimum/Sniffs/Variables/ServerVariablesSniff.php
@@ -55,10 +55,10 @@ class ServerVariablesSniff implements \PHP_CodeSniffer_Sniff {
 			return;
 		}
 
-		$variableNamePtr = $phpcsFile->findNext( array( T_CONSTANT_ENCAPSED_STRING ), ($stackPtr + 1), null, false, null, true );
-		$variableName = str_replace( "'", '', $tokens[ $variableNamePtr ]['content'] );
+		$variableNamePtr = $phpcsFile->findNext( array( T_CONSTANT_ENCAPSED_STRING ), ( $stackPtr + 1 ), null, false, null, true );
+		$variableName    = str_replace( "'", '', $tokens[ $variableNamePtr ]['content'] );
 
-		if ( false === in_array( $variableName, $this->restrictedVariables , true ) ) {
+		if ( false === in_array( $variableName, $this->restrictedVariables, true ) ) {
 			// Not the variable we are looking for.
 			return;
 		}

--- a/WordPressVIPMinimum/Tests/Variables/ServerVariablesUnitTest.inc
+++ b/WordPressVIPMinimum/Tests/Variables/ServerVariablesUnitTest.inc
@@ -1,0 +1,5 @@
+<?php
+
+$_SERVER['PHP_AUTH_PW']; // Bad. Should never happen.
+
+$_SERVER['SOME_OTHER_VARIABLE']; // We don't care.

--- a/WordPressVIPMinimum/Tests/Variables/ServerVariablesUnitTest.php
+++ b/WordPressVIPMinimum/Tests/Variables/ServerVariablesUnitTest.php
@@ -1,0 +1,40 @@
+<?php
+/**
+ * Unit test class for WordPressVIPMinimum Coding Standard.
+ *
+ * @package VIPCS\WordPressVIPMinimum
+ */
+
+namespace WordPressVIPMinimum\Tests\Variables;
+
+use PHP_CodeSniffer\Tests\Standards\AbstractSniffUnitTest;
+
+/**
+ * Unit test class for the Variable Analysis sniff.
+ *
+ * @package VIPCS\WordPressVIPMinimum
+ */
+class ServerVariablesUnitTest extends AbstractSniffUnitTest {
+
+	/**
+	 * Returns the lines where errors should occur.
+	 *
+	 * @return array <int line number> => <int number of errors>
+	 */
+	public function getErrorList() {
+		return array(
+			3 => 1,
+		);
+	}
+
+	/**
+	 * Returns the lines where warnings should occur.
+	 *
+	 * @return array <int line number> => <int number of warnings>
+	 */
+	public function getWarningList() {
+		return array();
+
+	}
+
+} // End class.


### PR DESCRIPTION
Basic Auth should not be set via PHP.

This commit adds new sniff which is producing errors in case it spots `$_SERVER['PHP_AUTH_PW']` in the code.

Unit tests are included.