### PR TITLE
Fix 171/file get contents mods

### DIFF
--- a/WordPressVIPMinimum/Sniffs/Files/IncludingNonPHPFileSniff.php
+++ b/WordPressVIPMinimum/Sniffs/Files/IncludingNonPHPFileSniff.php
@@ -1,0 +1,76 @@
+<?php
+/**
+ * WordPressVIPMinimum_Sniffs_Files_IncludingNonPHPFileSniff.
+ *
+ * @package VIPCS\WordPressVIPMinimum
+ */
+
+namespace WordPressVIPMinimum\Sniffs\Files;
+
+use PHP_CodeSniffer_File as File;
+use PHP_CodeSniffer_Tokens as Tokens;
+
+/**
+ * WordPressVIPMinimum_Sniffs_Files_IncludingNonPHPFileSniff.
+ *
+ * Checks that __DIR__, dirname( __FILE__ ) or plugin_dir_path( __FILE__ )
+ * is used when including or requiring files.
+ *
+ * @package VIPCS\WordPressVIPMinimum
+ */
+class IncludingNonPHPFileSniff implements \PHP_CodeSniffer_Sniff {
+
+	/**
+	 * Returns an array of tokens this test wants to listen for.
+	 *
+	 * @return array
+	 */
+	public function register() {
+		return Tokens::$includeTokens;
+
+	}//end register()
+
+
+	/**
+	 * Processes this test, when one of its tokens is encountered.
+	 *
+	 * @param \PHP_CodeSniffer\Files\File $phpcsFile The file being scanned.
+	 * @param int                         $stackPtr  The position of the current token in the
+	 *                                               stack passed in $tokens.
+	 *
+	 * @return void
+	 */
+	public function process( File $phpcsFile, $stackPtr ) {
+		$tokens = $phpcsFile->getTokens();
+
+		$curStackPtr = $stackPtr;
+		while ( $curStackPtr = $phpcsFile->findNext( Tokens::$stringTokens, ( $curStackPtr + 1 ), null, false, null, true ) ) {
+
+			if ( T_CONSTANT_ENCAPSED_STRING === $tokens[ $curStackPtr ]['code'] ) {
+				$stringWithoutEnclosingQuotationMarks = trim( $tokens[ $curStackPtr ]['content'], "\"'" );
+			} else {
+				$stringWithoutEnclosingQuotationMarks = $tokens[ $curStackPtr ]['content'];
+			}
+
+			$isFileName = preg_match( '/.*(\.[a-z]{2,})$/i', $stringWithoutEnclosingQuotationMarks, $regexMatches );
+
+			if ( false === $isFileName || 0 === $isFileName ) {
+				continue;
+			}
+
+			$extension = $regexMatches[1];
+			if ( true === in_array( $extension, array( '.php', '.inc' ) ) ) {
+				return;
+			}
+
+			if ( true === in_array( $extension, array( '.svg', '.css' ) ) ) {
+				$phpcsFile->addError( sprintf( 'Local SVG and CSS files should be loaded via `get_file_contents` rather than via `%s`.', $tokens[ $stackPtr ]['content'] ), $curStackPtr, 'IncludingSVGCSSFile' );
+			} else {
+				$phpcsFile->addWarning( sprintf( 'Local non-PHP file should be loaded via `get_file_contents` rather than via `%s`', $tokens[ $stackPtr ]['content'] ), $curStackPtr, 'IncludingNonPHPFile' );
+			}
+		}
+
+	}//end process()
+
+
+}//end class

--- a/WordPressVIPMinimum/Sniffs/VIP/FetchingRemoteDataSniff.php
+++ b/WordPressVIPMinimum/Sniffs/VIP/FetchingRemoteDataSniff.php
@@ -1,0 +1,60 @@
+<?php
+/**
+ * WordPress-VIP-Minimum Coding Standard.
+ *
+ * @package VIPCS\WordPressVIPMinimum
+ * @link https://github.com/Automattic/VIP-Coding-Standards
+ */
+
+namespace WordPressVIPMinimum\Sniffs\VIP;
+
+use PHP_CodeSniffer_File as File;
+use PHP_CodeSniffer_Tokens as Tokens;
+
+/**
+ * Restricts usage of rewrite rules flushing
+ *
+ *  @package VIPCS\WordPressVIPMinimum
+ */
+class FetchingRemoteDataSniff implements \PHP_CodeSniffer_Sniff {
+
+	/**
+	 * Returns an array of tokens this test wants to listen for.
+	 *
+	 * @return array
+	 */
+	public function register() {
+		return Tokens::$functionNameTokens;
+	}
+
+	/**
+	 * Process this test when one of its tokens is encountered.
+	 *
+	 * @param \PHP_CodeSniffer\Files\File $phpcsFile  The file being scanned.
+	 * @param int                         $stackPtr   The position of the current token in the stack passed in $tokens.
+	 *
+	 * @return void
+	 */
+	public function process( File $phpcsFile, $stackPtr ) {
+
+		$tokens = $phpcsFile->getTokens();
+
+		$functionName = $tokens[ $stackPtr ]['content'];
+		if ( 'file_get_contents' !== $functionName ) {
+			return;
+		}
+
+		$fileNameStackPtr = $phpcsFile->findNext( Tokens::$stringTokens, ( $stackPtr + 1 ), null, false, null, true );
+		if ( false === $fileNameStackPtr ) {
+			$phpcsFile->addWarning( sprintf( '`%s()` is highly discouraged for remote requests, please use `wpcom_vip_file_get_contents()` or `vip_safe_wp_remote_get()` instead.', $tokens[ $stackPtr ]['content']), $stackPtr, 'fileGetContentsUknown' );
+		}
+
+		$fileName = $tokens[ $fileNameStackPtr ]['content'];
+
+		$isRemoteFile = ( false !== strpos( $fileName, '://' ) );
+		if ( true === $isRemoteFile ) {
+			$phpcsFile->addWarning( sprintf( '`%s()` is highly discouraged for remote requests, please use `wpcom_vip_file_get_contents()` or `vip_safe_wp_remote_get()` instead.', $tokens[ $stackPtr ]['content']), $stackPtr, 'fileGetContentsRemoteFile' );
+		}
+	}
+
+}

--- a/WordPressVIPMinimum/Sniffs/VIP/RestrictedFunctionsSniff.php
+++ b/WordPressVIPMinimum/Sniffs/VIP/RestrictedFunctionsSniff.php
@@ -102,6 +102,8 @@ class RestrictedFunctionsSniff extends \WordPress\Sniffs\VIP\RestrictedFunctions
 			unset( $original_groups[ $restricted ] );
 		}
 
+		unset( $original_groups['file_get_contents'] );
+
 		return array_merge( $original_groups, $new_groups );
 
 	} // end getGroups().

--- a/WordPressVIPMinimum/Tests/Files/IncludingNonPHPFileUnitTest.inc
+++ b/WordPressVIPMinimum/Tests/Files/IncludingNonPHPFileUnitTest.inc
@@ -1,0 +1,53 @@
+<?php
+
+require_once __DIR__ . "/my_file.php"; // OK.
+
+require_once "my_file.php"; // OK.
+
+include( __DIR__ . "/my_file.php" ); // OK.
+
+include ( MY_CONSTANT . "my_file.php" ); // OK.
+
+require_once ( MY_CONSTANT . "my_file.php" ); // OK.
+
+include( locate_template('index-loop.php') ); // OK.
+
+require_once __DIR__ . "/my_file.svg"; // NOK.
+
+require_once "my_file.svg"; // NOK.
+
+include( __DIR__ . "/my_file.svg" ); // NOK.
+
+include ( MY_CONSTANT . "my_file.svg" ); // NOK.
+
+require_once ( MY_CONSTANT . "my_file.svg" ); // NOK.
+
+include( locate_template('index-loop.svg') ); // NOK.
+
+require_once __DIR__ . "/my_file.css"; // NOK.
+
+require_once "my_file.css"; // NOK.
+
+include( __DIR__ . "/my_file.css" ); // NOK.
+
+include ( MY_CONSTANT . "my_file.css" ); // NOK.
+
+require_once ( MY_CONSTANT . "my_file.css" ); // NOK.
+
+include( locate_template('index-loop.css') ); // NOK.
+
+require_once __DIR__ . "/my_file.csv"; // NOK.
+
+require_once "my_file.inc"; // OK.
+
+include( __DIR__ . "/my_file.csv" ); // NOK.
+
+include ( MY_CONSTANT . "my_file.csv" ); // NOK.
+
+require_once ( MY_CONSTANT . "my_file.csv" ); // NOK.
+
+include( locate_template('index-loop.csv') ); // NOK.
+
+echo file_get_contents( 'index-loop.svg' ); // XSS OK.
+
+echo file_get_contents( 'index-loop.css' ); // XSS OK.

--- a/WordPressVIPMinimum/Tests/Files/IncludingNonPHPFileUnitTest.php
+++ b/WordPressVIPMinimum/Tests/Files/IncludingNonPHPFileUnitTest.php
@@ -1,0 +1,53 @@
+<?php
+/**
+ * Unit test class for WordPressVIPMinimum Coding Standard.
+ *
+ * @package VIPCS\WordPressVIPMinimum
+ */
+
+namespace WordPressVIPMinimum\Tests\Files;
+
+use PHP_CodeSniffer\Tests\Standards\AbstractSniffUnitTest;
+/**
+ * Unit test class for the IncludingFile sniff.
+ *
+ * @package VIPCS\WordPressVIPMinimum
+ */
+class IncludingNonPHPFileUnitTest extends AbstractSniffUnitTest {
+
+	/**
+	 * Returns the lines where errors should occur.
+	 *
+	 * @return array <int line number> => <int number of errors>
+	 */
+	public function getErrorList() {
+		return array(
+			15 => 1,
+			17 => 1,
+			19 => 1,
+			21 => 1,
+			23 => 1,
+			25 => 1,
+			27 => 1,
+			31 => 1,
+			33 => 1,
+			35 => 1,
+			37 => 1,
+			39 => 1,
+			43 => 1,
+			45 => 1,
+			47 => 1,
+			49 => 1,
+		);
+	}
+
+	/**
+	 * Returns the lines where warnings should occur.
+	 *
+	 * @return array <int line number> => <int number of warnings>
+	 */
+	public function getWarningList() {
+		return array();
+	}
+
+} // End class.

--- a/WordPressVIPMinimum/Tests/VIP/FetchingRemoteDataUnitTest.inc
+++ b/WordPressVIPMinimum/Tests/VIP/FetchingRemoteDataUnitTest.inc
@@ -1,0 +1,7 @@
+<?php
+
+$file_content = file_get_contents( 'my-file.css' ); // OK.
+
+$file_content = file_get_contents( 'my-file.svg' ); // OK.
+
+$external_resource = file_get_contents( 'https://example.com' ); // NOK.

--- a/WordPressVIPMinimum/Tests/VIP/FetchingRemoteDataUnitTest.php
+++ b/WordPressVIPMinimum/Tests/VIP/FetchingRemoteDataUnitTest.php
@@ -1,0 +1,42 @@
+<?php
+/**
+ * Unit test class for WordPressVIPMinimum Coding Standard.
+ *
+ * @package VIPCS\WordPressVIPMinimum
+ */
+
+namespace WordPressVIPMinimum\Tests\VIP;
+
+use PHP_CodeSniffer\Tests\Standards\AbstractSniffUnitTest;
+
+/**
+ * Unit test class for the ExitAfterRedirect sniff.
+ *
+ * @package VIPCS\WordPressVIPMinimum
+ */
+class FetchingRemoteDataUnitTest extends AbstractSniffUnitTest {
+
+	/**
+	 * Returns the lines where errors should occur.
+	 *
+	 * @return array <int line number> => <int number of errors>
+	 */
+	public function getErrorList() {
+		return array();
+	}
+
+	/**
+	 * Returns the lines where warnings should occur.
+	 *
+	 * @return array <int line number> => <int number of warnings>
+	 */
+	public function getWarningList() {
+		return array(
+			3 => 1,
+			5 => 1,
+			7 => 2,
+		);
+
+	}
+
+} // End class.

--- a/WordPressVIPMinimum/ruleset.xml
+++ b/WordPressVIPMinimum/ruleset.xml
@@ -105,7 +105,9 @@
 	<!-- https://vip.wordpress.com/documentation/vip/code-review-what-we-look-for/#use-wp_json_encode-over-json_encode -->
 	<!-- https://vip.wordpress.com/documentation/vip/code-review-what-we-look-for/#filesystem-writes -->
 	<!-- https://vip.wordpress.com/documentation/vip/code-review-what-we-look-for/#remote-calls -->
-	<rule ref="WordPress.WP.AlternativeFunctions"/>
+	<rule ref="WordPress.WP.AlternativeFunctions">
+		<exclude name="WordPress.WP.AlternativeFunctions.file_get_contents_file_get_contents"/>
+	</rule>
 	<!-- VIP recommends other functions -->
 	<rule ref="WordPress.WP.AlternativeFunctions.curl">
 		<message>Using cURL functions is highly discouraged within VIP context. Check (Fetching Remote Data) on VIP Documentation.</message>


### PR DESCRIPTION
Adjusting the ruleset the way we can encourage developers to use `file_get_contents` for including local CSS and SVG files, and preventing them from using `include` and `require` for fetching non-php files.

The issue with including of non-php files is that those are being parsed for PHP content, which may lead to fatal errors in certain cases, but more importantly, may introduce PHP code which is not being properly reviewed - eg.: .css, .svg, or .txt files.

This PR contains 2 new sniffs for catching:

1) include/require with non-php files
2) file_get_contents used for non-local file

Further, this includes unit tests for those sniffs, and it removes the upstream reporting on file_get_contents.

fixes #171 