### PR TITLE
Adding sniff for flagging `defined` and `define` used with constants …

### DIFF
--- a/WordPressVIPMinimum/Sniffs/Constants/ConstantStringSniff.php
+++ b/WordPressVIPMinimum/Sniffs/Constants/ConstantStringSniff.php
@@ -1,0 +1,70 @@
+<?php
+/**
+ * WordPress-VIP-Minimum Coding Standard.
+ *
+ * @package VIPCS\WordPressVIPMinimum
+ * @link https://github.com/Automattic/VIP-Coding-Standards
+ */
+
+namespace WordPressVIPMinimum\Sniffs\Constants;
+
+use PHP_CodeSniffer_File as File;
+use PHP_CodeSniffer_Tokens as Tokens;
+
+/**
+ * Sniff for properly using constant name when checking whether a constant is defined.
+ *
+ * @package VIPCS\WordPressVIPMinimum
+ */
+class ConstantStringSniff implements \PHP_CodeSniffer_Sniff {
+
+	/**
+	 * Returns an array of tokens this test wants to listen for.
+	 *
+	 * @return array
+	 */
+	public function register() {
+		return array(
+			T_STRING,
+		);
+	}//end register()
+
+	/**
+	 * Process this test when one of its tokens is encountered.
+	 *
+	 * @param \PHP_CodeSniffer\Files\File $phpcsFile The file being scanned.
+	 * @param int                         $stackPtr  The position of the current token in the stack passed in $tokens.
+	 *
+	 * @return void
+	 */
+	public function process( File $phpcsFile, $stackPtr ) {
+
+		$tokens = $phpcsFile->getTokens();
+
+		if ( false === in_array( $tokens[ $stackPtr ]['content'], array( 'define', 'defined' ) ) ) {
+			return;
+		}
+
+		// Find the previous non-empty token.
+		$nextToken = $phpcsFile->findNext( Tokens::$emptyTokens, ( $stackPtr + 1 ), null, true, null, true );
+
+		if ( T_OPEN_PARENTHESIS !== $tokens[ $nextToken ]['code'] ) {
+			// Not a function call.
+			return;
+		}
+
+		if ( false === isset( $tokens[ $nextToken ]['parenthesis_closer'] ) ) {
+			// Not a function call.
+			return;
+		}
+
+		$nextToken = $phpcsFile->findNext( Tokens::$emptyTokens, ( $nextToken + 1 ), null, true, null, true );
+
+		if ( T_CONSTANT_ENCAPSED_STRING !== $tokens[ $nextToken ]['code'] ) {
+			$phpcsFile->addError( sprintf( 'Constant name, as a string, should be used along with %s().', $tokens[ $stackPtr ]['content'] ) , $nextToken, 'NotCheckingConstantName' );
+			return;
+		}
+
+	}
+
+} // End class.

--- a/WordPressVIPMinimum/Tests/Constants/ConstantStringUnitTest.php
+++ b/WordPressVIPMinimum/Tests/Constants/ConstantStringUnitTest.php
@@ -1,0 +1,41 @@
+<?php
+/**
+ * Unit test class for WordPressVIPMinimum Coding Standard.
+ *
+ * @package VIPCS\WordPressVIPMinimum
+ */
+
+namespace WordPressVIPMinimum\Tests\Constants;
+
+use PHP_CodeSniffer\Tests\Standards\AbstractSniffUnitTest;
+
+/**
+ * Unit test class for the ConstantString sniff.
+ *
+ * @package VIPCS\WordPressVIPMinimum
+ */
+class ConstantStringUnitTest extends AbstractSniffUnitTest {
+
+	/**
+	 * Returns the lines where errors should occur.
+	 *
+	 * @return array <int line number> => <int number of errors>
+	 */
+	public function getErrorList() {
+		return array(
+			7 => 1,
+			8 => 1,
+		);
+	}
+
+	/**
+	 * Returns the lines where warnings should occur.
+	 *
+	 * @return array <int line number> => <int number of warnings>
+	 */
+	public function getWarningList() {
+		return array();
+
+	}
+
+} // End class.


### PR DESCRIPTION
…instead of constant names as strings.

Fixes #136