### PR TITLE
Introduce reusable bash scripts

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,59 +3,18 @@ sudo: false
 dist: trusty
 
 cache:
-  apt: true
   directories:
-    # Cache directory for older Composer versions.
-    - $HOME/.composer/cache/files
-    # Cache directory for more recent Composer versions.
     - $HOME/.cache/composer/files
 
 language:
   - php
-
-php:
-  - 5.4
-  - 5.5
-  - 5.6
-  - 7.0
-  - 7.1
-  - 7.2
-  - nightly
-
-env:
-  # `master` is now 3.x.
-  - PHPCS_BRANCH="dev-master"
-  # Lowest supported release in the 3.x series with which VIPCS is compatible (and which can run the unit tests).
-  - PHPCS_BRANCH="3.1.0"
-
-matrix:
-  fast_finish: true
-  include:
-    # Run PHPCS against VIPCS, run PHP Lint, and run integration test
-    - php: 7.2
-      env: PHPCS_BRANCH="dev-master" SNIFF=1 INTEGRATION_TEST=1 LINT=1
-      addons:
-        apt:
-          packages:
-            - libxml2-utils
-  exclude:
-    # PHP 7.3 is known to fail with PHPCS < 3.3.1.
-    # @link https://github.com/squizlabs/PHP_CodeSniffer/issues/2086
-    - php: nightly
-      env: PHPCS_BRANCH="3.1.0"
-
-  allow_failures:
-    # Allow failures for unstable builds.
-    - php: nightly
 
 before_install:
   # Speed up build time by disabling Xdebug.
   # https://johnblackbourn.com/reducing-travis-ci-build-times-for-wordpress-projects/
   # https://twitter.com/kelunik/status/954242454676475904
   - phpenv config-rm xdebug.ini || echo 'No xdebug config.'
-  # Validate the composer.json file.
-  # @link https://getcomposer.org/doc/03-cli.md#validate
-  - composer validate --no-check-all --strict
+
   # Handle new PHP version with old PHPCS version. Version of PHPUnit 6 is the current latest release.
   - |
     if [[ ${TRAVIS_PHP_VERSION:0:2} == "7." && "$PHPCS_BRANCH" == "3.1.0" ]]; then
@@ -71,8 +30,6 @@ install:
   - if [[ "$USE_OLD_PHPUNIT" == "1" ]]; then wget -P "$PHPUNIT_DIR" "https://phar.phpunit.de/phpunit-$PHPUNIT6.phar" && chmod +x "$PHPUNIT_DIR/phpunit-$PHPUNIT6.phar"; fi
 
 script:
-  # Lint the PHP files against parse errors.
-  - if [[ "$LINT" == "1" ]]; then ./bin/php-lint; fi
   # Run the unit tests.
   - |
     if [[ "$USE_OLD_PHPUNIT" == "1" ]]; then
@@ -80,9 +37,113 @@ script:
     else
       ./bin/unit-tests
     fi
-  # Run PHPCS against VIPCS.
-  - if [[ "$SNIFF" == "1" ]]; then ./bin/phpcs; fi
-  # Validate the XML files and check the code-style consistency of the XML files.
-  - if [[ "$LINT" == "1" ]]; then ./bin/xml-lint; fi
+
   # Run integration test.
   - if [[ "$INTEGRATION_TEST" == "1" ]]; then ./bin/integration-test; fi
+
+# Rather than a `matrix` property, we use build stages. This allows early
+# build failure for basic linting and sniffing issues.
+# @link https://docs.travis-ci.com/user/build-stages/
+#
+# PHP >= 7.3 & PHPCS < 3.3.1 is known to fail.
+# @link https://github.com/squizlabs/PHP_CodeSniffer/issues/2086.
+#
+# We can't use Matrix Expansion here, since we need to exclude jobs for the known failures,
+# which Matrix Expansion does not yet support. We list each combination instead.
+# @link https://docs.travis-ci.com/user/conditional-builds-stages-jobs/#conditional-jobs
+
+stages:
+  - lint
+  - sniff
+  - test
+
+jobs:
+  allow_failure:
+    - php: nightly
+  fast_finish: true
+  include:
+
+    - stage: lint
+      php: 7.2
+      env: PHPCS_BRANCH="dev-master"
+      before_install: phpenv config-rm xdebug.ini || echo 'No xdebug config.'
+      install: false
+      cache: false
+      script:
+        # Lint the PHP files against parse errors.
+        - ./bin/php-lint
+
+        # Validate the XML files and check the code-style consistency of the XML files.
+        - ./bin/xml-lint
+
+        # Validate the composer.json file.
+        # @link https://getcomposer.org/doc/03-cli.md#validate
+        - composer validate --no-check-all --strict
+      addons:
+        apt:
+          packages:
+            - libxml2-utils
+
+    - stage: sniff
+      php: 7.2
+      env: PHPCS_BRANCH="dev-master"
+      before_install: phpenv config-rm xdebug.ini || echo 'No xdebug config.'
+      install: composer install --dev --no-suggest
+      script:
+        # Run PHPCS against VIPCS.
+        - ./bin/phpcs
+
+    # PHPCS_BRANCH="3.1.0" is the lowest supported release in the 3.x series with which VIPCS is compatible
+    # (and which can run the unit tests).
+    - stage: test
+      php: 5.4
+      env: PHPCS_BRANCH="dev-master"
+
+    - stage:
+      php: 5.4
+      env: PHPCS_BRANCH="3.1.0"
+
+    - stage:
+      php: 5.5
+      env: PHPCS_BRANCH="dev-master"
+
+    - stage:
+      php: 5.5
+      env: PHPCS_BRANCH="3.1.0"
+
+    - stage:
+      php: 5.6
+      env: PHPCS_BRANCH="dev-master"
+
+    - stage:
+      php: 5.6
+      env: PHPCS_BRANCH="3.1.0"
+
+    - stage:
+      php: 7.0
+      env: PHPCS_BRANCH="dev-master"
+
+    - stage:
+      php: 7.0
+      env: PHPCS_BRANCH="3.1.0"
+
+    - stage:
+      php: 7.1
+      env: PHPCS_BRANCH="dev-master"
+
+    - stage:
+      php: 7.1
+      env: PHPCS_BRANCH="3.1.0"
+
+    - stage:
+      php: 7.2
+      env: PHPCS_BRANCH="dev-master"
+
+    - stage:
+      php: 7.2
+      env: PHPCS_BRANCH="3.1.0"
+
+    # Only use PHPCS_BRANCH="dev-master" from this point.
+    - stage:
+      php: nightly
+      env: PHPCS_BRANCH="dev-master"

--- a/.travis.yml
+++ b/.travis.yml
@@ -58,10 +58,10 @@ before_install:
   - composer validate --no-check-all --strict
   # Handle new PHP version with old PHPCS version. Version of PHPUnit 6 is the current latest release.
   - |
-    if [[ "$TRAVIS_PHP_VERSION" == "7.2" && "$PHPCS_BRANCH" == "3.1.0" ]]; then
+    if [[ ${TRAVIS_PHP_VERSION:0:2} == "7." && "$PHPCS_BRANCH" == "3.1.0" ]]; then
       export USE_OLD_PHPUNIT="1"
       export PHPUNIT_DIR=/tmp/phpunit
-      export PHPUNIT6="6.5.11"
+      export PHPUNIT6="6.5.12"
     fi
 
 install:
@@ -72,29 +72,17 @@ install:
 
 script:
   # Lint the PHP files against parse errors.
-  - if [[ "$LINT" == "1" ]]; then if find . -path ./vendor -prune -o -path ./bin -prune -o -name "*.php" -exec php -l {} \; | grep "^[Parse error|Fatal error]"; then exit 1; fi; fi
+  - if [[ "$LINT" == "1" ]]; then ./bin/php-lint; fi
   # Run the unit tests.
   - |
     if [[ "$USE_OLD_PHPUNIT" == "1" ]]; then
       php "$PHPUNIT_DIR/phpunit-$PHPUNIT6.phar" --filter WordPressVIPMinimum "$(pwd)/vendor/squizlabs/php_codesniffer/tests/AllTests.php"
     else
-      phpunit --filter WordPressVIPMinimum "$(pwd)/vendor/squizlabs/php_codesniffer/tests/AllTests.php"
+      ./bin/unit-tests
     fi
   # Run PHPCS against VIPCS.
-  - if [[ "$SNIFF" == "1" ]]; then "$(pwd)/vendor/bin/phpcs" --runtime-set ignore_warnings_on_exit 1; fi
-  # Validate the XML files.
-  # @link http://xmlsoft.org/xmllint.html
-  - if [[ "$SNIFF" == "1" ]]; then xmllint --noout ./*/ruleset.xml; fi
-  # Check the code-style consistency of the XML files.
-  - |
-    if [[ "$SNIFF" == "1" ]]; then
-      export XMLLINT_INDENT="	"
-      diff -B --tabsize=4 ./WordPressVIPMinimum/ruleset.xml <(xmllint --format "./WordPressVIPMinimum/ruleset.xml")
-      diff -B --tabsize=4 ./WordPress-VIP-Go/ruleset.xml <(xmllint --format "./WordPress-VIP-Go/ruleset.xml")
-    fi
+  - if [[ "$SNIFF" == "1" ]]; then ./bin/phpcs; fi
+  # Validate the XML files and check the code-style consistency of the XML files.
+  - if [[ "$LINT" == "1" ]]; then ./bin/xml-lint; fi
   # Run integration test.
-  - |
-    if [[ "$INTEGRATION_TEST" == "1" ]]; then
-      export PHPCS_BIN="$(pwd)/vendor/bin/phpcs"
-      php ./ruleset_test.php
-    fi
+  - if [[ "$INTEGRATION_TEST" == "1" ]]; then ./bin/integration-test; fi

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,17 +1,31 @@
+# Contributing to VIP Coding Standards
+
 Hi, thank you for your interest in contributing to the VIP Coding Standards! We look forward to working with you.
 
-# Reporting Bugs
+## Reporting Bugs
 
 Before reporting a bug, you should check what sniff an error is coming from.
 Running `phpcs` with the `-s` flag will show the name of the sniff with each error.
 
 Bug reports containing a minimal code sample which can be used to reproduce the issue are highly appreciated as those are most easily actionable.
 
-## Upstream Issues
+### Upstream Issues
 
 Since VIPCS employs many sniffs that are part of PHPCS, and makes use of WordPress Coding Standards sniffs, sometimes an issue will be caused by a bug upstream and not in VIPCS itself. If the error message in question doesn't come from a sniff whose name starts with `WordPressVIPMinimum`, the issue is probably a bug in PHPCS itself, and should be [reported there](https://github.com/squizlabs/PHP_CodeSniffer/issues).
 
-# Contributing patches and new features
+----
+
+## tl;dr Composer Scripts
+
+This package contains Composer scripts to quickly run the developer checks which are described (with setups) further below.
+
+After `composer install`, you can do:
+
+ - `composer test`: **Run all checks and tests** - this should pass cleanly before you submit a pull request.
+     - `composer lint`: Just run PHP and XML linters.
+     - `composer phpcs`: Just run PHPCS against this package.
+     - `composer phpunit`: Just run the unit tests.
+     - `composer integration`: Just run the integration test.
 
 ## Branches
 
@@ -19,7 +33,9 @@ Ongoing development will be done in features branches then pulled against the `m
 
 To contribute an improvement to this project, fork the repo and open a pull request to the relevant branch. Alternatively, if you have push access to this repo, create a feature branch prefixed by `feature/` and then open an intra-repo PR from that branch to the right branch.
 
-# Considerations when writing sniffs
+## Code Standards for this project
+
+The sniffs and test files - not test _case_ files! - for VIPCS should be written such that they pass the `WordPress-Extra` and the `WordPress-Docs` code standards using the custom ruleset as found in `.phpcs.xml.dist`.
 
 ## Public properties
 
@@ -28,9 +44,9 @@ Only make a property `public` if that is the intended behaviour.
 
 When you introduce new `public` sniff properties, or your sniff extends a class from which you inherit a `public` property, please don't forget to update the [public properties wiki page](https://github.com/WordPress-Coding-Standards/WordPress-Coding-Standards/wiki/Customizable-sniff-properties) with the relevant details once your PR has been merged into the `develop` branch.
 
-# Unit Testing
+## Unit Testing
 
-## Pre-requisites
+### Pre-requisites
 * VIP Coding Standards
 * WordPress-Coding-Standards
 * PHP_CodeSniffer 3.x
@@ -47,7 +63,7 @@ If you already have PHPUnit installed on your system: Congrats, you're all set.
 If not, you can navigate to the directory where the `PHP_CodeSniffer` repo is checked out and do `composer install` to install the `dev` dependencies.
 Alternatively, you can [install PHPUnit](https://phpunit.de/manual/5.7/en/installation.html) as a PHAR file.
 
-## Before running the unit tests
+### Before running the unit tests
 
 N.B.: _If you used Composer to install the WordPress Coding Standards, you can skip this step._
 
@@ -67,7 +83,7 @@ The easiest way to do this is to add a `phpunit.xml` file to the root of your VI
 </phpunit>
 ```
 
-## Running the unit tests
+### Running the unit tests
 
 * Make sure you have registered the directory in which you installed VIPCS with PHPCS using;
     
@@ -92,7 +108,7 @@ Tests generated 29 unique error codes; 0 were fixable (0%)
 Time: 268 ms, Memory: 30.00MB
 ```
 
-## Unit Testing conventions
+### Unit Testing conventions
 
 If you look inside the `WordPressVIPMinimum/Tests` subdirectory, you'll see the structure mimics the `WordPressVIPMinimum/Sniffs` subdirectory structure. For example, the `WordPressVIPMinimum/Sniffs/VIP/WPQueryParams.php` sniff has its unit test class defined in `WordPressVIPMinimum/Tests/VIP/WPQueryParamsUnitTest.php` which checks the `WordPressVIPMinimum/Tests/VIP/WPQueryParamsUnitTest.inc` test case file. See the file naming convention?
 
@@ -152,7 +168,3 @@ FOUND 2 ERRORS AND 2 WARNINGS AFFECTING 4 LINES
 You'll see the line number and number of ERRORs we need to return in the `getErrorList()` method.
 
 The `--sniffs=...` directive limits the output to the sniff you are testing.
-
-## Code Standards for this project
-
-The sniffs and test files - not test _case_ files! - for VIPCS should be written such that they pass the `WordPress-Extra` and the `WordPress-Docs` code standards using the custom ruleset as found in `/bin/phpcs.xml`.

--- a/WordPress-VIP-Go/ruleset.xml
+++ b/WordPress-VIP-Go/ruleset.xml
@@ -12,7 +12,7 @@
 		<severity>6</severity>
 		<message>File system writes only work in /tmp/ and inside the /uploads/ folder on VIP Go. To do filesystem writes you must use the WP_Filesystem class, using functions such as %s() won't work or will return unexpected results. Read more here: https://vip.wordpress.com/documentation/using-wp_filesystem-instead-of-direct-file-access-functions/</message>
 	</rule>
-		<rule ref="WordPress.WP.AlternativeFunctions.file_system_read_fwrite">
+	<rule ref="WordPress.WP.AlternativeFunctions.file_system_read_fwrite">
 		<type>error</type>
 		<severity>5</severity>
 		<message>File system writes only work in /tmp/ and inside the /uploads/ folder on VIP Go. To do filesystem writes you must use the WP_Filesystem class, using functions such as %s() won't work or will return unexpected results. Read more here: https://vip.wordpress.com/documentation/using-wp_filesystem-instead-of-direct-file-access-functions/</message>

--- a/bin/integration-test
+++ b/bin/integration-test
@@ -1,0 +1,14 @@
+#!/usr/bin/env bash
+#
+# Run integration test.
+#
+# {description needed}
+#
+# EXAMPLE TO RUN LOCALLY:
+#
+#   ./bin/integration-test
+
+# Set PHPCS_BIN, which is used in the ruleset_test.php file.
+PHPCS_BIN="$(pwd)/vendor/bin/phpcs"
+export PHPCS_BIN
+php ./ruleset_test.php

--- a/bin/php-lint
+++ b/bin/php-lint
@@ -1,0 +1,22 @@
+#!/usr/bin/env bash
+#
+# Lint the PHP files against parse errors.
+#
+# The find utility recursively descends the directory tree for each path listed.
+#
+# find . = Start with all files in this package
+# -path ./vendor -prune = But remove those in the vendor directory
+# -o -path ./bin -prune = And remove those in the bin directory
+# -o -path ./.git -prune = And remove those in the .git directory
+# -o -name "*.php" = And only consider those with a .php extension
+# -exec php -l {} = Run PHP linter on the remaining files
+# | grep "^[Parse error|Fatal error]" = Look in the results for any parse or fatal errors.
+#
+# EXAMPLE TO RUN LOCALLY:
+#
+#   ./bin/php-lint
+#
+
+if find . -path ./vendor -prune -o -path ./bin -prune -o -path ./.git -prune -o -name "*.php" -exec php -l -f {} \; | grep "^[Errors parsing]"; then
+    exit 1;
+fi

--- a/bin/phpcs
+++ b/bin/phpcs
@@ -1,0 +1,12 @@
+#!/usr/bin/env bash
+#
+# Run PHPCS against VIP Coding Standards.
+#
+# This ensures that the code in the Sniffs and Tests follow the rules
+# defined in the custom ruleset for this repo, `.phpcs.xml.dist`.
+#
+# EXAMPLE TO RUN LOCALLY:
+#
+#   ./bin/phpcs
+
+"$(pwd)/vendor/bin/phpcs" --runtime-set ignore_warnings_on_exit 1

--- a/bin/unit-tests
+++ b/bin/unit-tests
@@ -1,0 +1,13 @@
+#!/usr/bin/env bash
+#
+# Run the unit tests.
+#
+# This ensures that the logic in the VIP sniffs is correct,
+# by running them against the .inc files in /tests.
+#
+# EXAMPLE TO RUN LOCALLY:
+#
+#   ./bin/unit-tests
+#
+
+"$(pwd)/vendor/bin/phpunit" --filter WordPressVIPMinimum "$(pwd)/vendor/squizlabs/php_codesniffer/tests/AllTests.php"

--- a/bin/xml-lint
+++ b/bin/xml-lint
@@ -1,0 +1,17 @@
+#!/usr/bin/env bash
+#
+# Check XML files.
+#
+# @link http://xmlsoft.org/xmllint.html
+#
+# EXAMPLE TO RUN LOCALLY:
+#
+#   ./bin/xml-lint
+
+# Validate the ruleset XML files.
+xmllint --noout ./*/ruleset.xml
+
+# Check the code-style consistency of the XML files.
+export XMLLINT_INDENT="	" # This is a tab character.
+diff -B --tabsize=4 ./WordPressVIPMinimum/ruleset.xml <(xmllint --format "./WordPressVIPMinimum/ruleset.xml")
+diff -B --tabsize=4 ./WordPress-VIP-Go/ruleset.xml <(xmllint --format "./WordPress-VIP-Go/ruleset.xml")

--- a/composer.json
+++ b/composer.json
@@ -15,7 +15,8 @@
 		"wp-coding-standards/wpcs": "1.*"
 	},
 	"require-dev" : {
-		"phpcompatibility/php-compatibility": "^8"
+		"phpcompatibility/php-compatibility": "^8",
+		"phpunit/phpunit": "*"
 	},
 	"suggest" : {
 		"dealerdirect/phpcodesniffer-composer-installer": "^0.4.3 || This Composer plugin will sort out the PHPCS 'installed_paths' automatically."
@@ -30,6 +31,19 @@
 	"scripts"    : {
 		"install-codestandards": "\"vendor/bin/phpcs\" --config-set installed_paths ../../..,../../wp-coding-standards/wpcs,../../phpcompatibility/php-compatibility",
 		"post-install-cmd": "@install-codestandards",
-		"post-update-cmd" : "@install-codestandards"
+		"post-update-cmd" : "@install-codestandards",
+		"lint": [
+			"bin/php-lint",
+			"bin/xml-lint"
+		],
+		"phpcs": "bin/phpcs",
+		"phpunit": "bin/unit-tests",
+		"integration": "bin/integration-test",
+		"test": [
+		    "@lint",
+		    "@phpcs",
+		    "@integration",
+		    "@phpunit"
+		]
 	}
 }


### PR DESCRIPTION
There are two commits in this PR:
 1. Introduce re-usable bash scripts, and have Composer and Travis use them.
 1. Split the updated Travis config to use Build Stages.

The first commit also incorporates PR #208, so that can be closed unmerged once this is merged.

## Reusable Scripts (1st commit)

A typical Travis config file is a YAML file containing shell scripts. This makes it a little painful to manage:

 - mixing YAML syntax requirements and shell syntax in the same lines takes unnecessary brain power to follow, and a competent IDE to highlight correctly.
 - scripts are not reusable locally, meaning the logic has to be reimplemented manually.
 - scripts are not fully documented, making much of the Travis config tricky for new developers to understand.

Within the Travis config file, I identified five main non-trivial tasks:

- PHP linting (finding and looping through the relevant PHP files)
- XML linting (running (globally installed - not ideal) Xmllint against the rulesets config files in different ways)
- Running the unit tests (including referencing a path deep inside PHPCS itself)
- Running the integration test
- Running PHPCS against VIPCS itself.

There are other tasks, like validating the Composer file which I've not moved into a script, since this is more trivial.

The first commit moves the logic for the tasks into `bin/*` shell script files (which have an executable bit set). There are fives scripts and they can be run individually, and being individual files, most terminals will allow them to autocomplete:

![screenshot showing five scripts being run in the terminal](https://user-images.githubusercontent.com/88371/44629362-17fc0f80-a946-11e8-8104-3901ad207d31.png)

The individual names of these files can be updated if needed.

The individual files contain a little or a lot more documentation about what the command is doing, which should help with future maintenance and understanding. No doubt this documentation could be interated on further.

The scripts have been run through https://www.shellcheck.net/.

Here's what failures in the PHP and XML lints look like:

![screenshot showing failures](https://user-images.githubusercontent.com/88371/44629768-97d8a880-a94b-11e8-97ae-88bb52f87f19.png)


### Composer Scripts

These scripts can be made more discoverable, by adding them as Composer scripts:

![screenshot showing five composer scripts being run in the terminal](https://user-images.githubusercontent.com/88371/44629389-893bc280-a946-11e8-851a-6ea44d45079c.png)

You can see that I've called the two linting shell scripts from the same Composer script.

Again, these Composer scripts names can be updated if needed.

### `composer test`

Composer scripts can run other Composer scripts. Here, I've added a `composer test` which runs all five tasks in one go:

![screenshot showing composer test script being run in the terminal](https://user-images.githubusercontent.com/88371/44629474-dbc9ae80-a947-11e8-8ed0-1b569488f28e.png)

This script name can be up for discussion - as you can see, my OhMyZsh setup tries to autocorrect it to `composer tests`, so picking a different name for this tasks would save developer frustration.

If `composer test` passes locally, then there's a strong chance that the commit / PR will pass on Travis as well.

## Documentation

I've added a short note to the `CONTRIBUTING.md` document suggesting that `composer test` be used and pass cleanly before a PR will be accepted. I also re-ordered a couple of bits and changed heading levels in the document to incorporate this note.

----

## Travis Build Stages (2nd commit)

The issue with the original approach, is that pPHPhp linting, XML linting and PHPCS (against VIPCS) were all done as the very last job in a Travis Build. Obviously, having invalid PHP, or invalid XML files is going to potentially affect every single job to make it error or fail, but this would be reported until each job has taken it's time to fail.

Build stages allow one job to complete before others are started.

In this case, for the second commit, I've changed it so that the linting and PHPCS checks are completed, once, before the unit and integration tests are run against multiple combinations of PHP and PHPCS. You can see the result on my fork [here](https://travis-ci.com/GaryJones/VIP-Coding-Standards/builds/82899767) or check the build for this PR.

I've optimised the stages where possible (i.e. not doing a `composer install` when only linting files), and added more documentation (and whitespace) to make maintenance easier.

### Future Improvements

There are a few potential optimisations for this Travis build config:

 - Bump the minimum supported version of PHPCS (#198).
  While we currently support PHPCS `^3.0.2`, we can only test down to `3.1.0`, and even then that requires pulling in a PHPUnit 6 PHAR file to use instead of the default PHPUnit 7 Composer package. The earliest version of PHPCS that [claims to support PHPUnit 7](https://github.com/squizlabs/PHP_CodeSniffer/blob/4842476c434e375f9d3182ff7b89059583aa8b27/composer.json#L34) is PHPCS `3.2.2`. Note that [support for PHPUnit 6 ends on February 1, 2019](https://phpunit.de/).
 - Remove some versions of PHP from Travis build.
  VIP Go production currently runs PHP 7.2. We run two Travis jobs for every x.y version of PHP from 7.2 back to 5.4 (one for PHPCS `master` and one for `3.1.0`). We also run a job for PHPCS `master` against PHP nightly. We could remove some intermediate versions (like PHP 5.5, PHP 7.0, PHP 7.1), or make a case for only running the tasks against PHP 7.2.