### PR TITLE
Update .gitignore to ignore vendor/ and some files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,5 @@
-.DS_Store
-.idea/
-.DS_Store
+vendor/
+composer.lock
+phpcs.xml
+.phpcs.xml
+


### PR DESCRIPTION
Operating system and IDE-specific files should be ignored at the global level - see https://gist.github.com/subfuzion/db7f57fff2fb6998a16c .

While `phpcs.xml.dist` does not (yet) exist, `phpcs.xml` and `.phpcs.xml` are meant to be local overrides, so should not be in version control anyway.