### PR TITLE
VIP Launch: Changing messages and error types for certain sniffs

### DIFF
--- a/WordPressVIPMinimum/ruleset.xml
+++ b/WordPressVIPMinimum/ruleset.xml
@@ -114,8 +114,61 @@
 		<message>%s() is highly discouraged, please use vip_safe_wp_remote_get() instead.</message>
 	</rule>
 
+	<!-- Lower severity for get_posts functions -->
 	<rule ref="WordPressVIPMinimum.VIP.RestrictedFunctions.get_posts_get_children">
-		<type>error</type>
+		<type>warning</type>
 		<message>%1$s() performs a no-LIMIT query by default, make sure to set a reasonable posts_per_page. %1$s() will do a -1 query by default, a maximum of 100 should be used.</message>
+		<severity>2</severity>
 	</rule>
+	<rule ref="WordPressVIPMinimum.VIP.RestrictedFunctions.get_posts_get_posts">
+		<type>warning</type>
+		<severity>2</severity>
+	</rule>
+	<rule ref="WordPressVIPMinimum.VIP.RestrictedFunctions.get_posts_wp_get_recent_posts">
+		<type>warning</type>
+		<severity>2</severity>
+	</rule>
+
+	<rule ref="WordPressVIPMinimum.VIP.RestrictedFunctions.switch_to_blog_switch_to_blog">
+		<type>warning</type>
+	</rule>
+
+	<rule ref="WordPress.VIP.SuperGlobalInputUsage.AccessDetected">
+		<type>warning</type>
+	</rule>
+
+	<!-- VIP Uncached warnings -->
+	<rule ref="WordPressVIPMinimum.VIP.RestrictedFunctions.get_page_by_path_get_page_by_path">
+		<type>warning</type>
+		<message>%s() is uncached, please use wpcom_vip_get_page_by_path() instead.</message>
+	</rule>
+
+	<rule ref="WordPressVIPMinimum.VIP.RestrictedFunctions.get_page_by_title_get_page_by_title">
+		<type>warning</type>
+		<message>%s() is uncached, please use wpcom_vip_get_page_by_title() instead.</message>
+	</rule>
+
+	<rule ref="WordPressVIPMinimum.VIP.RestrictedFunctions.url_to_postid_url_to_postid">
+		<type>warning</type>
+		<message>%s() is uncached, please use wpcom_vip_url_to_postid() instead.</message>
+	</rule>
+
+	<rule ref="WordPressVIPMinimum.VIP.RestrictedFunctions.file_get_contents_file_get_contents">
+		<type>warning</type>
+		<message>%s() is uncached. If this is being used to query a remote file please use wpcom_vip_file_get_contents() instead.</message>
+	</rule>
+
+	<rule ref="WordPressVIPMinimum.VIP.RestrictedFunctions.attachment_url_to_postid_attachment_url_to_postid">
+		<type>warning</type>
+		<message>%s() is uncached, please use wpcom_vip_attachment_url_to_postid() instead.</message>
+	</rule>
+
+	<rule ref="WordPressVIPMinimum.VIP.RestrictedFunctions.wp_old_slug_redirect_wp_old_slug_redirect">
+		<type>warning</type>
+	</rule>
+
+	<rule ref="WordPressVIPMinimum.VIP.RestrictedFunctions.get_adjacent_post_get_adjacent_post">
+		<type>warning</type>
+	</rule>
+
 </ruleset>


### PR DESCRIPTION
Per our Launch Meetup @ Lisbon (Feb, 2018), we're changing the messages and the error type of several sniffs. 