### PR TITLE
Extract ruleset changes in WordPressVIPMinimum to a new ruleset

### DIFF
--- a/WordPress-VIP-Go/ruleset.xml
+++ b/WordPress-VIP-Go/ruleset.xml
@@ -1,0 +1,86 @@
+<?xml version="1.0"?>
+<ruleset name="WordPress VIP Go">
+	<description>WordPress VIP Go Coding Standards</description>
+
+	<!-- Include the base VIP Minimum ruleset -->
+	<rule ref="WordPressVIPMinimum" />
+
+	<rule ref="WordPress.XSS.EscapeOutput">
+		<severity>3</severity>
+	</rule>
+	<rule ref="WordPress.XSS.EscapeOutput._e">
+		<severity>1</severity>
+	</rule>
+
+	<rule ref="WordPress.Functions.DontExtract">
+		<severity>3</severity>
+	</rule>
+
+	<rule ref="WordPress.VIP.RestrictedFunctions.get_posts">
+		<severity>1</severity>
+	</rule>	
+
+	<rule ref="WordPressVIPMinimum.VIP.RestrictedFunctions.file_get_contents">
+		<severity>3</severity>
+	</rule>
+  
+	<rule ref="WordPressVIPMinimum.Files.IncludingFile">
+		<severity>2</severity>
+	</rule>
+  
+	<rule ref="WordPressVIPMinimum.VIP.RestrictedFunctions.get_posts_get_children">
+		<type>warning</type>
+		<severity>2</severity>
+	</rule>
+	<rule ref="WordPressVIPMinimum.VIP.RestrictedFunctions.get_posts_get_posts">
+		<type>warning</type>
+		<severity>2</severity>
+	</rule>
+	<rule ref="WordPressVIPMinimum.VIP.RestrictedFunctions.get_posts_wp_get_recent_posts">
+		<type>warning</type>
+		<severity>2</severity>
+	</rule>
+
+	<rule ref="WordPressVIPMinimum.VIP.RestrictedFunctions.switch_to_blog_switch_to_blog">
+		<type>warning</type>
+	</rule>
+
+	<rule ref="WordPress.VIP.SuperGlobalInputUsage.AccessDetected">
+		<type>warning</type>
+	</rule>
+
+	<rule ref="WordPressVIPMinimum.VIP.RestrictedFunctions.wp_old_slug_redirect_wp_old_slug_redirect">
+		<type>warning</type>
+	</rule>
+
+	<rule ref="WordPressVIPMinimum.VIP.RestrictedFunctions.get_adjacent_post_get_adjacent_post">
+		<type>warning</type>
+	</rule>
+
+	<!-- VIP Uncached warnings -->
+	<rule ref="WordPressVIPMinimum.VIP.RestrictedFunctions.get_page_by_path_get_page_by_path">
+		<type>warning</type>
+		<message>%s() is uncached, please use wpcom_vip_get_page_by_path() instead.</message>
+	</rule>
+
+	<rule ref="WordPressVIPMinimum.VIP.RestrictedFunctions.get_page_by_title_get_page_by_title">
+		<type>warning</type>
+		<message>%s() is uncached, please use wpcom_vip_get_page_by_title() instead.</message>
+	</rule>
+
+	<rule ref="WordPressVIPMinimum.VIP.RestrictedFunctions.url_to_postid_url_to_postid">
+		<type>warning</type>
+		<message>%s() is uncached, please use wpcom_vip_url_to_postid() instead.</message>
+	</rule>
+
+	<rule ref="WordPressVIPMinimum.VIP.RestrictedFunctions.file_get_contents_file_get_contents">
+		<type>warning</type>
+		<message>%s() is uncached. If this is being used to query a remote file please use wpcom_vip_file_get_contents() instead.</message>
+	</rule>
+
+	<rule ref="WordPressVIPMinimum.VIP.RestrictedFunctions.attachment_url_to_postid_attachment_url_to_postid">
+		<type>warning</type>
+		<message>%s() is uncached, please use wpcom_vip_attachment_url_to_postid() instead.</message>
+	</rule>
+
+</ruleset>

--- a/WordPressVIPMinimum/ruleset.xml
+++ b/WordPressVIPMinimum/ruleset.xml
@@ -13,12 +13,7 @@
 		<exclude name="WordPress.VIP.RestrictedFunctions"/>
 	</rule>
 
-	<rule ref="WordPress.XSS.EscapeOutput">
-		<severity>3</severity>
-	</rule>
-	<rule ref="WordPress.XSS.EscapeOutput._e">
-		<severity>1</severity>
-	</rule>
+	<rule ref="WordPress.XSS.EscapeOutput"/>
 	<rule ref="WordPress.CSRF.NonceVerification"/>
 	<rule ref="WordPress.WP.EnqueuedResources"/>
 	<rule ref="WordPress.WP.PreparedSQL"/>
@@ -26,9 +21,7 @@
 	<rule ref="WordPress.PHP.StrictComparisons"/>
 	<rule ref="WordPress.CodeAnalysis.AssignmentInCondition"/>
 	<rule ref="WordPress.PHP.StrictInArray"/>
-	<rule ref="WordPress.Functions.DontExtract">
-		<severity>3</severity>
-	</rule>
+	<rule ref="WordPress.Functions.DontExtract"/>
 
 	<rule ref="Generic.NamingConventions.ConstructorName"/>
 	<rule ref="Generic.PHP.DisallowShortOpenTag"/>
@@ -121,72 +114,8 @@
 		<message>%s() is highly discouraged, please use vip_safe_wp_remote_get() instead.</message>
 	</rule>
 
-	<rule ref="WordPress.VIP.RestrictedFunctions.get_posts">
-		<severity>1</severity>
-	</rule>	
-
-	<rule ref="WordPressVIPMinimum.VIP.RestrictedFunctions.file_get_contents">
-		<severity>3</severity>
-	</rule>
-  
-  <rule ref="WordPressVIPMinimum.Files.IncludingFile">
-		<severity>2</severity>
-	</rule>
-  
 	<rule ref="WordPressVIPMinimum.VIP.RestrictedFunctions.get_posts_get_children">
-		<type>warning</type>
+		<type>error</type>
 		<message>%1$s() performs a no-LIMIT query by default, make sure to set a reasonable posts_per_page. %1$s() will do a -1 query by default, a maximum of 100 should be used.</message>
-		<severity>2</severity>
 	</rule>
-	<rule ref="WordPressVIPMinimum.VIP.RestrictedFunctions.get_posts_get_posts">
-		<type>warning</type>
-		<severity>2</severity>
-	</rule>
-	<rule ref="WordPressVIPMinimum.VIP.RestrictedFunctions.get_posts_wp_get_recent_posts">
-		<type>warning</type>
-		<severity>2</severity>
-	</rule>
-
-	<rule ref="WordPressVIPMinimum.VIP.RestrictedFunctions.switch_to_blog_switch_to_blog">
-		<type>warning</type>
-	</rule>
-
-	<rule ref="WordPress.VIP.SuperGlobalInputUsage.AccessDetected">
-		<type>warning</type>
-	</rule>
-
-	<!-- VIP Uncached warnings -->
-	<rule ref="WordPressVIPMinimum.VIP.RestrictedFunctions.get_page_by_path_get_page_by_path">
-		<type>warning</type>
-		<message>%s() is uncached, please use wpcom_vip_get_page_by_path() instead.</message>
-	</rule>
-
-	<rule ref="WordPressVIPMinimum.VIP.RestrictedFunctions.get_page_by_title_get_page_by_title">
-		<type>warning</type>
-		<message>%s() is uncached, please use wpcom_vip_get_page_by_title() instead.</message>
-	</rule>
-
-	<rule ref="WordPressVIPMinimum.VIP.RestrictedFunctions.url_to_postid_url_to_postid">
-		<type>warning</type>
-		<message>%s() is uncached, please use wpcom_vip_url_to_postid() instead.</message>
-	</rule>
-
-	<rule ref="WordPressVIPMinimum.VIP.RestrictedFunctions.file_get_contents_file_get_contents">
-		<type>warning</type>
-		<message>%s() is uncached. If this is being used to query a remote file please use wpcom_vip_file_get_contents() instead.</message>
-	</rule>
-
-	<rule ref="WordPressVIPMinimum.VIP.RestrictedFunctions.attachment_url_to_postid_attachment_url_to_postid">
-		<type>warning</type>
-		<message>%s() is uncached, please use wpcom_vip_attachment_url_to_postid() instead.</message>
-	</rule>
-
-	<rule ref="WordPressVIPMinimum.VIP.RestrictedFunctions.wp_old_slug_redirect_wp_old_slug_redirect">
-		<type>warning</type>
-	</rule>
-
-	<rule ref="WordPressVIPMinimum.VIP.RestrictedFunctions.get_adjacent_post_get_adjacent_post">
-		<type>warning</type>
-	</rule>
-
 </ruleset>


### PR DESCRIPTION
To preserve the original VIP Minimum ruleset, we're extracting the changes in the original file to a new ruleset, named `WordPress-VIP-Go`.