### PR TITLE
Downgrade severity of Variable assignment condition rule

### DIFF
--- a/WordPress-VIP-Go/ruleset.xml
+++ b/WordPress-VIP-Go/ruleset.xml
@@ -233,6 +233,10 @@
 		<type>warning</type>
 		<severity>3</severity>
 	</rule>
+	<rule ref="WordPress.CodeAnalysis.AssignmentInCondition.Found">
+		<type>warning</type>
+		<severity>1</severity>
+	</rule>
 	<rule ref="WordPressVIPMinimum.Files.IncludingFile.IncludingFile">
 		<type>warning</type>
 		<severity>3</severity>
@@ -305,10 +309,6 @@
 	</rule>
 	<rule ref="WordPress.DB.SlowDBQuery.slow_db_query_meta_key">
 		<!-- We are silencing this one because VIP Go has a combined index on meta_key, meta_value-->
-		<severity>0</severity>
-	</rule>
-	<rule ref="WordPress.CodeAnalysis.AssignmentInCondition.Found">
-		<!-- This is a false positive 99.9% of the time -->
 		<severity>0</severity>
 	</rule>
 

--- a/WordPress-VIP-Go/ruleset.xml
+++ b/WordPress-VIP-Go/ruleset.xml
@@ -233,10 +233,6 @@
 		<type>warning</type>
 		<severity>3</severity>
 	</rule>
-	<rule ref="WordPress.CodeAnalysis.AssignmentInCondition.Found">
-		<type>warning</type>
-		<severity>3</severity>
-	</rule>
 	<rule ref="WordPressVIPMinimum.Files.IncludingFile.IncludingFile">
 		<type>warning</type>
 		<severity>3</severity>
@@ -309,6 +305,10 @@
 	</rule>
 	<rule ref="WordPress.DB.SlowDBQuery.slow_db_query_meta_key">
 		<!-- We are silencing this one because VIP Go has a combined index on meta_key, meta_value-->
+		<severity>0</severity>
+	</rule>
+	<rule ref="WordPress.CodeAnalysis.AssignmentInCondition.Found">
+		<!-- This is a false positive 99.9% of the time -->
 		<severity>0</severity>
 	</rule>
 


### PR DESCRIPTION
`Variable assignment found within a condition. Did you mean to do a comparison?`

I find that this flags a false positive 99.9999% of the time since it's more of a...coding style? Would be nice to remove altogether for noise purposes on Go.