### PR TITLE
Remove PHPCS 2.x support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,4 +2,4 @@ vendor/
 composer.lock
 phpcs.xml
 .phpcs.xml
-
+phpunit.xml

--- a/.travis.yml
+++ b/.travis.yml
@@ -33,13 +33,6 @@ matrix:
           packages:
             - libxml2-utils
 
-    # Run against HHVM and PHP nightly.
-    - php: hhvm
-      sudo: required
-      dist: trusty
-      group: edge
-      env: PHPCS_BRANCH=master LINT=1
-
     # Test PHP 5.3 only against PHPCS 2.x as PHPCS 3.x has a minimum requirement of PHP 5.4.
     - php: 5.3
       env: PHPCS_BRANCH=2.9 LINT=1
@@ -55,7 +48,6 @@ matrix:
   allow_failures:
     # Allow failures for unstable builds.
     - php: nightly
-    - php: hhvm
 
 before_install:
     - export XMLLINT_INDENT="	"
@@ -66,7 +58,7 @@ before_install:
     - mkdir -p $PHPCS_DIR && git clone --depth 1 https://github.com/squizlabs/PHP_CodeSniffer.git -b $PHPCS_BRANCH $PHPCS_DIR
     - mkdir -p $WPCS_DIR && git clone --depth 1 https://github.com/WordPress-Coding-Standards/WordPress-Coding-Standards.git -b master $WPCS_DIR
     - $PHPCS_BIN --config-set installed_paths $(pwd),$WPCS_DIR
-    # Download PHPUnit 5.x for builds on PHP 7, nightly and HHVM as the PHPCS
+    # Download PHPUnit 5.x for builds on PHP 7, nightly as the PHPCS
     # test suite is currently not compatible with PHPUnit 6.x.
     # Fixed at a very specific PHPUnit version which is also compatible with HHVM.
     - if [[ ${TRAVIS_PHP_VERSION:0:2} != "5." ]]; then wget -P $PHPUNIT_DIR https://phar.phpunit.de/phpunit-5.7.17.phar && chmod +x $PHPUNIT_DIR/phpunit-5.7.17.phar; fi

--- a/.travis.yml
+++ b/.travis.yml
@@ -14,36 +14,25 @@ php:
     - 5.6
     - 7.0
     - 7.1
+    - 7.2
     - nightly
 
 env:
   # `master` is now 3.x.
-  - PHPCS_BRANCH=master LINT=1
-  # Lowest tagged release in the 2.x series with which WPCS is compatible.
-  - PHPCS_BRANCH=2.9.0
+  - PHPCS_BRANCH=master
+  # Lowest version of PHPCS that VIPCS supports (and that will run tests)
+  - PHPCS_BRANCH=3.1.0
 
 matrix:
   fast_finish: true
   include:
-    # Run PHPCS against WPCS. I just picked to run it against 7.0.
-    - php: 7.0
-      env: PHPCS_BRANCH=master SNIFF=1
+    # Run PHPCS against VIPCS, run PHP Lint, and run integration test
+    - php: 7.2
+      env: PHPCS_BRANCH=master SNIFF=1 INTEGRATION_TEST=1 LINT=1
       addons:
         apt:
           packages:
             - libxml2-utils
-
-    # Test PHP 5.3 only against PHPCS 2.x as PHPCS 3.x has a minimum requirement of PHP 5.4.
-    - php: 5.3
-      env: PHPCS_BRANCH=2.9 LINT=1
-      dist: precise
-    # Test PHP 5.3 with short_open_tags set to On (is Off by default)
-    - php: 5.3
-      env: PHPCS_BRANCH=2.9.0 SHORT_OPEN_TAGS=true
-      dist: precise
-    # Run custom integration test. I just picked to it agains PHP 7.0.
-    - php: 7.0
-      env: PHPCS_BRANCH=master INTEGRATION_TEST=1
 
   allow_failures:
     # Allow failures for unstable builds.
@@ -54,25 +43,21 @@ before_install:
     - export PHPCS_DIR=/tmp/phpcs
     - export WPCS_DIR=/tmp/wpcs
     - export PHPUNIT_DIR=/tmp/phpunit
-    - export PHPCS_BIN=$(if [[ $PHPCS_BRANCH == master ]]; then echo $PHPCS_DIR/bin/phpcs; else echo $PHPCS_DIR/scripts/phpcs; fi)
+    - export PHPCS_BIN=$PHPCS_DIR/bin/phpcs
     - mkdir -p $PHPCS_DIR && git clone --depth 1 https://github.com/squizlabs/PHP_CodeSniffer.git -b $PHPCS_BRANCH $PHPCS_DIR
     - mkdir -p $WPCS_DIR && git clone --depth 1 https://github.com/WordPress-Coding-Standards/WordPress-Coding-Standards.git -b master $WPCS_DIR
     - $PHPCS_BIN --config-set installed_paths $(pwd),$WPCS_DIR
     # Download PHPUnit 5.x for builds on PHP 7, nightly as the PHPCS
-    # test suite is currently not compatible with PHPUnit 6.x.
-    # Fixed at a very specific PHPUnit version which is also compatible with HHVM.
+    # test suite was not compatible with PHPUnit 6.x (but now is).
+    # Fixed at a very specific PHPUnit version which was also compatible with HHVM.
     - if [[ ${TRAVIS_PHP_VERSION:0:2} != "5." ]]; then wget -P $PHPUNIT_DIR https://phar.phpunit.de/phpunit-5.7.17.phar && chmod +x $PHPUNIT_DIR/phpunit-5.7.17.phar; fi
-    # Selectively adjust the ini values for the build image to test ini value dependent sniff features.
-    - if [[ "$SHORT_OPEN_TAGS" == "true" ]]; then echo "short_open_tag = On" >> ~/.phpenv/versions/$(phpenv version-name)/etc/php.ini; fi
 
 script:
     # Lint the PHP files against parse errors.
     - if [[ "$LINT" == "1" ]]; then if find . -name "*.php" -exec php -l {} \; | grep "^[Parse error|Fatal error]"; then exit 1; fi; fi
     # Run the unit tests.
-    - if [[ ${TRAVIS_PHP_VERSION:0:2} == "5." && ${PHPCS_BRANCH:0:2} == "2." ]]; then phpunit --bootstrap $WPCS_DIR/Test/bootstrap.php --filter WordPressVIPMinimum $WPCS_DIR/Test/AllTests.php; fi
-    - if [[ ${TRAVIS_PHP_VERSION:0:2} == "5." && ${PHPCS_BRANCH:0:2} != "2." ]]; then phpunit --bootstrap $WPCS_DIR/Test/bootstrap.php --filter WordPressVIPMinimum $PHPCS_DIR/tests/AllTests.php; fi
-    - if [[ ${TRAVIS_PHP_VERSION:0:2} != "5." && ${PHPCS_BRANCH:0:2} == "2." ]]; then php $PHPUNIT_DIR/phpunit-5.7.17.phar --bootstrap $WPCS_DIR/Test/bootstrap.php --filter WordPressVIPMinimum $WPCS_DIR/Test/AllTests.php; fi
-    - if [[ ${TRAVIS_PHP_VERSION:0:2} != "5." && ${PHPCS_BRANCH:0:2} != "2." ]]; then php $PHPUNIT_DIR/phpunit-5.7.17.phar --bootstrap $WPCS_DIR/Test/bootstrap.php --filter WordPressVIPMinumum $PHPCS_DIR/tests/AllTests.php; fi
+    - if [[ ${TRAVIS_PHP_VERSION:0:2} == "5." ]]; then phpunit --bootstrap $WPCS_DIR/Test/bootstrap.php --filter WordPressVIPMinimum $PHPCS_DIR/tests/AllTests.php; fi
+    - if [[ ${TRAVIS_PHP_VERSION:0:2} != "5." ]]; then php $PHPUNIT_DIR/phpunit-5.7.17.phar --bootstrap $WPCS_DIR/Test/bootstrap.php --filter WordPressVIPMinumum $PHPCS_DIR/tests/AllTests.php; fi
     # WordPress Coding Standards.
     # @link https://github.com/WordPress-Coding-Standards/WordPress-Coding-Standards
     # @link http://pear.php.net/package/PHP_CodeSniffer/

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,158 @@
+Hi, thank you for your interest in contributing to the VIP Coding Standards! We look forward to working with you.
+
+# Reporting Bugs
+
+Before reporting a bug, you should check what sniff an error is coming from.
+Running `phpcs` with the `-s` flag will show the name of the sniff with each error.
+
+Bug reports containing a minimal code sample which can be used to reproduce the issue are highly appreciated as those are most easily actionable.
+
+## Upstream Issues
+
+Since VIPCS employs many sniffs that are part of PHPCS, and makes use of WordPress Coding Standards sniffs, sometimes an issue will be caused by a bug upstream and not in VIPCS itself. If the error message in question doesn't come from a sniff whose name starts with `WordPressVIPMinimum`, the issue is probably a bug in PHPCS itself, and should be [reported there](https://github.com/squizlabs/PHP_CodeSniffer/issues).
+
+# Contributing patches and new features
+
+## Branches
+
+Ongoing development will be done in features branches then pulled against the `master` branch, with work for VIP Go currently done in the `vip-go` branch.
+
+To contribute an improvement to this project, fork the repo and open a pull request to the relevant branch. Alternatively, if you have push access to this repo, create a feature branch prefixed by `feature/` and then open an intra-repo PR from that branch to the right branch.
+
+# Considerations when writing sniffs
+
+## Public properties
+
+When writing sniffs, always remember that any `public` sniff property can be overruled via a custom ruleset by the end-user.
+Only make a property `public` if that is the intended behaviour.
+
+When you introduce new `public` sniff properties, or your sniff extends a class from which you inherit a `public` property, please don't forget to update the [public properties wiki page](https://github.com/WordPress-Coding-Standards/WordPress-Coding-Standards/wiki/Customizable-sniff-properties) with the relevant details once your PR has been merged into the `develop` branch.
+
+# Unit Testing
+
+## Pre-requisites
+* VIP Coding Standards
+* WordPress-Coding-Standards
+* PHP_CodeSniffer 3.x
+* PHPUnit 4.x, 5.x, 6.x or 7.x
+
+The VIP Coding Standards use the PHP_CodeSniffer native unit test suite for unit testing the sniffs.
+
+Presuming you have installed PHP_CodeSniffer, VIP Coding Standards, and the WordPress-Coding-Standards as [noted in the WPCS README](https://github.com/WordPress-Coding-Standards/WordPress-Coding-Standards#how-to-use-this), all you need now is `PHPUnit`.
+
+N.B.: If you installed VIPCS using Composer, make sure you used `--prefer-source` or run `composer install --prefer-source` now to make sure the unit tests are available.
+
+If you already have PHPUnit installed on your system: Congrats, you're all set.
+
+If not, you can navigate to the directory where the `PHP_CodeSniffer` repo is checked out and do `composer install` to install the `dev` dependencies.
+Alternatively, you can [install PHPUnit](https://phpunit.de/manual/5.7/en/installation.html) as a PHAR file.
+
+## Before running the unit tests
+
+N.B.: _If you used Composer to install the WordPress Coding Standards, you can skip this step._
+
+For the unit tests to work, you need to make sure PHPUnit can find your `PHP_CodeSniffer` install.
+
+The easiest way to do this is to add a `phpunit.xml` file to the root of your VIPCS installation and set a `PHPCS_DIR` environment variable from within this file. Make sure to adjust the path to reflect your local setup.
+```xml
+<phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+	xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/6.3/phpunit.xsd"
+	beStrictAboutTestsThatDoNotTestAnything="false"
+	bootstrap="./tests/bootstrap.php"
+	backupGlobals="true"
+	colors="true">
+	<php>
+		<env name="PHPCS_DIR" value="/path/to/PHP_CodeSniffer/"/>
+	</php>
+</phpunit>
+```
+
+## Running the unit tests
+
+* Make sure you have registered the directory in which you installed VIPCS with PHPCS using;
+    
+    ```sh
+    phpcs --config-set installed_paths path/to/VIPCS
+    ```
+* Navigate to the directory in which you installed VIPCS.
+* To run the unit tests:
+    
+    ```sh
+    phpunit --filter WordPressVIPMinimum $PHPCS_DIR/tests/AllTests.php
+    ```
+
+Expected output:
+```
+PHPUnit 7.2.6 by Sebastian Bergmann and contributors.
+
+.................................                                 33 / 33 (100%)
+
+Tests generated 29 unique error codes; 0 were fixable (0%)
+
+Time: 268 ms, Memory: 30.00MB
+```
+
+## Unit Testing conventions
+
+If you look inside the `WordPressVIPMinimum/Tests` subdirectory, you'll see the structure mimics the `WordPressVIPMinimum/Sniffs` subdirectory structure. For example, the `WordPressVIPMinimum/Sniffs/VIP/WPQueryParams.php` sniff has its unit test class defined in `WordPressVIPMinimum/Tests/VIP/WPQueryParamsUnitTest.php` which checks the `WordPressVIPMinimum/Tests/VIP/WPQueryParamsUnitTest.inc` test case file. See the file naming convention?
+
+Lets take a look at what's inside `WPQueryParamsUnitTest.php`:
+
+```php
+...
+namespace WordPressVIPMinimum\Tests\VIP;
+
+use PHP_CodeSniffer\Tests\Standards\AbstractSniffUnitTest;
+
+/**
+ * Unit test class for the WP_Query params sniff.
+ *
+ * @package VIPCS\WordPressVIPMinimum
+ */
+class WPQueryParamsUnitTest extends AbstractSniffUnitTest {
+
+	/**
+	 * Returns the lines where errors should occur.
+	 *
+	 * @return array <int line number> => <int number of errors>
+	 */
+	public function getErrorList() {
+		return array(
+			5  => 1,
+			17 => 1,
+		);
+	}
+...
+```
+
+Also note the class name convention. The method `getErrorList()` MUST return an array of line numbers indicating errors (when running `phpcs`) found in `WordPressVIPMinimum/Tests/VIP/WPQueryParamsUnitTest.inc`.
+If you run:
+
+```sh
+$ cd /path-to-cloned/phpcs
+$ ./bin/phpcs --standard=WordPressVIPMinimum -s --sniffs=WordPressVIPMinimum.VIP.WPQueryParams /path/to/WordPressVIPMinimum/Tests/VIP/WPQueryParamsUnitTest.inc
+...
+E 1 / 1 (100%)
+
+
+
+FILE: /path/to/vipcs/WordPressVIPMinimum/Tests/VIP/WPQueryParamsUnitTest.inc
+--------------------------------------------------------------------------------------------------------------------------------
+FOUND 2 ERRORS AND 2 WARNINGS AFFECTING 4 LINES
+--------------------------------------------------------------------------------------------------------------------------------
+  4 | WARNING | Using `post__not_in` should be done with caution. (WordPressVIPMinimum.VIP.WPQueryParams.post__not_in)
+  5 | ERROR   | Setting `suppress_filters` to `true` is probihited.
+    |         | (WordPressVIPMinimum.VIP.WPQueryParams.suppressFiltersTrue)
+ 11 | WARNING | Using `post__not_in` should be done with caution. (WordPressVIPMinimum.VIP.WPQueryParams.post__not_in)
+ 17 | ERROR   | Setting `suppress_filters` to `true` is probihited.
+    |         | (WordPressVIPMinimum.VIP.WPQueryParams.suppressFiltersTrue)
+--------------------------------------------------------------------------------------------------------------------------------
+....
+```
+You'll see the line number and number of ERRORs we need to return in the `getErrorList()` method.
+
+The `--sniffs=...` directive limits the output to the sniff you are testing.
+
+## Code Standards for this project
+
+The sniffs and test files - not test _case_ files! - for VIPCS should be written such that they pass the `WordPress-Extra` and the `WordPress-Docs` code standards using the custom ruleset as found in `/bin/phpcs.xml`.

--- a/WordPressVIPMinimum/Sniffs/Actions/PreGetPostsSniff.php
+++ b/WordPressVIPMinimum/Sniffs/Actions/PreGetPostsSniff.php
@@ -7,8 +7,9 @@
 
 namespace WordPressVIPMinimum\Sniffs\Actions;
 
-use PHP_CodeSniffer_File as File;
-use PHP_CodeSniffer_Tokens as Tokens;
+use PHP_CodeSniffer\Files\File;
+use PHP_CodeSniffer\Sniffs\Sniff;
+use PHP_CodeSniffer\Util\Tokens;
 
 /**
  * This sniff validates a propper usage of pre_get_posts action callback
@@ -17,7 +18,7 @@ use PHP_CodeSniffer_Tokens as Tokens;
  *
  * @package VIPCS\WordPressVIPMinimum
  */
-class PreGetPostsSniff implements \PHP_CodeSniffer_Sniff {
+class PreGetPostsSniff implements Sniff {
 
 	/**
 	 * The tokens of the phpcsFile.

--- a/WordPressVIPMinimum/Sniffs/Cache/BatcacheWhitelistedParamsSniff.php
+++ b/WordPressVIPMinimum/Sniffs/Cache/BatcacheWhitelistedParamsSniff.php
@@ -8,15 +8,16 @@
 
 namespace WordPressVIPMinimum\Sniffs\Cache;
 
-use PHP_CodeSniffer_File as File;
-use PHP_CodeSniffer_Tokens as Tokens;
+use PHP_CodeSniffer\Files\File;
+use PHP_CodeSniffer\Sniffs\Sniff;
+use PHP_CodeSniffer\Util\Tokens;
 
 /**
  * Checks whether proper escaping function is used.
  *
  *  @package VIPCS\WordPressVIPMinimum
  */
-class BatcacheWhitelistedParamsSniff implements \PHP_CodeSniffer_Sniff {
+class BatcacheWhitelistedParamsSniff implements Sniff {
 
 	/**
 	 * List of whitelisted batcache params.

--- a/WordPressVIPMinimum/Sniffs/Cache/CacheValueOverrideSniff.php
+++ b/WordPressVIPMinimum/Sniffs/Cache/CacheValueOverrideSniff.php
@@ -7,9 +7,9 @@
 
 namespace WordPressVIPMinimum\Sniffs\Cache;
 
-use PHP_CodeSniffer_Sniff as PHPCS_Sniff;
-use PHP_CodeSniffer_File as File;
-use PHP_CodeSniffer_Tokens as Tokens;
+use PHP_CodeSniffer\Files\File;
+use PHP_CodeSniffer\Sniffs\Sniff;
+use PHP_CodeSniffer\Util\Tokens;
 
 /**
  * This sniff enforces checking the return value of a function before passing it to anoher one.
@@ -22,7 +22,7 @@ use PHP_CodeSniffer_Tokens as Tokens;
  *
  * @package VIPCS\WordPressVIPMinimum
  */
-class CacheValueOverrideSniff implements PHPCS_Sniff {
+class CacheValueOverrideSniff implements Sniff {
 
 	/**
 	 * Tokens of the file.

--- a/WordPressVIPMinimum/Sniffs/Classes/DeclarationCompatibilitySniff.php
+++ b/WordPressVIPMinimum/Sniffs/Classes/DeclarationCompatibilitySniff.php
@@ -7,19 +7,15 @@
 
 namespace WordPressVIPMinimum\Sniffs\Classes;
 
-use PHP_CodeSniffer_File as File;
-
-// WPCS pre 0.13.1 backwardcompatibility.
-if ( ! class_exists( '\PHP_CodeSniffer_Standards_AbstractScopeSniff' ) ) {
-	class_alias( 'PHP_CodeSniffer\Sniffs\AbstractScopeSniff', '\PHP_CodeSniffer_Standards_AbstractScopeSniff' );
-}
+use PHP_CodeSniffer\Files\File;
+use PHP_CodeSniffer\Sniffs\AbstractScopeSniff;
 
 /**
  * Class WordPressVIPMinimum_Sniffs_Classes_DeclarationCompatibilitySniff
  *
  * @package VIPCS\WordPressVIPMinimum
  */
-class DeclarationCompatibilitySniff extends \PHP_CodeSniffer_Standards_AbstractScopeSniff {
+class DeclarationCompatibilitySniff extends AbstractScopeSniff {
 
 	/**
 	 * The name of the class we are currently checking.

--- a/WordPressVIPMinimum/Sniffs/Constants/ConstantRestrictionsSniff.php
+++ b/WordPressVIPMinimum/Sniffs/Constants/ConstantRestrictionsSniff.php
@@ -8,15 +8,16 @@
 
 namespace WordPressVIPMinimum\Sniffs\Constants;
 
-use PHP_CodeSniffer_File as File;
-use PHP_CodeSniffer_Tokens as Tokens;
+use PHP_CodeSniffer\Files\File;
+use PHP_CodeSniffer\Sniffs\Sniff;
+use PHP_CodeSniffer\Util\Tokens;
 
 /**
  * Restricts usage of some constants.
  *
  * @package VIPCS\WordPressVIPMinimum
  */
-class ConstantRestrictionsSniff implements \PHP_CodeSniffer_Sniff {
+class ConstantRestrictionsSniff implements Sniff {
 
 	/**
 	 * List of restricted constant names.

--- a/WordPressVIPMinimum/Sniffs/Constants/ConstantStringSniff.php
+++ b/WordPressVIPMinimum/Sniffs/Constants/ConstantStringSniff.php
@@ -8,15 +8,16 @@
 
 namespace WordPressVIPMinimum\Sniffs\Constants;
 
-use PHP_CodeSniffer_File as File;
-use PHP_CodeSniffer_Tokens as Tokens;
+use PHP_CodeSniffer\Files\File;
+use PHP_CodeSniffer\Sniffs\Sniff;
+use PHP_CodeSniffer\Util\Tokens;
 
 /**
  * Sniff for properly using constant name when checking whether a constant is defined.
  *
  * @package VIPCS\WordPressVIPMinimum
  */
-class ConstantStringSniff implements \PHP_CodeSniffer_Sniff {
+class ConstantStringSniff implements Sniff {
 
 	/**
 	 * Returns an array of tokens this test wants to listen for.

--- a/WordPressVIPMinimum/Sniffs/Files/IncludingFileSniff.php
+++ b/WordPressVIPMinimum/Sniffs/Files/IncludingFileSniff.php
@@ -7,8 +7,9 @@
 
 namespace WordPressVIPMinimum\Sniffs\Files;
 
-use PHP_CodeSniffer_File as File;
-use PHP_CodeSniffer_Tokens as Tokens;
+use PHP_CodeSniffer\Files\File;
+use PHP_CodeSniffer\Sniffs\Sniff;
+use PHP_CodeSniffer\Util\Tokens;
 
 /**
  * WordPressVIPMinimum_Sniffs_Files_IncludingFileSniff.
@@ -18,7 +19,7 @@ use PHP_CodeSniffer_Tokens as Tokens;
  *
  * @package VIPCS\WordPressVIPMinimum
  */
-class IncludingFileSniff implements \PHP_CodeSniffer_Sniff {
+class IncludingFileSniff implements Sniff {
 
 	/**
 	 * List of function used for getting paths.

--- a/WordPressVIPMinimum/Sniffs/Files/IncludingNonPHPFileSniff.php
+++ b/WordPressVIPMinimum/Sniffs/Files/IncludingNonPHPFileSniff.php
@@ -7,8 +7,9 @@
 
 namespace WordPressVIPMinimum\Sniffs\Files;
 
-use PHP_CodeSniffer_File as File;
-use PHP_CodeSniffer_Tokens as Tokens;
+use PHP_CodeSniffer\Files\File;
+use PHP_CodeSniffer\Sniffs\Sniff;
+use PHP_CodeSniffer\Util\Tokens;
 
 /**
  * WordPressVIPMinimum_Sniffs_Files_IncludingNonPHPFileSniff.
@@ -18,7 +19,7 @@ use PHP_CodeSniffer_Tokens as Tokens;
  *
  * @package VIPCS\WordPressVIPMinimum
  */
-class IncludingNonPHPFileSniff implements \PHP_CodeSniffer_Sniff {
+class IncludingNonPHPFileSniff implements Sniff {
 
 	/**
 	 * Returns an array of tokens this test wants to listen for.

--- a/WordPressVIPMinimum/Sniffs/Functions/CheckReturnValueSniff.php
+++ b/WordPressVIPMinimum/Sniffs/Functions/CheckReturnValueSniff.php
@@ -7,8 +7,9 @@
 
 namespace WordPressVIPMinimum\Sniffs\Functions;
 
-use PHP_CodeSniffer_File as File;
-use PHP_CodeSniffer_Tokens as Tokens;
+use PHP_CodeSniffer\Files\File;
+use PHP_CodeSniffer\Sniffs\Sniff;
+use PHP_CodeSniffer\Util\Tokens;
 
 /**
  * This sniff enforces checking the return value of a function before passing it to another one.
@@ -19,7 +20,7 @@ use PHP_CodeSniffer_Tokens as Tokens;
  * echo esc_url( wpcom_vip_get_term_link( $term ) );
  * </code>
  */
-class CheckReturnValueSniff implements \PHP_CodeSniffer_Sniff {
+class CheckReturnValueSniff implements Sniff {
 
 	/**
 	 * Tokens of the whole file.

--- a/WordPressVIPMinimum/Sniffs/Functions/DynamicCallsSniff.php
+++ b/WordPressVIPMinimum/Sniffs/Functions/DynamicCallsSniff.php
@@ -7,8 +7,8 @@
 
 namespace WordPressVIPMinimum\Sniffs\Functions;
 
-use PHP_CodeSniffer_File as File;
-use PHP_CodeSniffer_Tokens as Tokens;
+use PHP_CodeSniffer\Files\File;
+use PHP_CodeSniffer\Sniffs\Sniff;
 
 /**
  * This sniff enforces that certain functions are not
@@ -26,7 +26,7 @@ use PHP_CodeSniffer_Tokens as Tokens;
  * Note that this sniff does not catch all possible forms of dynamic
  * calling, only some.
  */
-class DynamicCallsSniff implements \PHP_CodeSniffer_Sniff {
+class DynamicCallsSniff implements Sniff {
 	/**
 	 * Functions that should not be called dynamically.
 	 *

--- a/WordPressVIPMinimum/Sniffs/JS/HTMLExecutingFunctionsSniff.php
+++ b/WordPressVIPMinimum/Sniffs/JS/HTMLExecutingFunctionsSniff.php
@@ -7,8 +7,9 @@
 
 namespace WordPressVIPMinimum\Sniffs\JS;
 
-use PHP_CodeSniffer_File as File;
-use PHP_CodeSniffer_Tokens as Tokens;
+use PHP_CodeSniffer\Files\File;
+use PHP_CodeSniffer\Sniffs\Sniff;
+use PHP_CodeSniffer\Util\Tokens;
 
 /**
  * WordPressVIPMinimum_Sniffs_JS_HTMLExecutingFunctions.
@@ -17,7 +18,7 @@ use PHP_CodeSniffer_Tokens as Tokens;
  *
  * @package VIPCS\WordPressVIPMinimum
  */
-class HTMLExecutingFunctionsSniff implements \PHP_CodeSniffer_Sniff {
+class HTMLExecutingFunctionsSniff implements Sniff {
 
 	/**
 	 * List of HTML executing functions.

--- a/WordPressVIPMinimum/Sniffs/JS/InnerHTMLSniff.php
+++ b/WordPressVIPMinimum/Sniffs/JS/InnerHTMLSniff.php
@@ -7,8 +7,9 @@
 
 namespace WordPressVIPMinimum\Sniffs\JS;
 
-use PHP_CodeSniffer_File as File;
-use PHP_CodeSniffer_Tokens as Tokens;
+use PHP_CodeSniffer\Files\File;
+use PHP_CodeSniffer\Sniffs\Sniff;
+use PHP_CodeSniffer\Util\Tokens;
 
 /**
  * WordPressVIPMinimum_Sniffs_JS_InnerHTMLSniff.
@@ -17,7 +18,7 @@ use PHP_CodeSniffer_Tokens as Tokens;
  *
  * @package VIPCS\WordPressVIPMinimum
  */
-class InnerHTMLSniff implements \PHP_CodeSniffer_Sniff {
+class InnerHTMLSniff implements Sniff {
 
 	/**
 	 * A list of tokenizers this sniff supports.

--- a/WordPressVIPMinimum/Sniffs/JS/StringConcatSniff.php
+++ b/WordPressVIPMinimum/Sniffs/JS/StringConcatSniff.php
@@ -7,8 +7,9 @@
 
 namespace WordPressVIPMinimum\Sniffs\JS;
 
-use PHP_CodeSniffer_File as File;
-use PHP_CodeSniffer_Tokens as Tokens;
+use PHP_CodeSniffer\Files\File;
+use PHP_CodeSniffer\Sniffs\Sniff;
+use PHP_CodeSniffer\Util\Tokens;
 
 /**
  * WordPressVIPMinimum_Sniffs_JS_StringConcatSniff.
@@ -17,7 +18,7 @@ use PHP_CodeSniffer_Tokens as Tokens;
  *
  * @package VIPCS\WordPressVIPMinimum
  */
-class StringConcatSniff implements \PHP_CodeSniffer_Sniff {
+class StringConcatSniff implements Sniff {
 
 	/**
 	 * A list of tokenizers this sniff supports.

--- a/WordPressVIPMinimum/Sniffs/JS/StrippingTagsSniff.php
+++ b/WordPressVIPMinimum/Sniffs/JS/StrippingTagsSniff.php
@@ -7,8 +7,9 @@
 
 namespace WordPressVIPMinimum\Sniffs\JS;
 
-use PHP_CodeSniffer_File as File;
-use PHP_CodeSniffer_Tokens as Tokens;
+use PHP_CodeSniffer\Files\File;
+use PHP_CodeSniffer\Sniffs\Sniff;
+use PHP_CodeSniffer\Util\Tokens;
 
 /**
  * WordPressVIPMinimum_Sniffs_JS_StrippingTagsSniff.
@@ -17,7 +18,7 @@ use PHP_CodeSniffer_Tokens as Tokens;
  *
  * @package VIPCS\WordPressVIPMinimum
  */
-class StrippingTagsSniff implements \PHP_CodeSniffer_Sniff {
+class StrippingTagsSniff implements Sniff {
 
 	/**
 	 * A list of tokenizers this sniff supports.

--- a/WordPressVIPMinimum/Sniffs/Plugins/ZoninatorSniff.php
+++ b/WordPressVIPMinimum/Sniffs/Plugins/ZoninatorSniff.php
@@ -7,14 +7,15 @@
 
 namespace WordPressVIPMinimum\Sniffs\Plugins;
 
-use PHP_CodeSniffer_File as File;
-use PHP_CodeSniffer_Tokens as Tokens;
+use PHP_CodeSniffer\Files\File;
+use PHP_CodeSniffer\Sniffs\Sniff;
+use PHP_CodeSniffer\Util\Tokens;
 
 /**
  * This sniff reminds the developers to check whether the WordPress Core REST API is enabled
  * along with loading v0.8 and above.
  */
-class ZoninatorSniff implements \PHP_CodeSniffer_Sniff {
+class ZoninatorSniff implements Sniff {
 
 	/**
 	 * Returns the token types that this sniff is interested in.

--- a/WordPressVIPMinimum/Sniffs/TemplatingEngines/UnescapedOutputMustacheSniff.php
+++ b/WordPressVIPMinimum/Sniffs/TemplatingEngines/UnescapedOutputMustacheSniff.php
@@ -7,8 +7,8 @@
 
 namespace WordPressVIPMinimum\Sniffs\TemplatingEngines;
 
-use PHP_CodeSniffer_File as File;
-use PHP_CodeSniffer_Tokens as Tokens;
+use PHP_CodeSniffer\Files\File;
+use PHP_CodeSniffer\Sniffs\Sniff;
 
 /**
  * WordPressVIPMinimum_Sniffs_TemplatingEngines_UnescapedOutputMustacheSniff.
@@ -17,7 +17,7 @@ use PHP_CodeSniffer_Tokens as Tokens;
  *
  * @package VIPCS\WordPressVIPMinimum
  */
-class UnescapedOutputMustacheSniff implements \PHP_CodeSniffer_Sniff {
+class UnescapedOutputMustacheSniff implements Sniff {
 
 	/**
 	 * A list of tokenizers this sniff supports.

--- a/WordPressVIPMinimum/Sniffs/TemplatingEngines/UnescapedOutputTwigSniff.php
+++ b/WordPressVIPMinimum/Sniffs/TemplatingEngines/UnescapedOutputTwigSniff.php
@@ -7,8 +7,8 @@
 
 namespace WordPressVIPMinimum\Sniffs\TemplatingEngines;
 
-use PHP_CodeSniffer_File as File;
-use PHP_CodeSniffer_Tokens as Tokens;
+use PHP_CodeSniffer\Files\File;
+use PHP_CodeSniffer\Sniffs\Sniff;
 
 /**
  * WordPressVIPMinimum_Sniffs_TemplatingEngines_UnescapedOutputTwigSniff.
@@ -17,7 +17,7 @@ use PHP_CodeSniffer_Tokens as Tokens;
  *
  * @package VIPCS\WordPressVIPMinimum
  */
-class UnescapedOutputTwigSniff implements \PHP_CodeSniffer_Sniff {
+class UnescapedOutputTwigSniff implements Sniff {
 
 	/**
 	 * A list of tokenizers this sniff supports.

--- a/WordPressVIPMinimum/Sniffs/TemplatingEngines/UnescapedOutputUnderscorejsSniff.php
+++ b/WordPressVIPMinimum/Sniffs/TemplatingEngines/UnescapedOutputUnderscorejsSniff.php
@@ -7,8 +7,8 @@
 
 namespace WordPressVIPMinimum\Sniffs\TemplatingEngines;
 
-use PHP_CodeSniffer_File as File;
-use PHP_CodeSniffer_Tokens as Tokens;
+use PHP_CodeSniffer\Files\File;
+use PHP_CodeSniffer\Sniffs\Sniff;
 
 /**
  * WordPressVIPMinimum_Sniffs_TemplatingEngines_UnescapedOutputUnderscorejsSniff.
@@ -17,7 +17,7 @@ use PHP_CodeSniffer_Tokens as Tokens;
  *
  * @package VIPCS\WordPressVIPMinimum
  */
-class UnescapedOutputUnderscorejsSniff implements \PHP_CodeSniffer_Sniff {
+class UnescapedOutputUnderscorejsSniff implements Sniff {
 
 	/**
 	 * A list of tokenizers this sniff supports.

--- a/WordPressVIPMinimum/Sniffs/TemplatingEngines/UnescapedOutputVuejsSniff.php
+++ b/WordPressVIPMinimum/Sniffs/TemplatingEngines/UnescapedOutputVuejsSniff.php
@@ -7,8 +7,8 @@
 
 namespace WordPressVIPMinimum\Sniffs\TemplatingEngines;
 
-use PHP_CodeSniffer_File as File;
-use PHP_CodeSniffer_Tokens as Tokens;
+use PHP_CodeSniffer\Files\File;
+use PHP_CodeSniffer\Sniffs\Sniff;
 
 /**
  * WordPressVIPMinimum_Sniffs_TemplatingEngines_UnescapedOutputVuejsSniff.
@@ -17,7 +17,7 @@ use PHP_CodeSniffer_Tokens as Tokens;
  *
  * @package VIPCS\WordPressVIPMinimum
  */
-class UnescapedOutputVuejsSniff implements \PHP_CodeSniffer_Sniff {
+class UnescapedOutputVuejsSniff implements Sniff {
 
 	/**
 	 * A list of tokenizers this sniff supports.

--- a/WordPressVIPMinimum/Sniffs/VIP/ErrorControlSniff.php
+++ b/WordPressVIPMinimum/Sniffs/VIP/ErrorControlSniff.php
@@ -8,14 +8,15 @@
 
 namespace WordPressVIPMinimum\Sniffs\VIP;
 
-use PHP_CodeSniffer_File as File;
+use PHP_CodeSniffer\Files\File;
+use PHP_CodeSniffer\Sniffs\Sniff;
 
 /**
  * Restricts usage of error control operators. Currently only the at sign.
  *
  *  @package VIPCS\WordPressVIPMinimum
  */
-class ErrorControlSniff implements \PHP_CodeSniffer_Sniff {
+class ErrorControlSniff implements Sniff {
 
 	/**
 	 * Returns an array of tokens this test wants to listen for.

--- a/WordPressVIPMinimum/Sniffs/VIP/EscapingVoidReturnFunctionsSniff.php
+++ b/WordPressVIPMinimum/Sniffs/VIP/EscapingVoidReturnFunctionsSniff.php
@@ -8,15 +8,16 @@
 
 namespace WordPressVIPMinimum\Sniffs\VIP;
 
-use PHP_CodeSniffer_File as File;
-use PHP_CodeSniffer_Tokens as Tokens;
+use PHP_CodeSniffer\Files\File;
+use PHP_CodeSniffer\Sniffs\Sniff;
+use PHP_CodeSniffer\Util\Tokens;
 
 /**
  * Flag suspicious WP_Query and get_posts params.
  *
  *  @package VIPCS\WordPressVIPMinimum
  */
-class EscapingVoidReturnFunctionsSniff implements \PHP_CodeSniffer_Sniff {
+class EscapingVoidReturnFunctionsSniff implements Sniff {
 
 	/**
 	 * Returns an array of tokens this test wants to listen for.

--- a/WordPressVIPMinimum/Sniffs/VIP/ExitAfterRedirectSniff.php
+++ b/WordPressVIPMinimum/Sniffs/VIP/ExitAfterRedirectSniff.php
@@ -8,15 +8,16 @@
 
 namespace WordPressVIPMinimum\Sniffs\VIP;
 
-use PHP_CodeSniffer_File as File;
-use PHP_CodeSniffer_Tokens as Tokens;
+use PHP_CodeSniffer\Files\File;
+use PHP_CodeSniffer\Sniffs\Sniff;
+use PHP_CodeSniffer\Util\Tokens;
 
 /**
  * Require `exit;` being called after wp_redirect and wp_safe_redirect.
  *
  *  @package VIPCS\WordPressVIPMinimum
  */
-class ExitAfterRedirectSniff implements \PHP_CodeSniffer_Sniff {
+class ExitAfterRedirectSniff implements Sniff {
 
 	/**
 	 * Returns an array of tokens this test wants to listen for.

--- a/WordPressVIPMinimum/Sniffs/VIP/FetchingRemoteDataSniff.php
+++ b/WordPressVIPMinimum/Sniffs/VIP/FetchingRemoteDataSniff.php
@@ -8,15 +8,16 @@
 
 namespace WordPressVIPMinimum\Sniffs\VIP;
 
-use PHP_CodeSniffer_File as File;
-use PHP_CodeSniffer_Tokens as Tokens;
+use PHP_CodeSniffer\Files\File;
+use PHP_CodeSniffer\Sniffs\Sniff;
+use PHP_CodeSniffer\Util\Tokens;
 
 /**
  * Restricts usage of rewrite rules flushing
  *
  *  @package VIPCS\WordPressVIPMinimum
  */
-class FetchingRemoteDataSniff implements \PHP_CodeSniffer_Sniff {
+class FetchingRemoteDataSniff implements Sniff {
 
 	/**
 	 * Returns an array of tokens this test wants to listen for.

--- a/WordPressVIPMinimum/Sniffs/VIP/FlushRewriteRulesSniff.php
+++ b/WordPressVIPMinimum/Sniffs/VIP/FlushRewriteRulesSniff.php
@@ -8,15 +8,16 @@
 
 namespace WordPressVIPMinimum\Sniffs\VIP;
 
-use PHP_CodeSniffer_File as File;
-use PHP_CodeSniffer_Tokens as Tokens;
+use PHP_CodeSniffer\Files\File;
+use PHP_CodeSniffer\Sniffs\Sniff;
+use PHP_CodeSniffer\Util\Tokens;
 
 /**
  * Restricts usage of rewrite rules flushing
  *
  *  @package VIPCS\WordPressVIPMinimum
  */
-class FlushRewriteRulesSniff implements \PHP_CodeSniffer_Sniff {
+class FlushRewriteRulesSniff implements Sniff {
 
 	/**
 	 * Returns an array of tokens this test wants to listen for.

--- a/WordPressVIPMinimum/Sniffs/VIP/ProperEscapingFunctionSniff.php
+++ b/WordPressVIPMinimum/Sniffs/VIP/ProperEscapingFunctionSniff.php
@@ -8,15 +8,16 @@
 
 namespace WordPressVIPMinimum\Sniffs\VIP;
 
-use PHP_CodeSniffer_File as File;
-use PHP_CodeSniffer_Tokens as Tokens;
+use PHP_CodeSniffer\Files\File;
+use PHP_CodeSniffer\Sniffs\Sniff;
+use PHP_CodeSniffer\Util\Tokens;
 
 /**
  * Checks whether proper escaping function is used.
  *
  *  @package VIPCS\WordPressVIPMinimum
  */
-class ProperEscapingFunctionSniff implements \PHP_CodeSniffer_Sniff {
+class ProperEscapingFunctionSniff implements Sniff {
 
 	/**
 	 * List of escaping functions which are being tested.

--- a/WordPressVIPMinimum/Sniffs/VIP/StaticStrreplaceSniff.php
+++ b/WordPressVIPMinimum/Sniffs/VIP/StaticStrreplaceSniff.php
@@ -8,15 +8,16 @@
 
 namespace WordPressVIPMinimum\Sniffs\VIP;
 
-use PHP_CodeSniffer_File as File;
-use PHP_CodeSniffer_Tokens as Tokens;
+use PHP_CodeSniffer\Files\File;
+use PHP_CodeSniffer\Sniffs\Sniff;
+use PHP_CodeSniffer\Util\Tokens;
 
 /**
  * Restricts usage of str_replace with all 3 params being static.
  *
  *  @package VIPCS\WordPressVIPMinimum
  */
-class StaticStrreplaceSniff implements \PHP_CodeSniffer_Sniff {
+class StaticStrreplaceSniff implements Sniff {
 
 	/**
 	 * Returns an array of tokens this test wants to listen for.

--- a/WordPressVIPMinimum/Sniffs/VIP/TaxonomyMetaInOptionsSniff.php
+++ b/WordPressVIPMinimum/Sniffs/VIP/TaxonomyMetaInOptionsSniff.php
@@ -8,15 +8,16 @@
 
 namespace WordPressVIPMinimum\Sniffs\VIP;
 
-use PHP_CodeSniffer_File as File;
-use PHP_CodeSniffer_Tokens as Tokens;
+use PHP_CodeSniffer\Files\File;
+use PHP_CodeSniffer\Sniffs\Sniff;
+use PHP_CodeSniffer\Util\Tokens;
 
 /**
  * Restricts the implementation of taxonomy term meta via options.
  *
  *  @package VIPCS\WordPressVIPMinimum
  */
-class TaxonomyMetaInOptionsSniff implements \PHP_CodeSniffer_Sniff {
+class TaxonomyMetaInOptionsSniff implements Sniff {
 
 	/**
 	 * List of options_ functions

--- a/WordPressVIPMinimum/Sniffs/VIP/WPQueryParamsSniff.php
+++ b/WordPressVIPMinimum/Sniffs/VIP/WPQueryParamsSniff.php
@@ -8,15 +8,16 @@
 
 namespace WordPressVIPMinimum\Sniffs\VIP;
 
-use PHP_CodeSniffer_File as File;
-use PHP_CodeSniffer_Tokens as Tokens;
+use PHP_CodeSniffer\Files\File;
+use PHP_CodeSniffer\Sniffs\Sniff;
+use PHP_CodeSniffer\Util\Tokens;
 
 /**
  * Flag suspicious WP_Query and get_posts params.
  *
  *  @package VIPCS\WordPressVIPMinimum
  */
-class WPQueryParamsSniff implements \PHP_CodeSniffer_Sniff {
+class WPQueryParamsSniff implements Sniff {
 
 	/**
 	 * Returns an array of tokens this test wants to listen for.

--- a/WordPressVIPMinimum/Sniffs/Variables/ServerVariablesSniff.php
+++ b/WordPressVIPMinimum/Sniffs/Variables/ServerVariablesSniff.php
@@ -8,15 +8,15 @@
 
 namespace WordPressVIPMinimum\Sniffs\Variables;
 
-use PHP_CodeSniffer_File as File;
-use PHP_CodeSniffer_Tokens as Tokens;
+use PHP_CodeSniffer\Files\File;
+use PHP_CodeSniffer\Sniffs\Sniff;
 
 /**
  * Restricts usage of some server variables.
  *
  * @package VIPCS\WordPressVIPMinimum
  */
-class ServerVariablesSniff implements \PHP_CodeSniffer_Sniff {
+class ServerVariablesSniff implements Sniff {
 
 	/**
 	 * List of restricted constant names.

--- a/WordPressVIPMinimum/Sniffs/Variables/VariableAnalysisSniff.php
+++ b/WordPressVIPMinimum/Sniffs/Variables/VariableAnalysisSniff.php
@@ -15,7 +15,8 @@
 
 namespace WordPressVIPMinimum\Sniffs\Variables;
 
-use PHP_CodeSniffer_File as File;
+use PHP_CodeSniffer\Files\File;
+use PHP_CodeSniffer\Sniffs\Sniff;
 
 /**
  * Checks the for undefined function variables.
@@ -29,8 +30,7 @@ use PHP_CodeSniffer_File as File;
  * @copyright 2011 Sam Graham <php-codesniffer-variableanalysis BLAHBLAH illusori.co.uk>
  * @link      http://pear.php.net/package/PHP_CodeSniffer
  */
-class VariableAnalysisSniff implements \PHP_CodeSniffer_Sniff
-{
+class VariableAnalysisSniff implements Sniff {
 	/**
      * The current phpcsFile being checked.
      *

--- a/composer.json
+++ b/composer.json
@@ -11,7 +11,7 @@
 	],
 	"require"    : {
 		"php" : ">=5.3",
-		"squizlabs/php_codesniffer": "^2.9.0 || ^3.0.2",
+		"squizlabs/php_codesniffer": "^3.0.2",
 		"wp-coding-standards/wpcs": "1.*"
 	},
 	"suggest" : {

--- a/composer.json
+++ b/composer.json
@@ -10,7 +10,7 @@
 		}
 	],
 	"require"    : {
-		"php" : ">=5.3",
+		"php" : ">=5.4",
 		"squizlabs/php_codesniffer": "^3.0.2",
 		"wp-coding-standards/wpcs": "1.*"
 	},

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -1,0 +1,9 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<phpunit
+		xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+		xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/7.2/phpunit.xsd"
+		backupGlobals="true"
+		bootstrap="./tests/bootstrap.php"
+		beStrictAboutTestsThatDoNotTestAnything="false"
+		colors="true">
+</phpunit>

--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -1,0 +1,59 @@
+<?php
+/**
+ * Bootstrap file for running the tests on PHPCS 3.x.
+ *
+ * Load the PHPCS autoloader and the PHPCS cross-version helper.
+ *
+ * {@internal We need to load the PHPCS autoloader first, so as to allow their
+ * auto-loader to find the classes we want to alias for PHPCS 3.x.
+ * This aliasing has to be done before any of the test classes are loaded by the
+ * PHPCS native unit test suite to prevent fatal errors.
+ *
+ * @package VIPCS\WordPressVIPMinimum
+ * @license gpl-2.0-or-later
+ */
+
+if ( ! \defined( 'PHP_CODESNIFFER_IN_TESTS' ) ) {
+	define( 'PHP_CODESNIFFER_IN_TESTS', true );
+}
+
+$ds = DIRECTORY_SEPARATOR;
+
+// Get the PHPCS dir from an environment variable.
+$phpcsDir = getenv( 'PHPCS_DIR' );
+
+// This may be a Composer install.
+if ( false === $phpcsDir && is_dir( dirname( __DIR__ ) . $ds . 'vendor' . $ds . 'squizlabs' . $ds . 'php_codesniffer' ) ) {
+	$phpcsDir = dirname( __DIR__ ) . $ds . 'vendor' . $ds . 'squizlabs' . $ds . 'php_codesniffer';
+} elseif ( false !== $phpcsDir ) {
+	$phpcsDir = realpath( $phpcsDir );
+}
+
+// Try and load the PHPCS autoloader.
+if ( false !== $phpcsDir && file_exists( $phpcsDir . $ds . 'autoload.php' ) ) {
+	require_once $phpcsDir . $ds . 'autoload.php';
+
+	/*
+	 * As of PHPCS 3.1, PHPCS supports PHPUnit 6.x and above, but needs a bootstrap,
+	 * so load it if it's available.
+	 */
+	if ( file_exists( $phpcsDir . $ds . 'tests' . $ds . 'bootstrap.php' ) ) {
+		require_once $phpcsDir . $ds . 'tests' . $ds . 'bootstrap.php';
+	}
+} else {
+	echo 'Uh oh... can\'t find PHPCS. Are you sure you are using PHPCS 3.x ?
+
+If you use Composer, please run `composer install`.
+Otherwise, make sure you set a `PHPCS_DIR` environment variable in your phpunit.xml file
+pointing to the PHPCS directory.
+
+Please read the contributors guidelines for more information:
+https://is.gd/contributing2WPCS
+';
+
+	die( 1 );
+}
+
+// Load our class aliases.
+require_once dirname( __DIR__ ) . $ds . 'WordPressVIPMinimum' . $ds . 'PHPCSCompatibility.php';
+unset( $ds, $phpcsDir );


### PR DESCRIPTION
See individual commits for more info.

Minimum version of PHPCS left as `3.0.2`, but ideally, I'd like to see this raised. This can be discussed in #198.

There's one extra commit in here related to adding setup and documentation for running unit tests. While it's not directly part of the scope of removing PHPCS 2.x support, I did need to research and document it, so that I could run them and convince myself that the sniffs still worked in the 3.x environment. I can extract this commit out if really necessary. The document was a copy/paste/amend from WPCS, so this may need to be fine-tuned later on, but it's better than nothing for now.

There's more that can be tidied up with the Travis config file, but I didn't want to get too out of scope for this. A separate PR would be better for the rest, as it also would benefit #185.

Fixes #190.