### PR TITLE
s/cautioun/caution

### DIFF
--- a/WordPressVIPMinimum/Sniffs/VIP/WPQueryParamsSniff.php
+++ b/WordPressVIPMinimum/Sniffs/VIP/WPQueryParamsSniff.php
@@ -51,7 +51,7 @@ class WPQueryParamsSniff implements \PHP_CodeSniffer_Sniff {
 		}
 
 		if ( 'post__not_in' === trim( $tokens[ $stackPtr ]['content'], '\'' ) ) {
-			$phpcsFile->addWarning( 'Using `post__not_in` should be used with cautioun.', $stackPtr, 'post__not_in' );
+			$phpcsFile->addWarning( 'Using `post__not_in` should be done with caution.', $stackPtr, 'post__not_in' );
 		}
 	}
 


### PR DESCRIPTION
_really_ fix that typo. Also, slight wording adjustment to prevent awkward redundancy.