### PR TITLE
Addnig basic sniff for catching possible implementation of term meta in options

### DIFF
--- a/WordPressVIPMinimum/Sniffs/VIP/TaxonomyMetaInOptionsSniff.php
+++ b/WordPressVIPMinimum/Sniffs/VIP/TaxonomyMetaInOptionsSniff.php
@@ -127,7 +127,7 @@ class TaxonomyMetaInOptionsSniff implements \PHP_CodeSniffer_Sniff {
 	 * Helper method for composing the Warnign for all possible cases.
 	 *
 	 * @param \PHP_CodeSniffer\Files\File $phpcsFile The file being scanned.
-	 * @param                             $stackPtr The position of the current token in the stack passed in $tokens.
+	 * @param int                         $stackPtr The position of the current token in the stack passed in $tokens.
 	 * @param string                      $type The warning type.
 	 *
 	 * @return void.

--- a/WordPressVIPMinimum/Sniffs/VIP/TaxonomyMetaInOptionsSniff.php
+++ b/WordPressVIPMinimum/Sniffs/VIP/TaxonomyMetaInOptionsSniff.php
@@ -76,17 +76,16 @@ class TaxonomyMetaInOptionsSniff implements \PHP_CodeSniffer_Sniff {
 			return;
 		}
 
-
 		$param_ptr = $phpcsFile->findNext( Tokens::$emptyTokens, $openBracket + 1, null, true );
 
 		if ( T_DOUBLE_QUOTED_STRING === $tokens[ $param_ptr ]['code'] ) {
-			foreach( $this->taxonomy_term_patterns as $taxonomy_term_pattern ) {
+			foreach ( $this->taxonomy_term_patterns as $taxonomy_term_pattern ) {
 				if ( false !== strpos( $tokens[ $param_ptr ]['content'], $taxonomy_term_pattern ) ) {
 					$this->addWarning( $phpcsFile, $stackPtr );
 					return;
 				}
 			}
-		} else if ( T_CONSTANT_ENCAPSED_STRING === $tokens[ $param_ptr ]['code'] ) {
+		} elseif ( T_CONSTANT_ENCAPSED_STRING === $tokens[ $param_ptr ]['code'] ) {
 
 			$string_concat = $phpcsFile->findNext( Tokens::$emptyTokens, ( $param_ptr + 1 ), null, true );
 			if ( T_STRING_CONCAT !== $tokens[ $string_concat ]['code'] ) {
@@ -115,16 +114,24 @@ class TaxonomyMetaInOptionsSniff implements \PHP_CodeSniffer_Sniff {
 				return;
 			}
 
-			foreach( $this->taxonomy_term_patterns as $taxonomy_term_pattern ) {
+			foreach ( $this->taxonomy_term_patterns as $taxonomy_term_pattern ) {
 				if ( false !== strpos( $tokens[ $object_property ]['content'], $taxonomy_term_pattern ) ) {
 					$this->addWarning( $phpcsFile, $stackPtr );
 					return;
 				}
 			}
-
 		}
 	}//end process()
 
+	/**
+	 * Helper method for composing the Warnign for all possible cases.
+	 *
+	 * @param \PHP_CodeSniffer\Files\File $phpcsFile The file being scanned.
+	 * @param                             $stackPtr The position of the current token in the stack passed in $tokens.
+	 * @param string                      $type The warning type.
+	 *
+	 * @return void.
+	 */
 	public function addWarning( $phpcsFile, $stackPtr, $type = 'PossibleTermMetaInOptions' ) {
 		$phpcsFile->addWarning( sprintf( 'Possible detection of storing taxonomy term meta in options table. Needs manual inspection. All such data should be stored in term_meta.' ), $stackPtr, $type );
 	}

--- a/WordPressVIPMinimum/Sniffs/VIP/TaxonomyMetaInOptionsSniff.php
+++ b/WordPressVIPMinimum/Sniffs/VIP/TaxonomyMetaInOptionsSniff.php
@@ -16,7 +16,7 @@ use PHP_CodeSniffer_Tokens as Tokens;
  *
  *  @package VIPCS\WordPressVIPMinimum
  */
-class TaxonomyMetaInOPtions implements \PHP_CodeSniffer_Sniff {
+class TaxonomyMetaInOptionsSniff implements \PHP_CodeSniffer_Sniff {
 
 	/**
 	 * List of options_ functions

--- a/WordPressVIPMinimum/Sniffs/VIP/TaxonomyMetaInOptionsSniff.php
+++ b/WordPressVIPMinimum/Sniffs/VIP/TaxonomyMetaInOptionsSniff.php
@@ -1,0 +1,131 @@
+<?php
+/**
+ * WordPress-VIP-Minimum Coding Standard.
+ *
+ * @package VIPCS\WordPressVIPMinimum
+ * @link https://github.com/Automattic/VIP-Coding-Standards
+ */
+
+namespace WordPressVIPMinimum\Sniffs\VIP;
+
+use PHP_CodeSniffer_File as File;
+use PHP_CodeSniffer_Tokens as Tokens;
+
+/**
+ * Restricts the implementation of taxonomy term meta via options.
+ *
+ *  @package VIPCS\WordPressVIPMinimum
+ */
+class TaxonomyMetaInOPtions implements \PHP_CodeSniffer_Sniff {
+
+	/**
+	 * List of options_ functions
+	 *
+	 * @var array
+	 */
+	public $option_functions = array(
+		'get_option',
+		'add_option',
+		'update_option',
+		'delete_option',
+	);
+
+	/**
+	 * List of possible variable names holding term ID.
+	 *
+	 * @var array
+	 */
+	public $taxonomy_term_patterns = array(
+		'category_id',
+		'cat_id',
+		'cat',
+		'term_id',
+		'term',
+		'tag_id',
+		'tag',
+	);
+
+	/**
+	 * Returns an array of tokens this test wants to listen for.
+	 *
+	 * @return array
+	 */
+	public function register() {
+		return Tokens::$functionNameTokens;
+	}
+
+	/**
+	 * Process this test when one of its tokens is encountered
+	 *
+	 * @param \PHP_CodeSniffer\Files\File $phpcsFile The file being scanned.
+	 * @param int                         $stackPtr  The position of the current token in the stack passed in $tokens.
+	 *
+	 * @return void
+	 */
+	public function process( File $phpcsFile, $stackPtr ) {
+
+		$tokens = $phpcsFile->getTokens();
+
+		if ( false === in_array( $tokens[ $stackPtr ]['content'], $this->option_functions, true ) ) {
+			return;
+		}
+
+		$openBracket = $phpcsFile->findNext( Tokens::$emptyTokens, ( $stackPtr + 1 ), null, true );
+
+		if ( T_OPEN_PARENTHESIS !== $tokens[ $openBracket ]['code'] ) {
+			return;
+		}
+
+
+		$param_ptr = $phpcsFile->findNext( Tokens::$emptyTokens, $openBracket + 1, null, true );
+
+		if ( T_DOUBLE_QUOTED_STRING === $tokens[ $param_ptr ]['code'] ) {
+			foreach( $this->taxonomy_term_patterns as $taxonomy_term_pattern ) {
+				if ( false !== strpos( $tokens[ $param_ptr ]['content'], $taxonomy_term_pattern ) ) {
+					$this->addWarning( $phpcsFile, $stackPtr );
+					return;
+				}
+			}
+		} else if ( T_CONSTANT_ENCAPSED_STRING === $tokens[ $param_ptr ]['code'] ) {
+
+			$string_concat = $phpcsFile->findNext( Tokens::$emptyTokens, ( $param_ptr + 1 ), null, true );
+			if ( T_STRING_CONCAT !== $tokens[ $string_concat ]['code'] ) {
+				return;
+			}
+
+			$variable_name = $phpcsFile->findNext( Tokens::$emptyTokens, ( $string_concat + 1 ), null, true );
+			if ( T_VARIABLE !== $tokens[ $variable_name ]['code'] ) {
+				return;
+			}
+
+			foreach ( $this->taxonomy_term_patterns as $taxonomy_term_pattern ) {
+				if ( false !== strpos( $tokens[ $variable_name ]['content'], $taxonomy_term_pattern ) ) {
+					$this->addWarning( $phpcsFile, $stackPtr );
+					return;
+				}
+			}
+
+			$object_operator = $phpcsFile->findNext( Tokens::$emptyTokens, ( $variable_name + 1 ), null, true );
+			if ( T_OBJECT_OPERATOR !== $tokens[ $object_operator ]['code'] ) {
+				return;
+			}
+
+			$object_property = $phpcsFile->findNext( Tokens::$emptyTokens, ( $object_operator + 1 ), null, true );
+			if ( T_STRING !== $tokens[ $object_property ]['code'] ) {
+				return;
+			}
+
+			foreach( $this->taxonomy_term_patterns as $taxonomy_term_pattern ) {
+				if ( false !== strpos( $tokens[ $object_property ]['content'], $taxonomy_term_pattern ) ) {
+					$this->addWarning( $phpcsFile, $stackPtr );
+					return;
+				}
+			}
+
+		}
+	}//end process()
+
+	public function addWarning( $phpcsFile, $stackPtr, $type = 'PossibleTermMetaInOptions' ) {
+		$phpcsFile->addWarning( sprintf( 'Possible detection of storing taxonomy term meta in options table. Needs manual inspection. All such data should be stored in term_meta.' ), $stackPtr, $type );
+	}
+}

--- a/WordPressVIPMinimum/Tests/VIP/TaxonomyMetaInOptionsUnitTest.inc
+++ b/WordPressVIPMinimum/Tests/VIP/TaxonomyMetaInOptionsUnitTest.inc
@@ -1,0 +1,8 @@
+<?php
+
+get_option( "taxonomy_rating_$obj->term_id" ); // NOK.
+delete_option( "taxonomy_rating_{$obj->term_id}" ); // NOK.
+get_option( "taxonomy_rating_$tag_id" ); // NOK.
+update_option( 'taxonomy_rating_' . $category_id ); // NOK.
+get_option( "taxonomy_rating_{$cat_id}" ); // NOK.
+add_option( 'taxonomy_rating_' . $obj->term_id ); // NOK.

--- a/WordPressVIPMinimum/Tests/VIP/TaxonomyMetaInOptionsUnitTest.php
+++ b/WordPressVIPMinimum/Tests/VIP/TaxonomyMetaInOptionsUnitTest.php
@@ -22,8 +22,7 @@ class TaxonomyMetaInOptionsUnitTest extends AbstractSniffUnitTest {
 	 * @return array <int line number> => <int number of errors>
 	 */
 	public function getErrorList() {
-		return array(
-		);
+		return array();
 	}
 
 	/**

--- a/WordPressVIPMinimum/Tests/VIP/TaxonomyMetaInOptionsUnitTest.php
+++ b/WordPressVIPMinimum/Tests/VIP/TaxonomyMetaInOptionsUnitTest.php
@@ -1,0 +1,46 @@
+<?php
+/**
+ * Unit test class for WordPressVIPMinimum Coding Standard.
+ *
+ * @package VIPCS\WordPressVIPMinimum
+ */
+
+namespace WordPressVIPMinimum\Tests\VIP;
+
+use PHP_CodeSniffer\Tests\Standards\AbstractSniffUnitTest;
+
+/**
+ * Unit test class for the TaxonomyMetaInOptions sniff.
+ *
+ * @package VIPCS\WordPressVIPMinimum
+ */
+class TaxonomyMetaInOptionsUnitTest extends AbstractSniffUnitTest {
+
+	/**
+	 * Returns the lines where errors should occur.
+	 *
+	 * @return array <int line number> => <int number of errors>
+	 */
+	public function getErrorList() {
+		return array(
+		);
+	}
+
+	/**
+	 * Returns the lines where warnings should occur.
+	 *
+	 * @return array <int line number> => <int number of warnings>
+	 */
+	public function getWarningList() {
+		return array(
+			3 => 1,
+			4 => 1,
+			5 => 1,
+			6 => 1,
+			7 => 1,
+			8 => 1,
+		);
+
+	}
+
+} // End class.

--- a/ruleset_test.inc
+++ b/ruleset_test.inc
@@ -159,5 +159,7 @@ dbDelta(); // Bad. Error.
 // WordPress.CodeAnalysis.AssignmentInCondition.
 if ( $a = 1 ) {} // Bad. Warning.
 
+add_option( 'taxonomy_rating_' . $obj->term_id ); // Bad. Warning.
+
 ?>
 

--- a/ruleset_test.php
+++ b/ruleset_test.php
@@ -48,7 +48,7 @@ $expected = array(
 		131 => 1,
 		133 => 1,
 		157 => 1,
-		162 => 1,
+		164 => 1, // Error on the end of the file. When any code is added, bounce this.
 	),
 	'warnings' => array(
 		9   => 1,
@@ -70,6 +70,7 @@ $expected = array(
 		153 => 1,
 		155 => 1,
 		160 => 1,
+		162 => 1,
 	),
 	'messages' => array(
 		129 => array(


### PR DESCRIPTION
As WordPress provides term meta and as there is a restriction on the size of alloptions on the WordPress.com VIP platform, all term related meta data should be stored in term meta table.