### PR TITLE
Add SVG files sniff for PHP openings

### DIFF
--- a/WordPressVIPMinimum/Sniffs/SVG/HTMLCodeSniff.php
+++ b/WordPressVIPMinimum/Sniffs/SVG/HTMLCodeSniff.php
@@ -39,6 +39,20 @@ class HTMLCodeSniff implements Sniff {
 	}
 
 	/**
+	 * Returns the file extension of a given file.
+	 *
+	 * @return string
+	 */
+	private function get_file_extension( $file_path ) {
+		return strtolower(
+			pathinfo(
+				$file_path,
+				PATHINFO_EXTENSION
+			)
+		);
+	}
+
+	/**
 	 * Processes the tokens that this sniff is interested in.
 	 *
 	 * @param \PHP_CodeSniffer\Files\File $phpcsFile The file where the token was found.
@@ -50,12 +64,9 @@ class HTMLCodeSniff implements Sniff {
 	public function process( File $phpcsFile, $stackPtr ) {
 		$tokens = $phpcsFile->getTokens();
 
-		// Make sure it is a SVG file.
-		$file_extension = strtolower(
-			pathinfo(
-				$phpcsFile->path,
-				PATHINFO_EXTENSION
-			)
+		// Get file extension
+		$file_extension = $this->get_file_extension(
+			$phpcsFile->path
 		);
 
 		// If not SVG file, ignore.

--- a/WordPressVIPMinimum/Sniffs/SVG/HTMLCodeSniff.php
+++ b/WordPressVIPMinimum/Sniffs/SVG/HTMLCodeSniff.php
@@ -1,0 +1,84 @@
+<?php
+/**
+ * WordPressVIPMinimum Coding Standard.
+ *
+ * @package VIPCS\WordPressVIPMinimum
+ */
+
+namespace WordPressVIPMinimum\Sniffs\SVG;
+
+use PHP_CodeSniffer\Files\File;
+use PHP_CodeSniffer\Sniffs\Sniff;
+
+/**
+ * This function generates an error when
+ * <?php or <? is found in a SVG file.
+ *
+ * The aim is to bring this to the notice of
+ * reviewers, so they can make sure the PHP-code
+ * is safe. The reason for this is that SVG files
+ * are often included in PHP files, but manually
+ * scanning SVG files takes alot of time and is prone
+ * to errors.
+ */
+class HTMLCodeSniff implements Sniff {
+	public $supportedTokenizers = array(
+		'PHP',
+	);
+
+	/**
+	 * Returns the token types that this sniff is interested in.
+	 *
+	 * We want everything function-related.
+	 *
+	 * @return array(int)
+	 */
+	public function register() {
+		return array(
+			T_OPEN_TAG,
+		);
+	}
+
+	/**
+	 * Processes the tokens that this sniff is interested in.
+	 *
+	 * @param \PHP_CodeSniffer\Files\File $phpcsFile The file where the token was found.
+	 * @param int						 $stackPtr  The position in the stack where
+	 *											   the token was found.
+	 *
+	 * @return void
+	 */
+	public function process( File $phpcsFile, $stackPtr ) {
+		$tokens	= $phpcsFile->getTokens();
+
+		$nxt = $phpcsFile->findNext(
+			T_OPEN_TAG,
+			( $stackPtr ),
+			null,
+			false,
+			null,
+			true
+		);
+
+		$tokens[ $nxt ]['content'] =
+			strtolower( $tokens[ $nxt ]['content'] );
+
+		$found1 =
+			strpos( $tokens[ $nxt ]['content'], '<?php' );
+
+		$found2 =
+			strpos( $tokens[ $nxt ]['content'], '<?' );
+
+
+		if (
+			( false !== $found1 ) ||
+			( false !== $found2 )
+		) {
+			$phpcsFile->addError(
+				'<?php or <? found in SVG file',
+				$nxt,
+				'HTMLCode'
+			);
+		}
+	}
+}

--- a/WordPressVIPMinimum/Sniffs/SVG/HTMLCodeSniff.php
+++ b/WordPressVIPMinimum/Sniffs/SVG/HTMLCodeSniff.php
@@ -74,7 +74,7 @@ class HTMLCodeSniff implements Sniff {
 			( false !== $found1 ) ||
 			( false !== $found2 )
 		) {
-			$phpcsFile->addError(
+			$phpcsFile->addWarning(
 				'<?php or <? found in SVG file',
 				$nxt,
 				'HTMLCode'

--- a/WordPressVIPMinimum/Sniffs/SVG/HTMLCodeSniff.php
+++ b/WordPressVIPMinimum/Sniffs/SVG/HTMLCodeSniff.php
@@ -22,6 +22,12 @@ use PHP_CodeSniffer\Sniffs\Sniff;
  * to errors.
  */
 class HTMLCodeSniff implements Sniff {
+
+	/**
+	 * A list of tokenizers this sniff supports.
+	 *
+	 * @var array
+	 */
 	public $supportedTokenizers = array(
 		'PHP',
 	);
@@ -43,8 +49,8 @@ class HTMLCodeSniff implements Sniff {
 	 * Processes the tokens that this sniff is interested in.
 	 *
 	 * @param \PHP_CodeSniffer\Files\File $phpcsFile The file where the token was found.
-	 * @param int						 $stackPtr  The position in the stack where
-	 *											   the token was found.
+	 * @param int                         $stackPtr  The position in the stack where
+	 *                                               the token was found.
 	 *
 	 * @return void
 	 */
@@ -68,7 +74,6 @@ class HTMLCodeSniff implements Sniff {
 
 		$found2 =
 			strpos( $tokens[ $nxt ]['content'], '<?' );
-
 
 		if (
 			( false !== $found1 ) ||

--- a/WordPressVIPMinimum/Sniffs/SVG/HTMLCodeSniff.php
+++ b/WordPressVIPMinimum/Sniffs/SVG/HTMLCodeSniff.php
@@ -9,6 +9,7 @@ namespace WordPressVIPMinimum\Sniffs\SVG;
 
 use PHP_CodeSniffer\Files\File;
 use PHP_CodeSniffer\Sniffs\Sniff;
+use PHP_CodeSniffer\Util\Tokens;
 
 /**
  * This function generates an error when
@@ -22,15 +23,6 @@ use PHP_CodeSniffer\Sniffs\Sniff;
  * to errors.
  */
 class HTMLCodeSniff implements Sniff {
-
-	/**
-	 * A list of tokenizers this sniff supports.
-	 *
-	 * @var array
-	 */
-	public $supportedTokenizers = array(
-		'PHP',
-	);
 
 	/**
 	 * Returns the token types that this sniff is interested in.

--- a/WordPressVIPMinimum/Sniffs/SVG/HTMLCodeSniff.php
+++ b/WordPressVIPMinimum/Sniffs/SVG/HTMLCodeSniff.php
@@ -55,8 +55,8 @@ class HTMLCodeSniff implements Sniff {
 	 * @return void
 	 */
 	public function process( File $phpcsFile, $stackPtr ) {
-		// Get tokens	
-		$tokens	= $phpcsFile->getTokens();
+		// Get tokens.
+		$tokens = $phpcsFile->getTokens();
 
 		$nxt = $phpcsFile->findNext(
 			T_OPEN_TAG,

--- a/WordPressVIPMinimum/Sniffs/SVG/HTMLCodeSniff.php
+++ b/WordPressVIPMinimum/Sniffs/SVG/HTMLCodeSniff.php
@@ -41,6 +41,8 @@ class HTMLCodeSniff implements Sniff {
 	/**
 	 * Returns the file extension of a given file.
 	 *
+	 * @param string $file_path Path to file.
+	 *
 	 * @return string
 	 */
 	private function get_file_extension( $file_path ) {
@@ -64,7 +66,7 @@ class HTMLCodeSniff implements Sniff {
 	public function process( File $phpcsFile, $stackPtr ) {
 		$tokens = $phpcsFile->getTokens();
 
-		// Get file extension
+		// Get file extension.
 		$file_extension = $this->get_file_extension(
 			$phpcsFile->path
 		);

--- a/WordPressVIPMinimum/Sniffs/SVG/HTMLCodeSniff.php
+++ b/WordPressVIPMinimum/Sniffs/SVG/HTMLCodeSniff.php
@@ -12,7 +12,7 @@ use PHP_CodeSniffer\Sniffs\Sniff;
 use PHP_CodeSniffer\Util\Tokens;
 
 /**
- * This function generates an error when
+ * This function generates a warning when
  * <?php or <? is found in a SVG file.
  *
  * The aim is to bring this to the notice of
@@ -27,13 +27,14 @@ class HTMLCodeSniff implements Sniff {
 	/**
 	 * Returns the token types that this sniff is interested in.
 	 *
-	 * We want everything function-related.
+	 * We want everything related to opening PHP tags.
 	 *
 	 * @return array(int)
 	 */
 	public function register() {
 		return array(
 			T_OPEN_TAG,
+			T_OPEN_TAG_WITH_ECHO,
 		);
 	}
 
@@ -47,36 +48,26 @@ class HTMLCodeSniff implements Sniff {
 	 * @return void
 	 */
 	public function process( File $phpcsFile, $stackPtr ) {
-		// Get tokens.
 		$tokens = $phpcsFile->getTokens();
+		print_r($tokens);
 
-		$nxt = $phpcsFile->findNext(
-			T_OPEN_TAG,
-			( $stackPtr ),
-			null,
-			false,
-			null,
-			true
+		// Make sure it is a SVG file.
+		$file_extension = strtolower(
+			pathinfo(
+				$phpcsFile->path,
+				PATHINFO_EXTENSION
+			)
 		);
 
-		$tokens[ $nxt ]['content'] =
-			strtolower( $tokens[ $nxt ]['content'] );
-
-		$found1 =
-			strpos( $tokens[ $nxt ]['content'], '<?php' );
-
-		$found2 =
-			strpos( $tokens[ $nxt ]['content'], '<?' );
-
-		if (
-			( false !== $found1 ) ||
-			( false !== $found2 )
-		) {
-			$phpcsFile->addWarning(
-				'<?php or <? found in SVG file',
-				$nxt,
-				'HTMLCode'
-			);
+		// If not SVG file, ignore.
+		if ( 'svg' !== $file_extension ) {
+			return;
 		}
+
+		$phpcsFile->addWarning(
+			'<?php or <?= found in SVG file, needs to be reviewed',
+			$stackPtr,
+			'HTMLCode'
+		);
 	}
 }

--- a/WordPressVIPMinimum/Sniffs/SVG/HTMLCodeSniff.php
+++ b/WordPressVIPMinimum/Sniffs/SVG/HTMLCodeSniff.php
@@ -49,7 +49,6 @@ class HTMLCodeSniff implements Sniff {
 	 */
 	public function process( File $phpcsFile, $stackPtr ) {
 		$tokens = $phpcsFile->getTokens();
-		print_r($tokens);
 
 		// Make sure it is a SVG file.
 		$file_extension = strtolower(
@@ -65,7 +64,7 @@ class HTMLCodeSniff implements Sniff {
 		}
 
 		$phpcsFile->addWarning(
-			'<?php or <?= found in SVG file, needs to be reviewed',
+			'<?php or <?= found in SVG file, needs to be reviewed manually',
 			$stackPtr,
 			'HTMLCode'
 		);

--- a/WordPressVIPMinimum/Sniffs/SVG/HTMLCodeSniff.php
+++ b/WordPressVIPMinimum/Sniffs/SVG/HTMLCodeSniff.php
@@ -55,6 +55,7 @@ class HTMLCodeSniff implements Sniff {
 	 * @return void
 	 */
 	public function process( File $phpcsFile, $stackPtr ) {
+		// Get tokens	
 		$tokens	= $phpcsFile->getTokens();
 
 		$nxt = $phpcsFile->findNext(

--- a/WordPressVIPMinimum/Tests/SVG/HTMLCodeSniff.php
+++ b/WordPressVIPMinimum/Tests/SVG/HTMLCodeSniff.php
@@ -22,9 +22,7 @@ class StrippingTagsUnitTest extends AbstractSniffUnitTest {
 	 * @return array <int line number> => <int number of errors>
 	 */
 	public function getErrorList() {
-		return array(
-			7 => 1,
-		);
+		return array();
 	}
 
 	/**
@@ -33,8 +31,9 @@ class StrippingTagsUnitTest extends AbstractSniffUnitTest {
 	 * @return array <int line number> => <int number of warnings>
 	 */
 	public function getWarningList() {
-		return array();
-
+		return array(
+			7 => 1,
+		);
 	}
 
 } // End class.

--- a/WordPressVIPMinimum/Tests/SVG/HTMLCodeSniff.php
+++ b/WordPressVIPMinimum/Tests/SVG/HTMLCodeSniff.php
@@ -33,7 +33,7 @@ class StrippingTagsUnitTest extends AbstractSniffUnitTest {
 	public function getWarningList() {
 		return array(
 			8  => 1,
-			19 => 1,
+			20 => 1,
 		);
 	}
 

--- a/WordPressVIPMinimum/Tests/SVG/HTMLCodeSniff.php
+++ b/WordPressVIPMinimum/Tests/SVG/HTMLCodeSniff.php
@@ -1,0 +1,40 @@
+<?php
+/**
+ * Unit test class for WordPressVIPMinimum Coding Standard.
+ *
+ * @package VIPCS\WordPressVIPMinimum
+ */
+
+namespace WordPressVIPMinimum\Tests\SVG;
+
+use PHP_CodeSniffer\Tests\Standards\AbstractSniffUnitTest;
+
+/**
+ * Unit test class for PHP opening tags in SVG files.
+ *
+ * @package VIPCS\WordPressVIPMinimum
+ */
+class StrippingTagsUnitTest extends AbstractSniffUnitTest {
+
+	/**
+	 * Returns the lines where errors should occur.
+	 *
+	 * @return array <int line number> => <int number of errors>
+	 */
+	public function getErrorList() {
+		return array(
+			7 => 1,
+		);
+	}
+
+	/**
+	 * Returns the lines where warnings should occur.
+	 *
+	 * @return array <int line number> => <int number of warnings>
+	 */
+	public function getWarningList() {
+		return array();
+
+	}
+
+} // End class.

--- a/WordPressVIPMinimum/Tests/SVG/HTMLCodeSniff.php
+++ b/WordPressVIPMinimum/Tests/SVG/HTMLCodeSniff.php
@@ -32,7 +32,8 @@ class StrippingTagsUnitTest extends AbstractSniffUnitTest {
 	 */
 	public function getWarningList() {
 		return array(
-			7 => 1,
+			8  => 1,
+			19 => 1,
 		);
 	}
 

--- a/WordPressVIPMinimum/Tests/SVG/HTMLCodeSniff.svg
+++ b/WordPressVIPMinimum/Tests/SVG/HTMLCodeSniff.svg
@@ -7,6 +7,7 @@
 
 <?php
 
+echo esc_html( 'time=' . time() );
 
 ?>
 
@@ -18,6 +19,7 @@
 
 <?=
 
+esc_html( time() )
 
 ?>
 

--- a/WordPressVIPMinimum/Tests/SVG/HTMLCodeSniff.svg
+++ b/WordPressVIPMinimum/Tests/SVG/HTMLCodeSniff.svg
@@ -4,6 +4,23 @@
 	<desc>Created with Sketch.</desc>
 
 
+
 <?php
 
 
+?>
+
+
+<text>
+	<g></g>
+</text>
+
+
+<?=
+
+
+?>
+
+
+<text>
+</text>

--- a/WordPressVIPMinimum/Tests/SVG/HTMLCodeSniff.svg
+++ b/WordPressVIPMinimum/Tests/SVG/HTMLCodeSniff.svg
@@ -1,0 +1,9 @@
+<svg width="299px" height="31px" viewBox="0 0 299 11" version="1.1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+	<!-- Generator: Tezt -->
+	<title>Page 100</title>
+	<desc>Created with Sketch.</desc>
+
+
+<?php
+
+

--- a/WordPressVIPMinimum/ruleset.xml
+++ b/WordPressVIPMinimum/ruleset.xml
@@ -19,6 +19,7 @@
 
 	<rule ref="WordPressVIPMinimum.SVG.HTMLCode">
 		<include-pattern>*.svg</include-pattern>
+		<exclude-pattern>*.php</exclude-pattern>
 	</rule>
 
 	<rule ref="WordPress.DB.PreparedSQL"/>

--- a/WordPressVIPMinimum/ruleset.xml
+++ b/WordPressVIPMinimum/ruleset.xml
@@ -16,6 +16,11 @@
 	<rule ref="WordPress.Security.EscapeOutput"/>
 	<rule ref="WordPress.Security.NonceVerification"/>
 	<rule ref="WordPress.WP.EnqueuedResources"/>
+
+	<rule ref="WordPressVIPMinimum.SVG.HTMLCode">
+		<include-pattern>*.svg</include-pattern>
+	</rule>
+
 	<rule ref="WordPress.DB.PreparedSQL"/>
 	<rule ref="WordPress.WP.GlobalVariablesOverride"/>
 	<rule ref="WordPress.PHP.StrictComparisons"/>


### PR DESCRIPTION
Look for <?php and <?= in SVG files, and give a warning when that happens.