### PR TITLE
Show a more helpful message for strip_tags() error

### DIFF
--- a/WordPressVIPMinimum/Sniffs/Functions/StripTagsNotAllowedSniff.php
+++ b/WordPressVIPMinimum/Sniffs/Functions/StripTagsNotAllowedSniff.php
@@ -15,7 +15,7 @@ class StripTagsNotAllowedSniff implements \PHP_CodeSniffer_Sniff {
 	 *
 	 * @var array
 	 */
-	private $_tokens = [];
+	private $_tokens = array();
 
 	/**
 	 * The phpcs file.
@@ -50,7 +50,6 @@ class StripTagsNotAllowedSniff implements \PHP_CodeSniffer_Sniff {
 
 		$this->_tokens    = $phpcsFile->getTokens();
 		$this->_phpcsFile = $phpcsFile;
-
 
 		if ( 'strip_tags' !== $this->_tokens[ $stackPtr ]['content'] ) {
 			// We only care for strip_slashes function.

--- a/WordPressVIPMinimum/Sniffs/Functions/StripTagsNotAllowedSniff.php
+++ b/WordPressVIPMinimum/Sniffs/Functions/StripTagsNotAllowedSniff.php
@@ -1,4 +1,9 @@
 <?php
+/**
+ * WordPressVIPMinimum Coding Standard.
+ *
+ * @package VIPCS\WordPressVIPMinimum
+ */
 
 namespace WordPressVIPMinimum\Sniffs\Functions;
 

--- a/WordPressVIPMinimum/Sniffs/Functions/StripTagsNotAllowedSniff.php
+++ b/WordPressVIPMinimum/Sniffs/Functions/StripTagsNotAllowedSniff.php
@@ -1,0 +1,111 @@
+<?php
+
+namespace WordPressVIPMinimum\Sniffs\Functions;
+
+use PHP_CodeSniffer_File as File;
+use PHP_CodeSniffer_Tokens as Tokens;
+
+/**
+ * This sniff will check for `strip_slashes()` usage and return a relavant error
+ */
+class StripTagsNotAllowedSniff implements \PHP_CodeSniffer_Sniff {
+
+	/**
+	 * Tokens of the whole file.
+	 *
+	 * @var array
+	 */
+	private $_tokens = [];
+
+	/**
+	 * The phpcs file.
+	 *
+	 * @var File
+	 */
+	private $_phpcsFile;
+
+
+	/**
+	 * Returns the token types that this sniff is interested in.
+	 *
+	 * @return array(int)
+	 */
+	public function register() {
+
+		return Tokens::$functionNameTokens;
+
+	}
+
+
+	/**
+	 * Processes the tokens that this sniff is interested in.
+	 *
+	 * @param \PHP_CodeSniffer\Files\File $phpcsFile The file where the token was found.
+	 * @param int                         $stackPtr  The position in the stack where
+	 *                                               the token was found.
+	 *
+	 * @return bool
+	 */
+	public function process( File $phpcsFile, $stackPtr ) {
+
+		$this->_tokens    = $phpcsFile->getTokens();
+		$this->_phpcsFile = $phpcsFile;
+
+
+		if ( 'strip_tags' !== $this->_tokens[ $stackPtr ]['content'] ) {
+			// We only care for strip_slashes function.
+			return false;
+		}
+
+		if ( ! $this->isFunctionCall( $stackPtr ) ) {
+			// Not a function call.
+			return false;
+		}
+
+		if ( $phpcsFile->findNext( T_COMMA, $stackPtr + 1, null, false, null, true ) ) {
+			// If there is a comma inside - there are more than 1 argument to strip_tags().
+			$phpcsFile->addError( '`strip_tags()` does not strip CSS and JS in between the script and style tags. Use `wp_kses()` instead to allow only the HTML you need.', $stackPtr, 'stripTagsNotAllowed' );
+		} else {
+			// `strip_tags()` called with 1 or less arguments.
+			$phpcsFile->addError( '`strip_tags()` does not strip CSS and JS in between the script and style tags. Use `wp_strip_all_tags()` to strip all tags.', $stackPtr, 'stripTagsNotAllowed' );
+		}
+	}
+
+
+	/**
+	 * Check whether the currently examined code is a function call.
+	 *
+	 * @param int $stackPtr The position of the current token in the stack passed in $tokens.
+	 *
+	 * @return bool
+	 */
+	private function isFunctionCall( $stackPtr ) {
+
+		$tokens    = $this->_tokens;
+		$phpcsFile = $this->_phpcsFile;
+
+		if ( false === in_array( $tokens[ $stackPtr ]['code'], Tokens::$functionNameTokens, true ) ) {
+			return false;
+		}
+
+		// Find the next non-empty token.
+		$openBracket = $phpcsFile->findNext( Tokens::$emptyTokens, ( $stackPtr + 1 ), null, true );
+
+		if ( T_OPEN_PARENTHESIS !== $tokens[ $openBracket ]['code'] ) {
+			// Not a function call.
+			return false;
+		}
+
+		// Find the previous non-empty token.
+		$search   = Tokens::$emptyTokens;
+		$search[] = T_BITWISE_AND;
+		$previous = $phpcsFile->findPrevious( $search, ( $stackPtr - 1 ), null, true );
+		if ( T_FUNCTION === $tokens[ $previous ]['code'] ) {
+			// It's a function definition, not a function call.
+			return false;
+		}
+
+		return true;
+	}
+
+}

--- a/WordPressVIPMinimum/Tests/Functions/StripTagsNotAllowedUnitTest.inc
+++ b/WordPressVIPMinimum/Tests/Functions/StripTagsNotAllowedUnitTest.inc
@@ -1,0 +1,3 @@
+<?php
+strip_tags( $foo, $bar ); // not-ok
+strip_tags( $foo ); // not-ok

--- a/WordPressVIPMinimum/Tests/Functions/StripTagsNotAllowedUnitTest.php
+++ b/WordPressVIPMinimum/Tests/Functions/StripTagsNotAllowedUnitTest.php
@@ -1,0 +1,45 @@
+<?php
+/**
+ * Unit test class for WordPressVIPMinimum Coding Standard.
+ *
+ * @package VIPCS\WordPressVIPMinimum
+ */
+
+namespace WordPressVIPMinimum\Tests\Functions;
+
+use PHP_CodeSniffer\Tests\Standards\AbstractSniffUnitTest;
+
+/**
+ * Unit test class for the StripTagsNotAllowed sniff.
+ *
+ * @package VIPCS\WordPressVIPMinimum
+ */
+class StripTagsNotAllowedUnitTest extends AbstractSniffUnitTest {
+
+	/**
+	 * Returns the lines where errors should occur.
+	 *
+	 * The key of the array should represent the line number and the value
+	 * should represent the number of errors that should occur on that line.
+	 *
+	 * @return array<int, int>
+	 */
+	protected function getErrorList() {
+		return [
+			2 => 1,
+			3 => 1,
+		];
+	}
+
+	/**
+	 * Returns the lines where warnings should occur.
+	 *
+	 * The key of the array should represent the line number and the value
+	 * should represent the number of warnings that should occur on that line.
+	 *
+	 * @return array<int, int>
+	 */
+	protected function getWarningList() {
+		return [];
+	}
+}

--- a/WordPressVIPMinimum/Tests/Functions/StripTagsNotAllowedUnitTest.php
+++ b/WordPressVIPMinimum/Tests/Functions/StripTagsNotAllowedUnitTest.php
@@ -25,10 +25,10 @@ class StripTagsNotAllowedUnitTest extends AbstractSniffUnitTest {
 	 * @return array<int, int>
 	 */
 	protected function getErrorList() {
-		return [
+		return array(
 			2 => 1,
 			3 => 1,
-		];
+		);
 	}
 
 	/**

--- a/WordPressVIPMinimum/Tests/Functions/StripTagsNotAllowedUnitTest.php
+++ b/WordPressVIPMinimum/Tests/Functions/StripTagsNotAllowedUnitTest.php
@@ -40,6 +40,6 @@ class StripTagsNotAllowedUnitTest extends AbstractSniffUnitTest {
 	 * @return array<int, int>
 	 */
 	protected function getWarningList() {
-		return [];
+		return array();
 	}
 }

--- a/WordPressVIPMinimum/ruleset.xml
+++ b/WordPressVIPMinimum/ruleset.xml
@@ -118,4 +118,10 @@
 		<type>error</type>
 		<message>%1$s() performs a no-LIMIT query by default, make sure to set a reasonable posts_per_page. %1$s() will do a -1 query by default, a maximum of 100 should be used.</message>
 	</rule>
+
+
+	<rule ref="WordPressVIPMinimum.VIP.RestrictedFunctions">
+		<!--Remove strip_tags() check, because we're rolling our own -->
+		<exclude name="WordPressVIPMinimum.VIP.RestrictedFunctions.strip_tags_strip_tags"/>
+	</rule>
 </ruleset>


### PR DESCRIPTION
Fixes #133 

I silenced the WordPress sniff for `strip_tags()` and replaced it with a custom sniff. 

This is going to check if `strip_tags()` function call contains a comma (and therefor, multiple arguments) - and if it does - it will change the message accordingly to use `wp_kses()` instead.

The two error messages I came up with are:
```
`strip_tags()` does not strip CSS and JS in between the script and style tags. Use `wp_strip_all_tags()` to strip all tags.
```

```
`strip_tags()` does not strip CSS and JS in between the script and style tags. Use `wp_kses()` instead to allow only the HTML you need.
```

