### PR TITLE
Removing `wpcom_vip_get_term_link` from return value sniff as the fun…

### DIFF
--- a/WordPressVIPMinimum/Sniffs/Functions/CheckReturnValueSniff.php
+++ b/WordPressVIPMinimum/Sniffs/Functions/CheckReturnValueSniff.php
@@ -35,7 +35,6 @@ class CheckReturnValueSniff implements \PHP_CodeSniffer_Sniff {
 	 */
 	public $catch = array(
 		'esc_url'          => array(
-			'wpcom_vip_get_term_link',
 			'get_term_link',
 		),
 		'wp_list_pluck'    => array(

--- a/WordPressVIPMinimum/Tests/Functions/CheckReturnValueUnitTest.inc
+++ b/WordPressVIPMinimum/Tests/Functions/CheckReturnValueUnitTest.inc
@@ -11,7 +11,7 @@ if ( ! array_key_exists( $key, $theme_settings ) || empty( $theme_settings[ $key
 
 $my_url = wpcom_vip_get_term_link();
 
-echo '<a href="' . esc_url( $my_url ) . '">My Link</a>'; // Bad.
+echo '<a href="' . esc_url( $my_url ) . '">My Link</a>'; // Okay, deprecated.
 
 echo '<a href="' . esc_url( get_term_link( $link ) ) . '">My term link</a>'; // Bad.
 

--- a/WordPressVIPMinimum/Tests/Functions/CheckReturnValueUnitTest.php
+++ b/WordPressVIPMinimum/Tests/Functions/CheckReturnValueUnitTest.php
@@ -25,7 +25,6 @@ class CheckReturnValueUnitTest extends AbstractSniffUnitTest {
 		return array(
 			5  => 1,
 			9  => 1,
-			14 => 1,
 			16 => 1,
 			19 => 1,
 			23 => 1,


### PR DESCRIPTION
…ction is deprecated and should not be used.

Fixes #135