### PR TITLE
XMLLINT: Fix whitespace in Go ruleset

### DIFF
--- a/WordPress-VIP-Go/ruleset.xml
+++ b/WordPress-VIP-Go/ruleset.xml
@@ -12,7 +12,7 @@
 		<severity>6</severity>
 		<message>File system writes only work in /tmp/ and inside the /uploads/ folder on VIP Go. To do filesystem writes you must use the WP_Filesystem class, using functions such as %s() won't work or will return unexpected results. Read more here: https://vip.wordpress.com/documentation/using-wp_filesystem-instead-of-direct-file-access-functions/</message>
 	</rule>
-		<rule ref="WordPress.WP.AlternativeFunctions.file_system_read_fwrite">
+	<rule ref="WordPress.WP.AlternativeFunctions.file_system_read_fwrite">
 		<type>error</type>
 		<severity>5</severity>
 		<message>File system writes only work in /tmp/ and inside the /uploads/ folder on VIP Go. To do filesystem writes you must use the WP_Filesystem class, using functions such as %s() won't work or will return unexpected results. Read more here: https://vip.wordpress.com/documentation/using-wp_filesystem-instead-of-direct-file-access-functions/</message>


### PR DESCRIPTION
The [VIPCS build](https://travis-ci.org/Automattic/VIP-Coding-Standards/builds/416477757) is broken because of an incorrect indentation in a ruleset.

This PR fixes that. Tested locally, and also on [Travis](https://travis-ci.org/GaryJones/VIP-Coding-Standards/builds/417613278).