### PR TITLE
Addnig sniff for flagging loading of Zoninator of version >= 0.8

### DIFF
--- a/WordPressVIPMinimum/Sniffs/Plugins/ZoninatorSniff.php
+++ b/WordPressVIPMinimum/Sniffs/Plugins/ZoninatorSniff.php
@@ -86,7 +86,7 @@ class ZoninatorSniff implements \PHP_CodeSniffer_Sniff {
 	/**
 	 * Removes the quotation marks around T_CONSTANT_ENCAPSED_STRING.
 	 *
-	 * @param $string T_CONSTANT_ENCAPSED_STRING containing wrapping quotation marks.
+	 * @param string $string T_CONSTANT_ENCAPSED_STRING containing wrapping quotation marks.
 	 *
 	 * @return string String w/o wrapping quotation marks.
 	 */

--- a/WordPressVIPMinimum/Sniffs/Plugins/ZoninatorSniff.php
+++ b/WordPressVIPMinimum/Sniffs/Plugins/ZoninatorSniff.php
@@ -49,7 +49,7 @@ class ZoninatorSniff implements \PHP_CodeSniffer_Sniff {
 
 		if ( T_OPEN_PARENTHESIS !== $tokens[ $openBracket ]['code'] ) {
 			// Not a function call.
-			return ;
+			return;
 		}
 
 		$plugin_name = $phpcsFile->findNext( Tokens::$emptyTokens, ( $openBracket + 1 ), null, true );
@@ -83,6 +83,13 @@ class ZoninatorSniff implements \PHP_CodeSniffer_Sniff {
 
 	}//end process()
 
+	/**
+	 * Removes the quotation marks around T_CONSTANT_ENCAPSED_STRING.
+	 *
+	 * @param $string T_CONSTANT_ENCAPSED_STRING containing wrapping quotation marks.
+	 *
+	 * @return string String w/o wrapping quotation marks.
+	 */
 	public function remove_wrapping_quotation_marks( $string ) {
 		return trim( str_replace( '"', "'", $string ), "'" );
 	}

--- a/WordPressVIPMinimum/Sniffs/Plugins/ZoninatorSniff.php
+++ b/WordPressVIPMinimum/Sniffs/Plugins/ZoninatorSniff.php
@@ -1,0 +1,92 @@
+<?php
+/**
+ * WordPressVIPMinimum Coding Standard.
+ *
+ * @package VIPCS\WordPressVIPMinimum
+ */
+
+namespace WordPressVIPMinimum\Sniffs\Plugins;
+
+use PHP_CodeSniffer_File as File;
+use PHP_CodeSniffer_Tokens as Tokens;
+
+/**
+ * This sniff reminds the developers to check whether the WordPress Core REST API is enabled
+ * along with loading v0.8 and above.
+ */
+class ZoninatorSniff implements \PHP_CodeSniffer_Sniff {
+
+	/**
+	 * Returns the token types that this sniff is interested in.
+	 *
+	 * @return array(int)
+	 */
+	public function register() {
+		return Tokens::$functionNameTokens;
+
+	}//end register()
+
+
+	/**
+	 * Processes the tokens that this sniff is interested in.
+	 *
+	 * @param \PHP_CodeSniffer\Files\File $phpcsFile The file where the token was found.
+	 * @param int                         $stackPtr  The position in the stack where
+	 *                                               the token was found.
+	 *
+	 * @return void
+	 */
+	public function process( File $phpcsFile, $stackPtr ) {
+
+		$tokens    = $phpcsFile->getTokens();
+		$phpcsFile = $phpcsFile;
+
+		if ( 'wpcom_vip_load_plugin' !== $tokens[ $stackPtr ]['content'] ) {
+			return;
+		}
+
+		$openBracket = $phpcsFile->findNext( Tokens::$emptyTokens, ( $stackPtr + 1 ), null, true );
+
+		if ( T_OPEN_PARENTHESIS !== $tokens[ $openBracket ]['code'] ) {
+			// Not a function call.
+			return ;
+		}
+
+		$plugin_name = $phpcsFile->findNext( Tokens::$emptyTokens, ( $openBracket + 1 ), null, true );
+
+		if ( 'zoninator' !== $this->remove_wrapping_quotation_marks( $tokens[ $plugin_name ]['content'] ) ) {
+			return;
+		}
+
+		$comma = $phpcsFile->findNext( Tokens::$emptyTokens, ( $plugin_name + 1 ), null, true );
+
+		if ( ! $comma || 'PHPCS_T_COMMA' !== $tokens[ $comma ]['code'] ) {
+			// We are loading the default version.
+			return;
+		}
+
+		$folder = $phpcsFile->findNext( Tokens::$emptyTokens, ( $comma + 1 ), null, true );
+
+		$comma = $phpcsFile->findNext( Tokens::$emptyTokens, ( $folder + 1 ), null, true );
+
+		if ( ! $comma || 'PHPCS_T_COMMA' !== $tokens[ $comma ]['code'] ) {
+			// We are loading the default version.
+			return;
+		}
+
+		$version = $phpcsFile->findNext( Tokens::$emptyTokens, ( $comma + 1 ), null, true );
+		$version = $this->remove_wrapping_quotation_marks( $tokens[ $version ]['content'] );
+
+		if ( true === version_compare( $version, '0.8', '>=' ) ) {
+			$phpcsFile->addWarning( 'Zoninator of version >= v0.8 requires WordPress core REST API. Please, make sure the `wpcom_vip_load_wp_rest_api()` is being called on all sites loading this file.', $stackPtr, 'Zoninator' );
+		}
+
+	}//end process()
+
+	public function remove_wrapping_quotation_marks( $string ) {
+		return trim( str_replace( '"', "'", $string ), "'" );
+	}
+
+}//end class
+
+

--- a/WordPressVIPMinimum/Tests/Plugins/ZoninatorUnitTest.inc
+++ b/WordPressVIPMinimum/Tests/Plugins/ZoninatorUnitTest.inc
@@ -1,0 +1,13 @@
+<?php
+
+wpcom_vip_load_plugin( 'zoninator', 'plugins', '0.8' ); // NOK.
+wpcom_vip_load_plugin( "zoninator", 'plugins', '0.8' ); // NOK.
+wpcom_vip_load_plugin( 'zoninator', 'plugins', '0.9' ); // NOK.
+wpcom_vip_load_plugin( 'zoninator', 'plugins', '1.9' ); // NOK.
+
+wpcom_vip_load_plugin( 'zoninator', 'plugins', '0.7' ); // OK.
+wpcom_vip_load_plugin( 'zoninator', 'plugins', '0.6' ); // OK.
+wpcom_vip_load_plugin( 'zoninator', 'plugins', '0.6' ); // OK.
+
+wpcom_vip_load_plugin( 'zoninator', 'plugins' ); // OK.
+wpcom_vip_load_plugin( 'zoninator' ); // OK.

--- a/WordPressVIPMinimum/Tests/Plugins/ZoninatorUnitTest.php
+++ b/WordPressVIPMinimum/Tests/Plugins/ZoninatorUnitTest.php
@@ -32,8 +32,8 @@ class ZoninatorUnitTest extends AbstractSniffUnitTest {
 	 */
 	public function getWarningList() {
 		return array(
-			3  => 1,
-			4  => 1,
+			3 => 1,
+			4 => 1,
 			5 => 1,
 			6 => 1,
 		);

--- a/WordPressVIPMinimum/Tests/Plugins/ZoninatorUnitTest.php
+++ b/WordPressVIPMinimum/Tests/Plugins/ZoninatorUnitTest.php
@@ -1,0 +1,43 @@
+<?php
+/**
+ * Unit test class for WordPressVIPMinimum Coding Standard.
+ *
+ * @package VIPCS\WordPressVIPMinimum
+ */
+
+namespace WordPressVIPMinimum\Tests\Plugins;
+
+use PHP_CodeSniffer\Tests\Standards\AbstractSniffUnitTest;
+
+/**
+ * Unit test class for the CheckReturnValue sniff.
+ *
+ * @package VIPCS\WordPressVIPMinimum
+ */
+class ZoninatorUnitTest extends AbstractSniffUnitTest {
+
+	/**
+	 * Returns the lines where errors should occur.
+	 *
+	 * @return array <int line number> => <int number of errors>
+	 */
+	public function getErrorList() {
+		return array();
+	}
+
+	/**
+	 * Returns the lines where warnings should occur.
+	 *
+	 * @return array <int line number> => <int number of warnings>
+	 */
+	public function getWarningList() {
+		return array(
+			3  => 1,
+			4  => 1,
+			5 => 1,
+			6 => 1,
+		);
+
+	}
+
+} // End class.


### PR DESCRIPTION
Zoninator of v >= 0.8 requires WordPress core REST API, which has to be loaded by `wpcom_vip_load_wp_rest_api()` before the plugin itself. This should remind the reviewers to make sure the core's REST API is being properly loaded.