### PR TITLE
Adding sniff for flaggig suspicous WP_Query params.

### DIFF
--- a/WordPressVIPMinimum/Sniffs/VIP/WPQueryParamsSniff.php
+++ b/WordPressVIPMinimum/Sniffs/VIP/WPQueryParamsSniff.php
@@ -1,0 +1,58 @@
+<?php
+/**
+ * WordPress-VIP-Minimum Coding Standard.
+ *
+ *  @package VIPCS\WordPressVIPMinimum
+ * @link https://github.com/Automattic/VIP-Coding-Standards
+ */
+
+namespace WordPressVIPMinimum\Sniffs\VIP;
+
+use PHP_CodeSniffer_File as File;
+use PHP_CodeSniffer_Tokens as Tokens;
+
+/**
+ * Flag suspicious WP_Query and get_posts params.
+ *
+ *  @package VIPCS\WordPressVIPMinimum
+ */
+class WPQueryParamsSniff implements \PHP_CodeSniffer_Sniff {
+
+	/**
+	 * Returns an array of tokens this test wants to listen for.
+	 *
+	 * @return array
+	 */
+	public function register() {
+		return array(
+			T_CONSTANT_ENCAPSED_STRING,
+		);
+	}
+
+	/**
+	 * Process this test when one of its tokens is encountered
+	 *
+	 * @param \PHP_CodeSniffer\Files\File $phpcsFile The file being scanned.
+	 * @param int                         $stackPtr  The position of the current token in the stack passed in $tokens.
+	 *
+	 * @return void
+	 */
+	public function process( File $phpcsFile, $stackPtr ) {
+
+		$tokens = $phpcsFile->getTokens();
+
+		if ( 'suppress_filters' === trim( $tokens[ $stackPtr ]['content'], '\'' ) ) {
+
+			$next_token = $phpcsFile->findNext( array_merge( Tokens::$emptyTokens, array( T_EQUAL, T_CLOSE_SQUARE_BRACKET, T_DOUBLE_ARROW ) ), ( $stackPtr + 1 ), null, true );
+
+			if ( T_TRUE === $tokens[ $next_token ]['code'] ) {
+				$phpcsFile->addError( 'Setting suppress_filters to true is probihited.', $stackPtr, 'suppressFiltersTrue' );
+			}
+		}
+
+		if ( 'post__not_in' === trim( $tokens[ $stackPtr ]['content'], '\'' ) ) {
+			$phpcsFile->addWarning( 'Using post__not_in should be used with cautious.', $stackPtr, 'post__not_in' );
+		}
+	}
+
+}

--- a/WordPressVIPMinimum/Tests/VIP/WPQueryParamsUnitTest.inc
+++ b/WordPressVIPMinimum/Tests/VIP/WPQueryParamsUnitTest.inc
@@ -1,0 +1,19 @@
+<?php
+
+get_posts( [
+	'post__not_in' => array( 1, 2, 3 ),
+	'suppress_filters' => true,
+] );
+
+$posts_not_in = [ 3, 4, 5 ];
+
+$query_args = array(
+	'post__not_in' => $posts_not_in,
+	'suppress_filters' => false,
+);
+
+$q = new WP_Query( $query_args );
+
+$query_args[ 'suppress_filters' ] = true;
+
+$q = new WP_query( $query_args );

--- a/WordPressVIPMinimum/Tests/VIP/WPQueryParamsUnitTest.php
+++ b/WordPressVIPMinimum/Tests/VIP/WPQueryParamsUnitTest.php
@@ -1,0 +1,44 @@
+<?php
+/**
+ * Unit test class for WordPressVIPMinimum Coding Standard.
+ *
+ * @package VIPCS\WordPressVIPMinimum
+ */
+
+namespace WordPressVIPMinimum\Tests\VIP;
+
+use PHP_CodeSniffer\Tests\Standards\AbstractSniffUnitTest;
+
+/**
+ * Unit test class for the WP_Query params sniff.
+ *
+ * @package VIPCS\WordPressVIPMinimum
+ */
+class WPQueryParamsUnitTest extends AbstractSniffUnitTest {
+
+	/**
+	 * Returns the lines where errors should occur.
+	 *
+	 * @return array <int line number> => <int number of errors>
+	 */
+	public function getErrorList() {
+		return array(
+			5  => 1,
+			17 => 1,
+		);
+	}
+
+	/**
+	 * Returns the lines where warnings should occur.
+	 *
+	 * @return array <int line number> => <int number of warnings>
+	 */
+	public function getWarningList() {
+		return array(
+			4  => 1,
+			11 => 1,
+		);
+
+	}
+
+} // End class.


### PR DESCRIPTION
Curently:

* `suppress_filters` set to true - fixes #124
* `post__not_in` - fixes #121

Includes unit tests