### PR TITLE
Composer: Bump to PHPCompatibility ^9

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -15,7 +15,7 @@
 		"wp-coding-standards/wpcs": "1.*"
 	},
 	"require-dev" : {
-		"phpcompatibility/php-compatibility": "^8",
+		"phpcompatibility/php-compatibility": "^9",
 		"phpunit/phpunit": "*"
 	},
 	"suggest" : {


### PR DESCRIPTION
See https://github.com/PHPCompatibility/PHPCompatibility/releases/tag/9.0.0

PHPCS still passes cleanly:

![screenshot 2018-10-08 10 21 11](https://user-images.githubusercontent.com/88371/46601040-f44eec00-cae3-11e8-888a-437862ecb32a.png)
