### PR TITLE
Downgrade severity of StrictComparisons

### DIFF
--- a/WordPress-VIP-Go/ruleset.xml
+++ b/WordPress-VIP-Go/ruleset.xml
@@ -231,7 +231,7 @@
 	</rule>
 	<rule ref="WordPress.PHP.StrictComparisons.LooseComparison">
 		<type>warning</type>
-		<severity>3</severity>
+		<severity>2</severity>
 	</rule>
 	<rule ref="WordPress.CodeAnalysis.AssignmentInCondition.Found">
 		<type>warning</type>


### PR DESCRIPTION
As per #164, let's downgrade the severity of `==. Use strict comparisons (=== or !==)` to a 2.