### PR TITLE
Add new sniff to find dynamic calls to functions

### DIFF
--- a/WordPressVIPMinimum/Sniffs/Functions/DynamicCallsSniff.php
+++ b/WordPressVIPMinimum/Sniffs/Functions/DynamicCallsSniff.php
@@ -60,8 +60,7 @@ class DynamicCallsSniff implements \PHP_CodeSniffer_Sniff {
 	 * @return array(int)
 	 */
 	public function register() {
-		return array( T_VARIABLE => T_VARIABLE ) +
-			Tokens::$functionNameTokens;
+		return array( T_VARIABLE => T_VARIABLE );
 
 	}//end register()
 

--- a/WordPressVIPMinimum/Sniffs/Functions/DynamicCallsSniff.php
+++ b/WordPressVIPMinimum/Sniffs/Functions/DynamicCallsSniff.php
@@ -1,5 +1,4 @@
 <?php
-
 /**
  * WordPressVIPMinimum Coding Standard.
  *
@@ -27,14 +26,12 @@ use PHP_CodeSniffer_Tokens as Tokens;
  * Note that this sniff does not catch all possible forms of dynamic
  * calling, only some.
  */
-
 class DynamicCallsSniff implements \PHP_CodeSniffer_Sniff {
 	/**
 	 * Functions that should not be called dynamically.
 	 *
 	 * @var array
 	 */
-
 	private $_blacklisted_functions = array(
 		'assert',
 		'compact',
@@ -53,9 +50,7 @@ class DynamicCallsSniff implements \PHP_CodeSniffer_Sniff {
 	 *
 	 * @var array
 	 */
-
 	private	$_variables_arr = array();
-
 
 	/**
 	 * Returns the token types that this sniff is interested in.
@@ -81,6 +76,7 @@ class DynamicCallsSniff implements \PHP_CodeSniffer_Sniff {
 	 * @return void
 	 */
 	public function process( File $phpcsFile, $stackPtr ) {
+
 		$this->_tokens    = $phpcsFile->getTokens();
 		$this->_phpcsFile = $phpcsFile;
 		$this->_stackPtr = $stackPtr;
@@ -100,8 +96,8 @@ class DynamicCallsSniff implements \PHP_CodeSniffer_Sniff {
 	 *
 	 * @return void
 	 */
-
 	function _collect_variables() {
+
 		/*
 		 * Make sure we are working with a variable,
 		 * get its value if so.
@@ -178,7 +174,6 @@ class DynamicCallsSniff implements \PHP_CodeSniffer_Sniff {
 
 	} // end _collect_variables
 
-
 	/**
 	 * Find any dynamic calls being made using variables.
 	 * Report on this when found, using name of the function
@@ -186,8 +181,8 @@ class DynamicCallsSniff implements \PHP_CodeSniffer_Sniff {
 	 *
 	 * @return void
 	 */
-
 	function _find_dynamic_calls() {
+
 		/*
 		 * No variables detected; no basis for doing
 		 * anything
@@ -283,6 +278,5 @@ class DynamicCallsSniff implements \PHP_CodeSniffer_Sniff {
 			$t_item_key,
 			'DynamicCalls'
 		);
-
 	} // end _find_dynamic_calls
 }

--- a/WordPressVIPMinimum/Sniffs/Functions/DynamicCallsSniff.php
+++ b/WordPressVIPMinimum/Sniffs/Functions/DynamicCallsSniff.php
@@ -95,7 +95,7 @@ class DynamicCallsSniff implements \PHP_CodeSniffer_Sniff {
 
 	function _collect_variables() {
 		/*
-		 * Find variable within the next semicolon 
+		 * Find variable within the next semicolon
 		 */
 
 		$t_item_key = $this->_phpcsFile->findNext(
@@ -170,9 +170,9 @@ class DynamicCallsSniff implements \PHP_CodeSniffer_Sniff {
 	 */
 
 	function _find_dynamic_calls() {
-		/* 
-		 * No variables detected; no basis for doing 
-		 * anything 
+		/*
+		 * No variables detected; no basis for doing
+		 * anything
 		 */
 
 		if ( empty( $this->_variables_arr ) ) {
@@ -220,8 +220,8 @@ class DynamicCallsSniff implements \PHP_CodeSniffer_Sniff {
 		$t_item_val = $this->_tokens[ $t_item_key ];
 
 
-		/* 
-		 * If variable is not found in our registry of 
+		/*
+		 * If variable is not found in our registry of
 		 * variables, do not do anything, as we cannot be
 		 * sure that the function being called is one of the
 		 * blacklisted ones.

--- a/WordPressVIPMinimum/Sniffs/Functions/DynamicCallsSniff.php
+++ b/WordPressVIPMinimum/Sniffs/Functions/DynamicCallsSniff.php
@@ -50,7 +50,7 @@ class DynamicCallsSniff implements \PHP_CodeSniffer_Sniff {
 	 *
 	 * @var array
 	 */
-	private	$_variables_arr = array();
+	private $_variables_arr = array();
 
 	/**
 	 * Returns the token types that this sniff is interested in.
@@ -60,8 +60,7 @@ class DynamicCallsSniff implements \PHP_CodeSniffer_Sniff {
 	 * @return array(int)
 	 */
 	public function register() {
-		return
-			array( T_VARIABLE => T_VARIABLE ) +
+		return array( T_VARIABLE => T_VARIABLE ) +
 			Tokens::$functionNameTokens;
 
 	}//end register()
@@ -76,15 +75,14 @@ class DynamicCallsSniff implements \PHP_CodeSniffer_Sniff {
 	 * @return void
 	 */
 	public function process( File $phpcsFile, $stackPtr ) {
-
 		$this->_tokens    = $phpcsFile->getTokens();
 		$this->_phpcsFile = $phpcsFile;
-		$this->_stackPtr = $stackPtr;
+		$this->_stackPtr  = $stackPtr;
 
-		// First collect all variables encountered and their values
+		// First collect all variables encountered and their values.
 		$this->_collect_variables();
 
-		// Then find all dynamic calls, and report them
+		// Then find all dynamic calls, and report them.
 		$this->_find_dynamic_calls();
 
 	}//end process()
@@ -96,24 +94,22 @@ class DynamicCallsSniff implements \PHP_CodeSniffer_Sniff {
 	 *
 	 * @return void
 	 */
-	function _collect_variables() {
-
+	private function _collect_variables() {
 		/*
 		 * Make sure we are working with a variable,
 		 * get its value if so.
 		 */
 
 		if (
-			"T_VARIABLE" !==
-				$this->_tokens[ $this->_stackPtr ][ "type" ]
+			'T_VARIABLE' !==
+				$this->_tokens[ $this->_stackPtr ]['type']
 		) {
 			return;
 		}
 
 		$current_var_name = $this->_tokens[
 			$this->_stackPtr
-		]["content"];
-
+		]['content'];
 
 		/*
 		 * Find assignments ( $foo = "bar"; )
@@ -134,11 +130,11 @@ class DynamicCallsSniff implements \PHP_CodeSniffer_Sniff {
 			return;
 		}
 
-		if ( "T_EQUAL" !== $this->_tokens[ $t_item_key ]["type"] ) {
+		if ( 'T_EQUAL' !== $this->_tokens[ $t_item_key ]['type'] ) {
 			return;
 		}
 
-		if ( 1 !== $this->_tokens[ $t_item_key ]["length"] ) {
+		if ( 1 !== $this->_tokens[ $t_item_key ]['length'] ) {
 			return;
 		}
 
@@ -158,7 +154,6 @@ class DynamicCallsSniff implements \PHP_CodeSniffer_Sniff {
 			return;
 		}
 
-
 		/*
 		 * We have found variable-assignment,
 		 * register its name and value in the
@@ -166,11 +161,10 @@ class DynamicCallsSniff implements \PHP_CodeSniffer_Sniff {
 		 */
 
 		$current_var_value =
-			$this->_tokens[ $t_item_key ]["content"];
-
+			$this->_tokens[ $t_item_key ]['content'];
 
 		$this->_variables_arr[ $current_var_name ] =
-			str_replace( "'", "", $current_var_value );
+			str_replace( "'", '', $current_var_value );
 
 	} // end _collect_variables
 
@@ -181,8 +175,7 @@ class DynamicCallsSniff implements \PHP_CodeSniffer_Sniff {
 	 *
 	 * @return void
 	 */
-	function _find_dynamic_calls() {
-
+	private function _find_dynamic_calls() {
 		/*
 		 * No variables detected; no basis for doing
 		 * anything
@@ -192,18 +185,16 @@ class DynamicCallsSniff implements \PHP_CodeSniffer_Sniff {
 			return;
 		}
 
-
 		/*
 		 * Make sure we do have a variable to work with.
 		 */
 
 		if (
-			"T_VARIABLE" !==
-				$this->_tokens[ $this->_stackPtr ][ "type" ]
+			'T_VARIABLE' !==
+				$this->_tokens[ $this->_stackPtr ]['type']
 		) {
 			return;
 		}
-
 
 		/*
 		 * If variable is not found in our registry of
@@ -214,12 +205,11 @@ class DynamicCallsSniff implements \PHP_CodeSniffer_Sniff {
 
 		if ( ! isset(
 			$this->_variables_arr[
-				$this->_tokens[ $this->_stackPtr ]["content"]
+				$this->_tokens[ $this->_stackPtr ]['content']
 			]
 		) ) {
 			return;
 		}
-
 
 		/*
 		 * Check if we have an '(' next, or separated by whitespaces
@@ -231,23 +221,22 @@ class DynamicCallsSniff implements \PHP_CodeSniffer_Sniff {
 		do {
 			$i++;
 		} while (
-			"T_WHITESPACE" ===
+			'T_WHITESPACE' ===
 				$this->_tokens[
 					$this->_stackPtr + $i
-				]["type"]
+				]['type']
 		);
 
 		if (
-			"T_OPEN_PARENTHESIS" !==
+			'T_OPEN_PARENTHESIS' !==
 				$this->_tokens[
 					$this->_stackPtr + $i
-				]["type"]
+				]['type']
 		) {
 			return;
 		}
 
 		$t_item_key = $this->_stackPtr + $i;
-
 
 		/*
 		 * We have a variable match, but make sure it contains name
@@ -256,23 +245,23 @@ class DynamicCallsSniff implements \PHP_CodeSniffer_Sniff {
 
 		if ( ! in_array(
 			$this->_variables_arr[
-				$this->_tokens[ $this->_stackPtr ]["content"]
+				$this->_tokens[ $this->_stackPtr ]['content']
 			],
-			$this->_blacklisted_functions
+			$this->_blacklisted_functions,
+			true
 		) ) {
 			return;
 		}
 
-
 		// We do, so report.
 		$this->_phpcsFile->addError(
 			sprintf(
-				"Dynamic calling is not recommended " .
-					"in the case of %s",
+				'Dynamic calling is not recommended ' .
+					'in the case of %s',
 				$this->_variables_arr[
 					$this->_tokens[
 						$this->_stackPtr
-					]["content"]
+					]['content']
 				]
 			),
 			$t_item_key,

--- a/WordPressVIPMinimum/Sniffs/Functions/DynamicCallsSniff.php
+++ b/WordPressVIPMinimum/Sniffs/Functions/DynamicCallsSniff.php
@@ -1,0 +1,268 @@
+<?php
+
+/**
+ * WordPressVIPMinimum Coding Standard.
+ *
+ * @package VIPCS\WordPressVIPMinimum
+ */
+
+namespace WordPressVIPMinimum\Sniffs\Functions;
+
+use PHP_CodeSniffer_File as File;
+use PHP_CodeSniffer_Tokens as Tokens;
+
+/**
+ * This sniff enforces that certain functions are not
+ * dynamically called.
+ *
+ * An example:
+ *
+ * <code>
+ *   $func = 'func_num_args';
+ *   $func();
+ * </code>
+ */
+class DynamicCallsSniff implements \PHP_CodeSniffer_Sniff {
+	/**
+	 * Functions that should not be called dynamically.
+	 *
+	 * @var array
+	 */
+
+	private $_blacklisted_functions = array(
+		'assert',
+		'compact',
+		'extract',
+		'func_get_args',
+		'func_get_arg',
+		'func_num_args',
+		'get_defined_vars',
+		'mb_parse_str',
+		'parse_str',
+	);
+
+	/**
+	 * Array of functions encountered, along with their values.
+	 * Populated on run-time.
+	 *
+	 * @var array
+	 */
+
+	private	$_variables_arr = array();
+
+
+	/**
+	 * Returns the token types that this sniff is interested in.
+	 *
+	 * We want everything variable- and function-related.
+	 *
+	 * @return array(int)
+	 */
+	public function register() {
+		return
+			array( T_VARIABLE => T_VARIABLE ) +
+			Tokens::$functionNameTokens;
+
+	}//end register()
+
+	/**
+	 * Processes the tokens that this sniff is interested in.
+	 *
+	 * @param \PHP_CodeSniffer\Files\File $phpcsFile The file where the token was found.
+	 * @param int                         $stackPtr  The position in the stack where
+	 *                                               the token was found.
+	 *
+	 * @return void
+	 */
+	public function process( File $phpcsFile, $stackPtr ) {
+		$this->_tokens    = $phpcsFile->getTokens();
+		$this->_phpcsFile = $phpcsFile;
+		$this->_stackPtr = $stackPtr;
+
+		$this->_collect_variables();
+		
+		$this->_find_dynamic_calls();
+
+	}//end process()
+
+	/**
+	 * Finds any variable-definitions in the file being processed,
+	 * and stores them internally in a private array. The data stored
+	 * is the name of the variable and its assigned value.
+	 *
+	 * @return void
+	 */
+
+	function _collect_variables() {
+		/*
+		 * Find variable within the next semicolon 
+		 */
+
+		$t_item_key = $this->_phpcsFile->findNext(
+			array( T_VARIABLE ),
+			$this->_stackPtr,
+			null,
+			false,
+			null,
+			true
+		);
+
+		if ( false === $t_item_key ) {
+			return;
+		}
+
+		$current_var_name = $this->_tokens[ $t_item_key ]["content"];
+
+
+		/*
+		 * Find encapsed string ( "" )
+		 */
+		$t_item_key = $this->_phpcsFile->findNext(
+			array( T_CONSTANT_ENCAPSED_STRING ),
+			$this->_stackPtr,
+			null,
+			false,
+			null,
+			true
+		);
+
+		if ( false === $t_item_key ) {
+			return;
+		}
+
+		$current_var_value =
+			$this->_tokens[ $t_item_key ]["content"];
+
+
+		/*
+		 * Find assignments ( $foo = "bar"; )
+		 */
+
+		$t_item_key = $this->_phpcsFile->findNext(
+			array( T_EQUAL ),
+			$this->_stackPtr,
+			null,
+			false,
+			null,
+			true
+		);
+
+		if ( false === $t_item_key ) {
+			return;
+		}
+
+		if ( 1 !== $this->_tokens[ $t_item_key ]["length"] ) {
+			return;
+		}
+
+		$this->_variables_arr[ $current_var_name ] =
+			str_replace( "'", "", $current_var_value );
+
+	} // end _collect_variables
+
+
+	/**
+	 * Find any dynamic calls being made using variables.
+	 * Report on this when found, using name of the function
+	 * in the message.
+	 *
+	 * @return void
+	 */
+
+	function _find_dynamic_calls() {
+		/* 
+		 * No variables detected; no basis for doing 
+		 * anything 
+		 */
+
+		if ( empty( $this->_variables_arr ) ) {
+			return;
+		}
+
+		/*
+		 * Make sure we do have a variable
+		 * in the stack, and within the next semicolon.
+		 */
+
+		$t_item_key = $this->_phpcsFile->findNext(
+			array( T_VARIABLE ),
+			$this->_stackPtr,
+			null,
+			false,
+			null,
+			true
+		);
+
+		if ( false === $t_item_key ) {
+			return;
+		}
+
+
+		/*
+		 * Check if we have an '(' somewhere next in the stack,
+		 * but not outside of the next semicolon ( ';' ).
+		 */
+
+		$t_item_key  = $this->_phpcsFile->findNext(
+			array( T_OPEN_PARENTHESIS ),
+			$this->_stackPtr + 1,
+			null,
+			false,
+			null,
+			true
+		);
+
+		if ( false === $t_item_key ) {
+			// None found, return
+			return;
+		}
+
+		$t_item_val = $this->_tokens[ $t_item_key ];
+
+
+		/* 
+		 * If variable is not found in our registry of 
+		 * variables, do not do anything, as we cannot be
+		 * sure that the function being called is one of the
+		 * blacklisted ones.
+		 */
+
+		if ( ! isset(
+			$this->_variables_arr[
+				$this->_tokens[ $this->_stackPtr ]["content"]
+			]
+		) ) {
+			return;
+		}
+
+		/*
+		 * We have a variable match, but make sure it contains name
+		 * of a function which is on our blacklist.
+		 */
+
+		if ( ! in_array(
+			$this->_variables_arr[
+				$this->_tokens[ $this->_stackPtr ]["content"]
+			],
+			$this->_blacklisted_functions
+		) ) {
+			return;
+		}
+
+
+		// We do, so report.
+		$this->_phpcsFile->addError(
+			sprintf(
+				"Dynamic calling is not recommended in the case of %s",
+				$this->_variables_arr[
+					$this->_tokens[
+						$this->_stackPtr
+					]["content"]
+				]
+			),
+			$t_item_key,
+			'DynamicCalls'
+		);
+
+	} // end _find_dynamic_calls
+}

--- a/WordPressVIPMinimum/Tests/Functions/DynamicCallsUnitTest.inc
+++ b/WordPressVIPMinimum/Tests/Functions/DynamicCallsUnitTest.inc
@@ -1,0 +1,7 @@
+<?php
+
+$myfunc = 'extract';
+
+$myfunc();
+
+

--- a/WordPressVIPMinimum/Tests/Functions/DynamicCallsUnitTest.inc
+++ b/WordPressVIPMinimum/Tests/Functions/DynamicCallsUnitTest.inc
@@ -1,7 +1,15 @@
 <?php
 
-$myfunc = 'extract';
+function my_test() {
+	echo esc_html( "foo" );
+}
 
-$myfunc();
+
+$my_notokay_func = 'extract';
+$my_notokay_func();
+
+$my_okay_func = 'my_test';
+$my_okay_func();
+
 
 

--- a/WordPressVIPMinimum/Tests/Functions/DynamicCallsUnitTest.php
+++ b/WordPressVIPMinimum/Tests/Functions/DynamicCallsUnitTest.php
@@ -23,7 +23,7 @@ class DynamicCallsUnitTest extends AbstractSniffUnitTest {
 	 */
 	public function getErrorList() {
 		return array(
-			9  => 1,
+			9 => 1,
 		);
 	}
 

--- a/WordPressVIPMinimum/Tests/Functions/DynamicCallsUnitTest.php
+++ b/WordPressVIPMinimum/Tests/Functions/DynamicCallsUnitTest.php
@@ -23,7 +23,7 @@ class DynamicCallsUnitTest extends AbstractSniffUnitTest {
 	 */
 	public function getErrorList() {
 		return array(
-			5  => 1,
+			9  => 1,
 		);
 	}
 

--- a/WordPressVIPMinimum/Tests/Functions/DynamicCallsUnitTest.php
+++ b/WordPressVIPMinimum/Tests/Functions/DynamicCallsUnitTest.php
@@ -1,0 +1,40 @@
+<?php
+/**
+ * Unit test class for WordPressVIPMinimum Coding Standard.
+ *
+ * @package VIPCS\WordPressVIPMinimum
+ */
+
+namespace WordPressVIPMinimum\Tests\Functions;
+
+use PHP_CodeSniffer\Tests\Standards\AbstractSniffUnitTest;
+
+/**
+ * Unit test class for the DynamicCalls sniff.
+ *
+ * @package VIPCS\WordPressVIPMinimum
+ */
+class DynamicCallsUnitTest extends AbstractSniffUnitTest {
+
+	/**
+	 * Returns the lines where errors should occur.
+	 *
+	 * @return array <int line number> => <int number of errors>
+	 */
+	public function getErrorList() {
+		return array(
+			5  => 1,
+		);
+	}
+
+	/**
+	 * Returns the lines where warnings should occur.
+	 *
+	 * @return array <int line number> => <int number of warnings>
+	 */
+	public function getWarningList() {
+		return array();
+
+	}
+
+} // End class.


### PR DESCRIPTION
Dynamic calls to certain functions are not allowed in PHP 7.1 and forwards. This sniff will find some of these.

http://php.net/manual/en/migration71.incompatible.php