### PR TITLE
Adding open attribute ending with `url` to the ProperEscapingFunction sniff

### DIFF
--- a/WordPressVIPMinimum/Sniffs/VIP/ProperEscapingFunctionSniff.php
+++ b/WordPressVIPMinimum/Sniffs/VIP/ProperEscapingFunctionSniff.php
@@ -103,7 +103,7 @@ class ProperEscapingFunctionSniff implements \PHP_CodeSniffer_Sniff {
 	 */
 	public function is_href_or_src( $content ) {
 		$is_href_or_src = false;
-		foreach ( array( 'href', 'src' ) as $attr ) {
+		foreach ( array( 'href', 'src', 'url' ) as $attr ) {
 			foreach ( array(
 				'="',
 				"='",

--- a/WordPressVIPMinimum/Tests/VIP/ProperEscapingFunctionUnitTest.inc
+++ b/WordPressVIPMinimum/Tests/VIP/ProperEscapingFunctionUnitTest.inc
@@ -25,3 +25,13 @@ echo "<a title='" . esc_html( $some_var ) . "'></a>"; // NOK.
 <a href="<?php esc_url( $url );?>"></a> <!-- OK. -->
 
 <a title="<?php esc_attr( $url );?>"></a> <!-- OK. -->
+
+<?php
+
+echo '<media:content url="' . esc_url( $post_image ) . '" medium="image">'; // OK.
+
+echo '<media:content url="' . esc_attr( $post_image ) . '" medium="image">'; // NOK.
+
+echo 'data-param-url="' . esc_url( $share_url ) . '"'; // OK.
+
+echo 'data-param-url="' . esc_html( $share_url ) . '"'; // NOK.

--- a/WordPressVIPMinimum/Tests/VIP/ProperEscapingFunctionUnitTest.php
+++ b/WordPressVIPMinimum/Tests/VIP/ProperEscapingFunctionUnitTest.php
@@ -29,6 +29,8 @@ class ProperEscapingFunctionUnitTest extends AbstractSniffUnitTest {
 			17 => 1,
 			21 => 1,
 			23 => 1,
+			33 => 1,
+			37 => 1,
 		);
 	}
 


### PR DESCRIPTION
Eg.: `<media:content url="`, `data-image-url="`