### PR TITLE
Fix fatal of too few arguments

### DIFF
--- a/WordPressVIPMinimum/Sniffs/Files/IncludingFileSniff.php
+++ b/WordPressVIPMinimum/Sniffs/Files/IncludingFileSniff.php
@@ -119,7 +119,7 @@ class IncludingFileSniff implements \PHP_CodeSniffer_Sniff {
 
 			if ( true === in_array( $tokens[ $nextToken ]['content'], array_keys( $this->restrictedConstants ), true ) ) {
 				// The construct is using one of the restricted constants.
-				$phpcsFile->addError( sprintf( '`%s` constant might not be defined or available. Use `%s()` instead.', $tokens[ $nextToken ]['content'], $this->restrictedConstants[ $tokens[ $nextToken ]['content'] ] ), $nextToken );
+				$phpcsFile->addError( sprintf( '`%s` constant might not be defined or available. Use `%s()` instead.', $tokens[ $nextToken ]['content'], $this->restrictedConstants[ $tokens[ $nextToken ]['content'] ] ), $nextToken, 'IncludingFile' );
 				return;
 			}
 


### PR DESCRIPTION
Ran into a fatal today on doing a PHPCS:

```
Fatal error: Uncaught ArgumentCountError: Too few arguments to function PHP_CodeSniffer\Files\File::addError(), 2 passed in /Users/rebasaurus/source/wpcs/WordPressVIPMinimum/Sniffs/Files/IncludingFileSniff.php on line 122 and at least 3 expected in phar:///usr/local/Cellar/php-code-sniffer/3.3.0/bin/phpcs/src/Files/File.php on line 2
```

This PR should resolve it.