### PR TITLE
Fix detection of double quotes, add additional server variables and u…

### DIFF
--- a/WordPressVIPMinimum/Sniffs/Variables/ServerVariablesSniff.php
+++ b/WordPressVIPMinimum/Sniffs/Variables/ServerVariablesSniff.php
@@ -27,7 +27,7 @@ class ServerVariablesSniff implements Sniff {
 		'PHP_AUTH_PW',
 		'HTTP_X_IP_TRAIL',
 		'HTTP_X_FORWARDED_FOR',
-		'REMOTE_ADDR'
+		'REMOTE_ADDR',
 	);
 
 	/**
@@ -59,7 +59,7 @@ class ServerVariablesSniff implements Sniff {
 		}
 
 		$variableNamePtr = $phpcsFile->findNext( array( T_CONSTANT_ENCAPSED_STRING ), ( $stackPtr + 1 ), null, false, null, true );
-		$variableName    = str_replace( array( "'", "\"" ), '', $tokens[ $variableNamePtr ]['content'] );
+		$variableName    = str_replace( array( "'", '"' ), '', $tokens[ $variableNamePtr ]['content'] );
 
 		if ( false === in_array( $variableName, $this->restrictedVariables, true ) ) {
 			// Not the variable we are looking for.
@@ -68,11 +68,11 @@ class ServerVariablesSniff implements Sniff {
 
 		if ( 'PHP_AUTH_PW' === $variableName ) {
 			$phpcsFile->addError( 'Basic authentication should not be handled via PHP code.', $stackPtr, 'ServerVariables' );
-		} else if ( 'HTTP_X_IP_TRAIL' === $variableName || 'HTTP_X_FORWARDED_FOR' === $variableName || 'REMOTE_ADDR' === $variableName ) {
-			$phpcsFile->addError( 
-				sprintf( 'Header "%s" is user-controlled and should be properly validated before use.', $variableName ), 
-				$stackPtr, 
-				'UserControlledHeaders' 
+		} elseif ( 'HTTP_X_IP_TRAIL' === $variableName || 'HTTP_X_FORWARDED_FOR' === $variableName || 'REMOTE_ADDR' === $variableName ) {
+			$phpcsFile->addError(
+				sprintf( 'Header "%s" is user-controlled and should be properly validated before use.', $variableName ),
+				$stackPtr,
+				'UserControlledHeaders'
 			);
 		}
 	}

--- a/WordPressVIPMinimum/Sniffs/Variables/ServerVariablesSniff.php
+++ b/WordPressVIPMinimum/Sniffs/Variables/ServerVariablesSniff.php
@@ -25,6 +25,9 @@ class ServerVariablesSniff implements Sniff {
 	 */
 	public $restrictedVariables = array(
 		'PHP_AUTH_PW',
+		'HTTP_X_IP_TRAIL',
+		'HTTP_X_FORWARDED_FOR',
+		'REMOTE_ADDR'
 	);
 
 	/**
@@ -56,14 +59,22 @@ class ServerVariablesSniff implements Sniff {
 		}
 
 		$variableNamePtr = $phpcsFile->findNext( array( T_CONSTANT_ENCAPSED_STRING ), ( $stackPtr + 1 ), null, false, null, true );
-		$variableName    = str_replace( "'", '', $tokens[ $variableNamePtr ]['content'] );
+		$variableName    = str_replace( array( "'", "\"" ), '', $tokens[ $variableNamePtr ]['content'] );
 
 		if ( false === in_array( $variableName, $this->restrictedVariables, true ) ) {
 			// Not the variable we are looking for.
 			return;
 		}
 
-		$phpcsFile->addError( 'Basic authentication should not be handled via PHP code.', $stackPtr, 'ServerVariables' );
+		if ( 'PHP_AUTH_PW' === $variableName ) {
+			$phpcsFile->addError( 'Basic authentication should not be handled via PHP code.', $stackPtr, 'ServerVariables' );
+		} else if ( 'HTTP_X_IP_TRAIL' === $variableName || 'HTTP_X_FORWARDED_FOR' === $variableName || 'REMOTE_ADDR' === $variableName ) {
+			$phpcsFile->addError( 
+				sprintf( 'Header "%s" is user-controlled and should be properly validated before use.', $variableName ), 
+				$stackPtr, 
+				'UserControlledHeaders' 
+			);
+		}
 	}
 
 }

--- a/WordPressVIPMinimum/Tests/Variables/ServerVariablesUnitTest.inc
+++ b/WordPressVIPMinimum/Tests/Variables/ServerVariablesUnitTest.inc
@@ -4,7 +4,6 @@
 $_SERVER['PHP_AUTH_PW']; 
 $_SERVER['HTTP_X_IP_TRAIL'];
 $_SERVER['HTTP_X_FORWARDED_FOR'];  
-// let's test one with double quotes too
-$_SERVER["REMOTE_ADDR"];
+$_SERVER["REMOTE_ADDR"]; 	// let's test one with double quotes too
 
 $_SERVER['SOME_OTHER_VARIABLE']; // We don't care.

--- a/WordPressVIPMinimum/Tests/Variables/ServerVariablesUnitTest.inc
+++ b/WordPressVIPMinimum/Tests/Variables/ServerVariablesUnitTest.inc
@@ -1,5 +1,10 @@
 <?php
 
-$_SERVER['PHP_AUTH_PW']; // Bad. Should never happen.
+// Bad variables. Should never happen.
+$_SERVER['PHP_AUTH_PW']; 
+$_SERVER['HTTP_X_IP_TRAIL'];
+$_SERVER['HTTP_X_FORWARDED_FOR'];  
+// let's test one with double quotes too
+$_SERVER["REMOTE_ADDR"];
 
 $_SERVER['SOME_OTHER_VARIABLE']; // We don't care.

--- a/WordPressVIPMinimum/Tests/Variables/ServerVariablesUnitTest.php
+++ b/WordPressVIPMinimum/Tests/Variables/ServerVariablesUnitTest.php
@@ -26,7 +26,7 @@ class ServerVariablesUnitTest extends AbstractSniffUnitTest {
 			4 => 1,
 			5 => 1,
 			6 => 1,
-			8 => 1
+			8 => 1,
 		);
 	}
 

--- a/WordPressVIPMinimum/Tests/Variables/ServerVariablesUnitTest.php
+++ b/WordPressVIPMinimum/Tests/Variables/ServerVariablesUnitTest.php
@@ -23,7 +23,10 @@ class ServerVariablesUnitTest extends AbstractSniffUnitTest {
 	 */
 	public function getErrorList() {
 		return array(
-			3 => 1,
+			4 => 1,
+			5 => 1,
+			6 => 1,
+			8 => 1
 		);
 	}
 

--- a/WordPressVIPMinimum/Tests/Variables/ServerVariablesUnitTest.php
+++ b/WordPressVIPMinimum/Tests/Variables/ServerVariablesUnitTest.php
@@ -26,7 +26,7 @@ class ServerVariablesUnitTest extends AbstractSniffUnitTest {
 			4 => 1,
 			5 => 1,
 			6 => 1,
-			8 => 1,
+			7 => 1,
 		);
 	}
 


### PR DESCRIPTION
As per #20, this PR adds the additional server variables and updates the related unit tests.

In addition, it also detects the usage of double quotes.

E.g.
```
echo $_SERVER[ "REMOTE_ADDR" ];
```