### PR TITLE
Adding VIP.ProperEscapingFunction sniff for catching instances where …

### DIFF
--- a/WordPressVIPMinimum/Sniffs/VIP/ProperEscapingFunctionSniff.php
+++ b/WordPressVIPMinimum/Sniffs/VIP/ProperEscapingFunctionSniff.php
@@ -18,6 +18,11 @@ use PHP_CodeSniffer_Tokens as Tokens;
  */
 class ProperEscapingFunctionSniff implements \PHP_CodeSniffer_Sniff {
 
+	/**
+	 * List of escaping functions which are being tested.
+	 *
+	 * @var array
+	 */
 	public $escaping_functions = array(
 		'esc_url',
 		'esc_attr',
@@ -66,7 +71,6 @@ class ProperEscapingFunctionSniff implements \PHP_CodeSniffer_Sniff {
 			if ( T_INLINE_HTML !== $tokens[ $html ]['code'] ) {
 				return;
 			}
-
 		} elseif ( T_STRING_CONCAT === $tokens[ $echo_or_string_concat ]['code'] ) {
 			// Very likely string concatenation mixing strings and functions/variables.
 			$html = $phpcsFile->findPrevious( Tokens::$emptyTokens, ( $echo_or_string_concat - 1 ), null, true );
@@ -93,7 +97,7 @@ class ProperEscapingFunctionSniff implements \PHP_CodeSniffer_Sniff {
 	/**
 	 * Tests whether provided string ends with open src or href attribute.
 	 *
-	 * @param $content Haystak in which we look for an open src or href attribute.
+	 * @param string $content Haystack in which we look for an open src or href attribute.
 	 *
 	 * @return bool True if string ends with open src or href attribute.
 	 */
@@ -147,6 +151,6 @@ class ProperEscapingFunctionSniff implements \PHP_CodeSniffer_Sniff {
 	 * @return bool True if haystack ends with needle.
 	 */
 	public function endswith( $haystack, $needle ) {
-		return $needle === substr( $haystack, -strlen( $needle ) );
+		return substr( $haystack, -strlen( $needle ) ) === $needle;
 	}
 }

--- a/WordPressVIPMinimum/Sniffs/VIP/ProperEscapingFunctionSniff.php
+++ b/WordPressVIPMinimum/Sniffs/VIP/ProperEscapingFunctionSniff.php
@@ -1,0 +1,152 @@
+<?php
+/**
+ * WordPress-VIP-Minimum Coding Standard.
+ *
+ * @package VIPCS\WordPressVIPMinimum
+ * @link https://github.com/Automattic/VIP-Coding-Standards
+ */
+
+namespace WordPressVIPMinimum\Sniffs\VIP;
+
+use PHP_CodeSniffer_File as File;
+use PHP_CodeSniffer_Tokens as Tokens;
+
+/**
+ * Checks whether proper escaping function is used.
+ *
+ *  @package VIPCS\WordPressVIPMinimum
+ */
+class ProperEscapingFunctionSniff implements \PHP_CodeSniffer_Sniff {
+
+	public $escaping_functions = array(
+		'esc_url',
+		'esc_attr',
+		'esc_html',
+	);
+
+	/**
+	 * Returns an array of tokens this test wants to listen for.
+	 *
+	 * @return array
+	 */
+	public function register() {
+		return Tokens::$functionNameTokens;
+	}
+
+	/**
+	 * Process this test when one of its tokens is encountered
+	 *
+	 * @param \PHP_CodeSniffer\Files\File $phpcsFile The file being scanned.
+	 * @param int                         $stackPtr  The position of the current token in the stack passed in $tokens.
+	 *
+	 * @return void
+	 */
+	public function process( File $phpcsFile, $stackPtr ) {
+
+		$tokens = $phpcsFile->getTokens();
+
+		if ( false === in_array( $tokens[ $stackPtr ]['content'], $this->escaping_functions, true ) ) {
+			return;
+		}
+
+		$function_name = $tokens[ $stackPtr ]['content'];
+
+		$echo_or_string_concat = $phpcsFile->findPrevious( Tokens::$emptyTokens, ( $stackPtr - 1 ), null, true );
+
+		if ( T_ECHO === $tokens[ $echo_or_string_concat ]['code'] ) {
+			// Very likely inline HTML with <?php tag.
+			$php_open = $phpcsFile->findPrevious( Tokens::$emptyTokens, ( $echo_or_string_concat - 1 ), null, true );
+
+			if ( T_OPEN_TAG !== $tokens[ $php_open ]['code'] ) {
+				return;
+			}
+
+			$html = $phpcsFile->findPrevious( Tokens::$emptyTokens, ( $php_open - 1 ), null, true );
+
+			if ( T_INLINE_HTML !== $tokens[ $html ]['code'] ) {
+				return;
+			}
+
+		} elseif ( T_STRING_CONCAT === $tokens[ $echo_or_string_concat ]['code'] ) {
+			// Very likely string concatenation mixing strings and functions/variables.
+			$html = $phpcsFile->findPrevious( Tokens::$emptyTokens, ( $echo_or_string_concat - 1 ), null, true );
+
+			if ( T_CONSTANT_ENCAPSED_STRING !== $tokens[ $html ]['code'] ) {
+				return;
+			}
+		} else {
+			// Neither - bailing.
+			return;
+		}
+
+		if ( 'esc_url' !== $function_name && $this->is_href_or_src( $tokens[ $html ]['content'] ) ) {
+			$phpcsFile->addError( sprintf( 'Wrong escaping function. href and src attributes should be escaped by esc_url, not by %s', $function_name ), $stackPtr, 'hrefSrcEscUrl' );
+			return;
+		}
+		if ( 'esc_html' === $function_name && $this->is_html_attr( $tokens[ $html ]['content'] ) ) {
+			$phpcsFile->addError( sprintf( 'Wrong escaping function. HTML attributes should be escaped by esc_attr, not by %s', $function_name ), $stackPtr, 'htmlAttrNotByEscHTML' );
+			return;
+		}
+
+	}//end process()
+
+	/**
+	 * Tests whether provided string ends with open src or href attribute.
+	 *
+	 * @param $content Haystak in which we look for an open src or href attribute.
+	 *
+	 * @return bool True if string ends with open src or href attribute.
+	 */
+	public function is_href_or_src( $content ) {
+		$is_href_or_src = false;
+		foreach ( array( 'href', 'src' ) as $attr ) {
+			foreach ( array(
+				'="',
+				"='",
+				'=\'"', // The tokenizer does some fun stuff when it comes to mixing double and single quotes.
+				'="\'', // The tokenizer does some fun stuff when it comes to mixing double and single quotes.
+			) as $ending ) {
+				if ( true === $this->endswith( $content, $attr . $ending ) ) {
+					$is_href_or_src = true;
+					break;
+				}
+			}
+		}
+		return $is_href_or_src;
+	}
+
+	/**
+	 * Tests, whether provided string ends with open HMTL attribute.
+	 *
+	 * @param string $content Haystack in which we look for open HTML attribute.
+	 *
+	 * @return bool True if string ends with open HTML attribute.
+	 */
+	public function is_html_attr( $content ) {
+		$is_html_attr = false;
+		foreach ( array(
+			'="',
+			"='",
+			'=\'"', // The tokenizer does some fun stuff when it comes to mixing double and single quotes.
+			'="\'', // The tokenizer does some fun stuff when it comes to mixing double and single quotes.
+		) as $ending ) {
+			if ( true === $this->endswith( $content, $ending ) ) {
+				$is_html_attr = true;
+				break;
+			}
+		}
+		return $is_html_attr;
+	}
+
+	/**
+	 * A helper function which tests whether string ends with some other.
+	 *
+	 * @param string $haystack String which is being tested.
+	 * @param string $needle The substring, which we try to locate on the end of the $haystack.
+	 *
+	 * @return bool True if haystack ends with needle.
+	 */
+	public function endswith( $haystack, $needle ) {
+		return $needle === substr( $haystack, -strlen( $needle ) );
+	}
+}

--- a/WordPressVIPMinimum/Tests/VIP/ProperEscapingFunctionUnitTest.inc
+++ b/WordPressVIPMinimum/Tests/VIP/ProperEscapingFunctionUnitTest.inc
@@ -1,0 +1,27 @@
+<?php
+
+echo '<a href="' . esc_attr( $some_var ) . '"></a>'; // NOK.
+
+echo "<a href='" . esc_attr( $some_var ) . "'></a>"; // NOK.
+
+echo '<a href="' . esc_url( $some_var ) . '"></a>'; // OK.
+
+echo "<a href='" . esc_url( $some_var ) . "'></a>"; // OK.
+
+echo '<a title="' . esc_attr( $some_var ) . '"></a>'; // OK.
+
+echo "<a title='" . esc_attr( $some_var ) . "'></a>"; // OK.
+
+echo '<a title="' . esc_html( $some_var ) . '"></a>'; // NOK.
+
+echo "<a title='" . esc_html( $some_var ) . "'></a>"; // NOK.
+
+?>
+
+<a href="<?php echo esc_attr( $some_var ); ?>">Hello</a> <!-- NOK. -->
+
+<a href="" class="<?php echo esc_html( $some_var); ?>">Hey</a> <!-- NOK. -->
+
+<a href="<?php esc_url( $url );?>"></a> <!-- OK. -->
+
+<a title="<?php esc_attr( $url );?>"></a> <!-- OK. -->

--- a/WordPressVIPMinimum/Tests/VIP/ProperEscapingFunctionUnitTest.php
+++ b/WordPressVIPMinimum/Tests/VIP/ProperEscapingFunctionUnitTest.php
@@ -1,0 +1,44 @@
+<?php
+/**
+ * Unit test class for WordPressVIPMinimum Coding Standard.
+ *
+ * @package VIPCS\WordPressVIPMinimum
+ */
+
+namespace WordPressVIPMinimum\Tests\VIP;
+
+use PHP_CodeSniffer\Tests\Standards\AbstractSniffUnitTest;
+
+/**
+ * Unit test class for the ProperEscapingFunction sniff.
+ *
+ * @package VIPCS\WordPressVIPMinimum
+ */
+class ProperEscapingFunctionUnitTest extends AbstractSniffUnitTest {
+
+	/**
+	 * Returns the lines where errors should occur.
+	 *
+	 * @return array <int line number> => <int number of errors>
+	 */
+	public function getErrorList() {
+		return array(
+			3  => 1,
+			5  => 1,
+			15 => 1,
+			17 => 1,
+			21 => 1,
+			23 => 1,
+		);
+	}
+
+	/**
+	 * Returns the lines where warnings should occur.
+	 *
+	 * @return array <int line number> => <int number of warnings>
+	 */
+	public function getWarningList() {
+		return array();
+	}
+
+} // End class.

--- a/ruleset_test.inc
+++ b/ruleset_test.inc
@@ -163,5 +163,7 @@ add_option( 'taxonomy_rating_' . $obj->term_id ); // Bad. Warning.
 
 //wpcom_vip_load_plugin( 'disqus' ); // Bad. Warning.
 
+echo "<a href='" . esc_attr( $some_var ) . "'></a>"; // NOK. Error.
+
 ?>
 

--- a/ruleset_test.php
+++ b/ruleset_test.php
@@ -48,7 +48,8 @@ $expected = array(
 		131 => 1,
 		133 => 1,
 		157 => 1,
-		166 => 1, // Error on the end of the file. When any code is added, bounce this.
+		166 => 1,
+		168 => 1, // Error on the end of the file. When any code is added, bounce this.
 	),
 	'warnings' => array(
 		9   => 1,


### PR DESCRIPTION
…`esc_url` is not used for escaping `href` or `src` attribute, and when `esc_html` is used for escaping HTML attriutes.