### PR TITLE
Adding sniff for flagging functions which are parsing and executing HTML passed to them.

### DIFF
--- a/WordPressVIPMinimum/Sniffs/JS/HTMLExecutingFunctionsSniff.php
+++ b/WordPressVIPMinimum/Sniffs/JS/HTMLExecutingFunctionsSniff.php
@@ -1,0 +1,87 @@
+<?php
+/**
+ * WordPressVIPMinimum_Sniffs_Files_IncludingFileSniff.
+ *
+ * @package VIPCS\WordPressVIPMinimum
+ */
+
+namespace WordPressVIPMinimum\Sniffs\JS;
+
+use PHP_CodeSniffer_File as File;
+use PHP_CodeSniffer_Tokens as Tokens;
+
+/**
+ * WordPressVIPMinimum_Sniffs_JS_HTMLExecutingFunctions.
+ *
+ * Flags functions which are executing HTML passed to it.
+ *
+ * @package VIPCS\WordPressVIPMinimum
+ */
+class HTMLExecutingFunctionsSniff implements \PHP_CodeSniffer_Sniff {
+
+	/**
+	 * List of HTML executing functions
+	 */
+	public $HTMLExecutingFunctions = array(
+		'html',
+		'append',
+	);
+
+	/**
+	 * A list of tokenizers this sniff supports.
+	 *
+	 * @var array
+	 */
+	public $supportedTokenizers = array(
+		'JS',
+	);
+
+	/**
+	 * Returns an array of tokens this test wants to listen for.
+	 *
+	 * @return array
+	 */
+	public function register() {
+		return array(
+			T_STRING,
+		);
+
+	}//end register()
+
+	/**
+	 * Processes this test, when one of its tokens is encountered.
+	 *
+	 * @param \PHP_CodeSniffer\Files\File $phpcsFile The file being scanned.
+	 * @param int                         $stackPtr  The position of the current token in the
+	 *                                               stack passed in $tokens.
+	 *
+	 * @return void
+	 */
+	public function process( File $phpcsFile, $stackPtr ) {
+		$tokens = $phpcsFile->getTokens();
+
+		if ( false === in_array( $tokens[ $stackPtr ]['content'], $this->HTMLExecutingFunctions, true ) ) {
+			// Looking for specific functions only.
+			return;
+		}
+
+		$nextToken = $phpcsFile->findNext( Tokens::$emptyTokens, ( $stackPtr + 1 ), null, true, null, true );
+
+		if ( T_OPEN_PARENTHESIS !== $tokens[ $nextToken ]['code'] ) {
+			// Not a function.
+			return;
+		}
+
+		$parenthesis_closer = $tokens[ $nextToken ]['parenthesis_closer'];
+
+		while ( $nextToken < $parenthesis_closer ) {
+			$nextToken = $phpcsFile->findNext( Tokens::$emptyTokens, ( $nextToken + 1 ), null, true, null, true );
+			if ( T_STRING === $tokens[ $nextToken ]['code'] ) {
+				$phpcsFile->addWarning( sprintf( 'Any HTML passed to %s gets executed. Make sure it\'s properly escaped.', $tokens[ $stackPtr ]['content'] ), $stackPtr, $tokens[ $stackPtr ]['content'] );
+				return;
+			}
+		}
+
+	}//end process()
+
+}//end class

--- a/WordPressVIPMinimum/Sniffs/JS/HTMLExecutingFunctionsSniff.php
+++ b/WordPressVIPMinimum/Sniffs/JS/HTMLExecutingFunctionsSniff.php
@@ -20,7 +20,9 @@ use PHP_CodeSniffer_Tokens as Tokens;
 class HTMLExecutingFunctionsSniff implements \PHP_CodeSniffer_Sniff {
 
 	/**
-	 * List of HTML executing functions
+	 * List of HTML executing functions.
+	 *
+	 * @var array
 	 */
 	public $HTMLExecutingFunctions = array(
 		'html',

--- a/WordPressVIPMinimum/Tests/JS/HTMLExecutingFunctionsUnitTest.js
+++ b/WordPressVIPMinimum/Tests/JS/HTMLExecutingFunctionsUnitTest.js
@@ -1,0 +1,10 @@
+(function(){
+    var el = document.querySelector(".myclass");
+    el.html(''); // OK.
+    el.html('<b>Hand written HTML</b>'); // OK.
+    el.html( '<b>' + variable + '</b>' ); // NOK.
+    el.html( variable ); // NOK.
+    el.append( variable ); // NOK.
+    el.append( '<b>Hand written HTML</b>' ); // OK.
+    el.append( '<b>' + variable + '</b>' ); // NOK.
+})();

--- a/WordPressVIPMinimum/Tests/JS/HTMLExecutingFunctionsUnitTest.php
+++ b/WordPressVIPMinimum/Tests/JS/HTMLExecutingFunctionsUnitTest.php
@@ -1,0 +1,43 @@
+<?php
+/**
+ * Unit test class for WordPressVIPMinimum Coding Standard.
+ *
+ * @package VIPCS\WordPressVIPMinimum
+ */
+
+namespace WordPressVIPMinimum\Tests\JS;
+
+use PHP_CodeSniffer\Tests\Standards\AbstractSniffUnitTest;
+
+/**
+ * Unit test class for the HTML executing JS functions sniff.
+ *
+ * @package VIPCS\WordPressVIPMinimum
+ */
+class HTMLExecutingFunctionsUnitTest extends AbstractSniffUnitTest {
+
+	/**
+	 * Returns the lines where errors should occur.
+	 *
+	 * @return array <int line number> => <int number of errors>
+	 */
+	public function getErrorList() {
+		return array();
+	}
+
+	/**
+	 * Returns the lines where warnings should occur.
+	 *
+	 * @return array <int line number> => <int number of warnings>
+	 */
+	public function getWarningList() {
+		return array(
+			5 => 1,
+			6 => 1,
+			7 => 1,
+			9 => 1,
+		);
+
+	}
+
+} // End class.


### PR DESCRIPTION
So far, `.html()` and `.append()`