### PR TITLE
Sniff to detect create_function()

### DIFF
--- a/WordPressVIPMinimum/Sniffs/Functions/CreateFunctionSniff.php
+++ b/WordPressVIPMinimum/Sniffs/Functions/CreateFunctionSniff.php
@@ -76,7 +76,7 @@ class CreateFunctionSniff implements \PHP_CodeSniffer_Sniff {
 			if ( 'create_function' !==
 				$this->_tokens[ $this->_stackPtr ]['content']
 			) {
-				// Not a function call, repeat.
+				// Not the function call we want.
 				$functionName = $this->getNextTString(
 					$phpcsFile,
 					$functionName + 1
@@ -97,7 +97,7 @@ class CreateFunctionSniff implements \PHP_CodeSniffer_Sniff {
 				( false === $bracket ) ||
 				( T_OPEN_PARENTHESIS !== $this->_tokens[ $bracket ]['code'] )
 			) {
-				// Not a function call, repeat.
+				// Not a function call.
 				$functionName = $this->getNextTString(
 					$phpcsFile,
 					$functionName + 1

--- a/WordPressVIPMinimum/Sniffs/Functions/CreateFunctionSniff.php
+++ b/WordPressVIPMinimum/Sniffs/Functions/CreateFunctionSniff.php
@@ -37,6 +37,26 @@ class CreateFunctionSniff implements \PHP_CodeSniffer_Sniff {
 	}
 
 	/**
+	 * Get next T_STRING token.
+	 *
+	 * @param \PHP_CodeSniffer\Files\File $phpcsFile The file where the token was found.
+	 * @param int                         $stackPtr  The position in the stack where
+	 *                                               the token was found.
+	 *
+	 * @return void
+	 */
+	private function getNextTString( File $phpcsFile, $stackPtr ) {
+		return $phpcsFile->findNext(
+			T_STRING,
+			( $stackPtr ),
+			null,
+			false,
+			null,
+			true
+		);
+	}
+
+	/**
 	 * Processes the tokens that this sniff is interested in.
 	 *
 	 * @param \PHP_CodeSniffer\Files\File $phpcsFile The file where the token was found.
@@ -50,27 +70,16 @@ class CreateFunctionSniff implements \PHP_CodeSniffer_Sniff {
 		$this->_phpcsFile = $phpcsFile;
 		$this->_stackPtr  = $stackPtr;
 
-		$functionName = $phpcsFile->findNext(
-			T_STRING,
-			( $stackPtr ),
-			null,
-			false,
-			null,
-			true
-		);
+		$functionName = $this->getNextTString( $phpcsFile, $stackPtr );
 
 		while ( false !== $functionName ) {
 			if ( 'create_function' !==
 				$this->_tokens[ $this->_stackPtr ]['content']
 			) {
 				// Not a function call, repeat.
-				$functionName = $phpcsFile->findNext(
-					T_STRING,
-					( $functionName + 1 ),
-					null,
-					false,
-					null,
-					true
+				$functionName = $this->getNextTString(
+					$phpcsFile,
+					$functionName + 1
 				);
 
 				continue;
@@ -89,13 +98,9 @@ class CreateFunctionSniff implements \PHP_CodeSniffer_Sniff {
 				( T_OPEN_PARENTHESIS !== $this->_tokens[ $bracket ]['code'] )
 			) {
 				// Not a function call, repeat.
-				$functionName = $phpcsFile->findNext(
-					T_STRING,
-					( $functionName + 1 ),
-					null,
-					false,
-					null,
-					true
+				$functionName = $this->getNextTString(
+					$phpcsFile,
+					$functionName + 1
 				);
 
 				continue;

--- a/WordPressVIPMinimum/Sniffs/Functions/CreateFunctionSniff.php
+++ b/WordPressVIPMinimum/Sniffs/Functions/CreateFunctionSniff.php
@@ -32,28 +32,8 @@ class CreateFunctionSniff implements \PHP_CodeSniffer_Sniff {
 	 * @return array(int)
 	 */
 	public function register() {
-		return Tokens::$functionNameTokens;
+		return [ T_STRING ];
 
-	}
-
-	/**
-	 * Get next T_STRING token.
-	 *
-	 * @param \PHP_CodeSniffer\Files\File $phpcsFile The file where the token was found.
-	 * @param int                         $stackPtr  The position in the stack where
-	 *                                               the token was found.
-	 *
-	 * @return int
-	 */
-	private function getNextTString( File $phpcsFile, $stackPtr ) {
-		return $phpcsFile->findNext(
-			T_STRING,
-			( $stackPtr ),
-			null,
-			false,
-			null,
-			true
-		);
 	}
 
 	/**
@@ -66,54 +46,45 @@ class CreateFunctionSniff implements \PHP_CodeSniffer_Sniff {
 	 * @return void
 	 */
 	public function process( File $phpcsFile, $stackPtr ) {
-		$this->_tokens    = $phpcsFile->getTokens();
-		$this->_phpcsFile = $phpcsFile;
-		$this->_stackPtr  = $stackPtr;
+		$tokens    = $phpcsFile->getTokens();
+		$phpcsFile = $phpcsFile;
+		$stackPtr  = $stackPtr;
 
-		$functionName = $this->getNextTString( $phpcsFile, $stackPtr );
+		$functionName = $phpcsFile->findNext(
+			T_STRING,
+			( $stackPtr ),
+			null,
+			false,
+			null,
+			true
+		);
 
-		while ( false !== $functionName ) {
-			if ( 'create_function' !==
-				$this->_tokens[ $this->_stackPtr ]['content']
-			) {
-				// Not the function call we want.
-				$functionName = $this->getNextTString(
-					$phpcsFile,
-					$functionName + 1
-				);
-
-				continue;
-			}
-
-			// Check if this is really a function.
-			$bracket = $phpcsFile->findNext(
-				T_WHITESPACE,
-				( $functionName + 1 ),
-				null,
-				true
-			);
-
-			if (
-				( false === $bracket ) ||
-				( T_OPEN_PARENTHESIS !== $this->_tokens[ $bracket ]['code'] )
-			) {
-				// Not a function call.
-				$functionName = $this->getNextTString(
-					$phpcsFile,
-					$functionName + 1
-				);
-
-				continue;
-			}
-
-			$this->_phpcsFile->addError(
-				'create_function() is deprecated as of ' .
-					'PHP 7.2.0',
-				$functionName,
-				'CreateFunction'
-			);
-
-			break;
+		if ( 'create_function' !==
+			$tokens[ $stackPtr ]['content']
+		) {
+			return;
 		}
+
+		// Check if this is really a function.
+		$bracket = $phpcsFile->findNext(
+			T_WHITESPACE,
+			( $functionName + 1 ),
+			null,
+			true
+		);
+
+		if (
+			( false === $bracket ) ||
+			( T_OPEN_PARENTHESIS !== $tokens[ $bracket ]['code'] )
+		) {
+			return;
+		}
+
+		$phpcsFile->addError(
+			'create_function() is deprecated as of ' .
+				'PHP 7.2.0',
+			$functionName,
+			'CreateFunction'
+		);
 	}
 }

--- a/WordPressVIPMinimum/Sniffs/Functions/CreateFunctionSniff.php
+++ b/WordPressVIPMinimum/Sniffs/Functions/CreateFunctionSniff.php
@@ -43,7 +43,7 @@ class CreateFunctionSniff implements \PHP_CodeSniffer_Sniff {
 	 * @param int                         $stackPtr  The position in the stack where
 	 *                                               the token was found.
 	 *
-	 * @return void
+	 * @return int
 	 */
 	private function getNextTString( File $phpcsFile, $stackPtr ) {
 		return $phpcsFile->findNext(

--- a/WordPressVIPMinimum/Sniffs/Functions/CreateFunctionSniff.php
+++ b/WordPressVIPMinimum/Sniffs/Functions/CreateFunctionSniff.php
@@ -34,50 +34,85 @@ class CreateFunctionSniff implements \PHP_CodeSniffer_Sniff {
 	public function register() {
 		return Tokens::$functionNameTokens;
 
-	}//end register()
+	}
 
 	/**
 	 * Processes the tokens that this sniff is interested in.
 	 *
 	 * @param \PHP_CodeSniffer\Files\File $phpcsFile The file where the token was found.
-	 * @param int                         $stackPtr  The position in the stack where
-	 *                                               the token was found.
+	 * @param int $stackPtr The position in the stack where
+	 *                      the token was found.
 	 *
 	 * @return void
 	 */
 	public function process( File $phpcsFile, $stackPtr ) {
-		$this->_tokens    = $phpcsFile->getTokens();
+		$this->_tokens	= $phpcsFile->getTokens();
 		$this->_phpcsFile = $phpcsFile;
 		$this->_stackPtr  = $stackPtr;
 
-		if (
-			( 'T_STRING' !==
-				$this->_tokens[ $this->_stackPtr ]['type'] )
-			||
-			( 'create_function' !==
-				$this->_tokens[ $this->_stackPtr ]['content'] )
-		) {
-			return;
-		}
-
-		$t_item_key = $this->_phpcsFile->findNext(
-			array( T_OPEN_PARENTHESIS ),
-			$this->_stackPtr + 1,
+		$functionName = $phpcsFile->findNext(
+			T_STRING,
+			( $stackPtr ),
 			null,
 			false,
 			null,
 			true
 		);
 
-		if ( false === $t_item_key ) {
-			return;
-		}
+		while ( false !== $functionName ) {
+			if (
+				( 'T_STRING' !==
+					$this->_tokens[ $this->_stackPtr ]['type'] )
+				||
+				( 'create_function' !==
+					$this->_tokens[ $this->_stackPtr ]['content'] )
+			) {
+				// Not a function call, repeat.
+				$functionName = $phpcsFile->findNext(
+					T_STRING,
+					( $functionName + 1 ),
+					null,
+					false,
+					null,
+					true
+				);
 
-		$this->_phpcsFile->addError(
-			'create_function() is deprecated as of ' .
-				'PHP 7.2.0',
-			$t_item_key,
-			'CreateFunction'
-		);
-	}//end process()
+				continue;
+			}
+
+			// Check if this is really a function.
+			$bracket = $phpcsFile->findNext(
+				T_WHITESPACE,
+				( $functionName + 1 ),
+				null,
+				true
+			);
+
+			if (
+				( false === $bracket ) ||
+				( $this->_tokens[ $bracket ]['code'] !== T_OPEN_PARENTHESIS )
+			) {
+				// Not a function call, repeat.
+				$functionName = $phpcsFile->findNext(
+					T_STRING,
+					( $functionName + 1 ),
+					null,
+					false,
+					null,
+					true
+				);
+
+				continue;
+			}
+
+			$this->_phpcsFile->addError(
+				'create_function() is deprecated as of ' .
+					'PHP 7.2.0',
+				$functionName,
+				'CreateFunction'
+			);
+
+			break;
+		}
+	}
 }

--- a/WordPressVIPMinimum/Sniffs/Functions/CreateFunctionSniff.php
+++ b/WordPressVIPMinimum/Sniffs/Functions/CreateFunctionSniff.php
@@ -60,7 +60,6 @@ class CreateFunctionSniff implements \PHP_CodeSniffer_Sniff {
 			return;
 		}
 
-
 		$t_item_key = $this->_phpcsFile->findNext(
 			array( T_OPEN_PARENTHESIS ),
 			$this->_stackPtr + 1,

--- a/WordPressVIPMinimum/Sniffs/Functions/CreateFunctionSniff.php
+++ b/WordPressVIPMinimum/Sniffs/Functions/CreateFunctionSniff.php
@@ -40,13 +40,13 @@ class CreateFunctionSniff implements \PHP_CodeSniffer_Sniff {
 	 * Processes the tokens that this sniff is interested in.
 	 *
 	 * @param \PHP_CodeSniffer\Files\File $phpcsFile The file where the token was found.
-	 * @param int $stackPtr The position in the stack where
-	 *                      the token was found.
+	 * @param int $stackPtr                          The position in the stack where
+	 *                                               the token was found.
 	 *
 	 * @return void
 	 */
 	public function process( File $phpcsFile, $stackPtr ) {
-		$this->_tokens	= $phpcsFile->getTokens();
+		$this->_tokens	  = $phpcsFile->getTokens();
 		$this->_phpcsFile = $phpcsFile;
 		$this->_stackPtr  = $stackPtr;
 
@@ -90,7 +90,7 @@ class CreateFunctionSniff implements \PHP_CodeSniffer_Sniff {
 
 			if (
 				( false === $bracket ) ||
-				( $this->_tokens[ $bracket ]['code'] !== T_OPEN_PARENTHESIS )
+				( T_OPEN_PARENTHESIS !== $this->_tokens[ $bracket ]['code'] )
 			) {
 				// Not a function call, repeat.
 				$functionName = $phpcsFile->findNext(

--- a/WordPressVIPMinimum/Sniffs/Functions/CreateFunctionSniff.php
+++ b/WordPressVIPMinimum/Sniffs/Functions/CreateFunctionSniff.php
@@ -40,13 +40,13 @@ class CreateFunctionSniff implements \PHP_CodeSniffer_Sniff {
 	 * Processes the tokens that this sniff is interested in.
 	 *
 	 * @param \PHP_CodeSniffer\Files\File $phpcsFile The file where the token was found.
-	 * @param int $stackPtr                          The position in the stack where
+	 * @param int                         $stackPtr  The position in the stack where
 	 *                                               the token was found.
 	 *
 	 * @return void
 	 */
 	public function process( File $phpcsFile, $stackPtr ) {
-		$this->_tokens	  = $phpcsFile->getTokens();
+		$this->_tokens    = $phpcsFile->getTokens();
 		$this->_phpcsFile = $phpcsFile;
 		$this->_stackPtr  = $stackPtr;
 

--- a/WordPressVIPMinimum/Sniffs/Functions/CreateFunctionSniff.php
+++ b/WordPressVIPMinimum/Sniffs/Functions/CreateFunctionSniff.php
@@ -1,0 +1,84 @@
+<?php
+/**
+ * WordPressVIPMinimum Coding Standard.
+ *
+ * @package VIPCS\WordPressVIPMinimum
+ */
+
+namespace WordPressVIPMinimum\Sniffs\Functions;
+
+use PHP_CodeSniffer_File as File;
+use PHP_CodeSniffer_Tokens as Tokens;
+
+/**
+ * This function generates an error when
+ * create_function() is found in code.
+ * create_function() is deprecated in PHP 7.2.0.
+ *
+ * An example:
+ *
+ * <code>
+ *   create_function( 'foo', 'return "bar";' );
+ * </code>
+ *
+ * See here: http://php.net/manual/en/function.create-function.php
+ */
+class CreateFunctionSniff implements \PHP_CodeSniffer_Sniff {
+	/**
+	 * Returns the token types that this sniff is interested in.
+	 *
+	 * We want everything function-related.
+	 *
+	 * @return array(int)
+	 */
+	public function register() {
+		return Tokens::$functionNameTokens;
+
+	}//end register()
+
+	/**
+	 * Processes the tokens that this sniff is interested in.
+	 *
+	 * @param \PHP_CodeSniffer\Files\File $phpcsFile The file where the token was found.
+	 * @param int                         $stackPtr  The position in the stack where
+	 *                                               the token was found.
+	 *
+	 * @return void
+	 */
+	public function process( File $phpcsFile, $stackPtr ) {
+		$this->_tokens    = $phpcsFile->getTokens();
+		$this->_phpcsFile = $phpcsFile;
+		$this->_stackPtr  = $stackPtr;
+
+		if (
+			( 'T_STRING' !==
+				$this->_tokens[ $this->_stackPtr ]['type'] )
+			||
+			( 'create_function' !==
+				$this->_tokens[ $this->_stackPtr ]['content'] )
+		) {
+			return;
+		}
+
+
+		$t_item_key = $this->_phpcsFile->findNext(
+			array( T_OPEN_PARENTHESIS ),
+			$this->_stackPtr + 1,
+			null,
+			false,
+			null,
+			true
+		);
+
+		if ( false === $t_item_key ) {
+			return;
+		}
+
+		$this->_phpcsFile->addError(
+			'create_function() is deprecated as of ' .
+				'PHP 7.2.0',
+			$t_item_key,
+			'CreateFunction'
+		);
+	}//end process()
+}

--- a/WordPressVIPMinimum/Sniffs/Functions/CreateFunctionSniff.php
+++ b/WordPressVIPMinimum/Sniffs/Functions/CreateFunctionSniff.php
@@ -60,12 +60,8 @@ class CreateFunctionSniff implements \PHP_CodeSniffer_Sniff {
 		);
 
 		while ( false !== $functionName ) {
-			if (
-				( 'T_STRING' !==
-					$this->_tokens[ $this->_stackPtr ]['type'] )
-				||
-				( 'create_function' !==
-					$this->_tokens[ $this->_stackPtr ]['content'] )
+			if ( 'create_function' !==
+				$this->_tokens[ $this->_stackPtr ]['content']
 			) {
 				// Not a function call, repeat.
 				$functionName = $phpcsFile->findNext(

--- a/WordPressVIPMinimum/Tests/Functions/CreateFunctionSniff.inc
+++ b/WordPressVIPMinimum/Tests/Functions/CreateFunctionSniff.inc
@@ -22,3 +22,10 @@ $c = new Foo();
 $c->create_function = 'bar' . ( 1 === 1 ?? 'foo' );
 
 $m = bla_function( '$a, $b', 'return ( $b / $a ); ');
+
+$wp_random_testing = 
+   create_function2( '$a, $b', 'return ( $b / $a ); ');
+
+$wp_random_testing = 
+   create_function3( '$a, $b', 'return ( $b / $a ); ');
+

--- a/WordPressVIPMinimum/Tests/Functions/CreateFunctionSniff.inc
+++ b/WordPressVIPMinimum/Tests/Functions/CreateFunctionSniff.inc
@@ -3,6 +3,22 @@
 $a = time();
 $b = time() * 2;
 
+/*
+ * Test for true positive
+ */
 $wp_random_testing = create_function( '$a, $b', 'return ( $b / $a ); ');
 
+
+/*
+ * Test for false positives
+ */
+
 echo esc_html( $wp_random_testing( $a, $b ) );
+
+class Foo {
+    public create_function = 'foo';
+}
+$c = new Foo();
+$c->create_function = 'bar' . ( 1 === 1 ?? 'foo' );
+
+$m = bla_function( '$a, $b', 'return ( $b / $a ); ');

--- a/WordPressVIPMinimum/Tests/Functions/CreateFunctionSniff.inc
+++ b/WordPressVIPMinimum/Tests/Functions/CreateFunctionSniff.inc
@@ -1,0 +1,16 @@
+<?php
+
+$a = time();
+$b = time() * 2;
+
+$wp_random_testing = create_function( '$a, $b', 'return ( $b / $a ); ');
+
+echo esc_html( $wp_random_testing( $a, $b ) );
+
+
+
+
+
+
+
+

--- a/WordPressVIPMinimum/Tests/Functions/CreateFunctionSniff.inc
+++ b/WordPressVIPMinimum/Tests/Functions/CreateFunctionSniff.inc
@@ -6,11 +6,3 @@ $b = time() * 2;
 $wp_random_testing = create_function( '$a, $b', 'return ( $b / $a ); ');
 
 echo esc_html( $wp_random_testing( $a, $b ) );
-
-
-
-
-
-
-
-

--- a/WordPressVIPMinimum/Tests/Functions/CreateFunctionSniff.php
+++ b/WordPressVIPMinimum/Tests/Functions/CreateFunctionSniff.php
@@ -23,7 +23,7 @@ class CreateFunctionUnitTest extends AbstractSniffUnitTest {
 	 */
 	public function getErrorList() {
 		return array(
-			6 => 1,
+			9 => 1,
 		);
 	}
 

--- a/WordPressVIPMinimum/Tests/Functions/CreateFunctionSniff.php
+++ b/WordPressVIPMinimum/Tests/Functions/CreateFunctionSniff.php
@@ -23,7 +23,7 @@ class CreateFunctionUnitTest extends AbstractSniffUnitTest {
 	 */
 	public function getErrorList() {
 		return array(
-			6  => 1,
+			6 => 1,
 		);
 	}
 

--- a/WordPressVIPMinimum/Tests/Functions/CreateFunctionSniff.php
+++ b/WordPressVIPMinimum/Tests/Functions/CreateFunctionSniff.php
@@ -1,0 +1,40 @@
+<?php
+/**
+ * Unit test class for WordPressVIPMinimum Coding Standard.
+ *
+ * @package VIPCS\WordPressVIPMinimum
+ */
+
+namespace WordPressVIPMinimum\Tests\Functions;
+
+use PHP_CodeSniffer\Tests\Standards\AbstractSniffUnitTest;
+
+/**
+ * Unit test class for the CheckReturnValue sniff.
+ *
+ * @package VIPCS\WordPressVIPMinimum
+ */
+class CreateFunctionUnitTest extends AbstractSniffUnitTest {
+
+	/**
+	 * Returns the lines where errors should occur.
+	 *
+	 * @return array <int line number> => <int number of errors>
+	 */
+	public function getErrorList() {
+		return array(
+			6  => 1,
+		);
+	}
+
+	/**
+	 * Returns the lines where warnings should occur.
+	 *
+	 * @return array <int line number> => <int number of warnings>
+	 */
+	public function getWarningList() {
+		return array();
+
+	}
+
+} // End class.


### PR DESCRIPTION
create_function() is deprecated as of PHP 7.2.0 (see: http://php.net/manual/en/function.create-function.php). This sniff will generate an error when call to that function is detected.