### PR TITLE
Fix error of WordPress.WP.GlobalVariables.OverrideProhibited not existing

### DIFF
--- a/WordPress-VIP-Go/ruleset.xml
+++ b/WordPress-VIP-Go/ruleset.xml
@@ -226,7 +226,7 @@
 		<!-- This is still safe, just sub-optimal-->
 		<severity>3</severity>
 	</rule>
-	<rule ref="WordPress.WP.GlobalVariables.OverrideProhibited">
+	<rule ref="WordPress.Variables.GlobalVariables.OverrideProhibited">
 		<!-- This is often a false positive. Still nice to flag for a check -->
 		<severity>3</severity>
 	</rule>


### PR DESCRIPTION
```
ERROR: Referenced sniff "WordPress.WP.GlobalVariables.OverrideProhibited" does not exist
```
This should resolve it.