### PR TITLE
Docs: Update VIP link references

### DIFF
--- a/WordPressVIPMinimum/ruleset.xml
+++ b/WordPressVIPMinimum/ruleset.xml
@@ -2,6 +2,10 @@
 <ruleset name="WordPress VIP Minimum">
 	<description>WordPress VIP Minimum Coding Standards</description>
 
+	<!-- Link references are platform-specific. See
+		https://vip.wordpress.com/documentation/vip-go/understanding-codebase-differences/
+		for the differences between the platforms -->
+
 	<autoload>./PHPCSCompatibility.php</autoload>
 
 	<rule ref="WordPressVIPMinimum.TemplatingEngines.UnescapedOutputTwig">
@@ -16,7 +20,7 @@
 	<rule ref="WordPress.Security.EscapeOutput"/>
 	<rule ref="WordPress.Security.NonceVerification"/>
 	<rule ref="WordPress.WP.EnqueuedResources"/>
-	
+
 	<rule ref="WordPress.DB.PreparedSQL"/>
 	<rule ref="WordPress.WP.GlobalVariablesOverride"/>
 	<rule ref="WordPress.PHP.StrictComparisons"/>
@@ -38,14 +42,16 @@
 	</rule>
 	<rule ref="Squiz.PHP.CommentedOutCode"/>
 
-	<!-- https://vip.wordpress.com/documentation/vip/code-review-what-we-look-for/#eval-and-create_function -->
+	<!-- WordPress.com: https://lobby.vip.wordpress.com/wordpress-com-documentation/code-review-what-we-look-for/#eval-create_function -->
+	<!-- VIP-Go: https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/#eval-and-create_function -->
 	<rule ref="Squiz.PHP.Eval"/>
 	<rule ref="Squiz.PHP.Eval.Discouraged">
 		<type>error</type>
 		<message>`eval()` is a security risk so not allowed.</message>
 	</rule>
 
-	<!-- https://vip.wordpress.com/documentation/vip/code-review-what-we-look-for/#settings-alteration -->
+	<!-- WordPress.com: https://lobby.vip.wordpress.com/wordpress-com-documentation/code-review-what-we-look-for/#settings-alteration -->
+	<!-- VIP-Go: https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/#settings-alteration -->
 	<rule ref="WordPress.PHP.DiscouragedPHPFunctions">
 		<!-- https://github.com/WordPress-Coding-Standards/WordPress-Coding-Standards/pull/633#issuecomment-266634811 -->
 		<properties>
@@ -86,12 +92,14 @@
 		<type>error</type>
 	</rule>
 
-	<!-- https://vip.wordpress.com/documentation/code-review-what-we-look-for/#commented-out-code-debug-code-or-output -->
+	<!-- WordPress.com: https://lobby.vip.wordpress.com/wordpress-com-documentation/code-review-what-we-look-for/#commented-out-code-debug-code-or-output -->
+	<!-- VIP-Go: https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/#commented-out-code-debug-code-or-output -->
 	<rule ref="WordPress.PHP.DevelopmentFunctions">
-		<!-- this is being covered in terms of WordPress.PHP.DiscouragedPHPFunctions sniff -->
+		<!-- This is being covered in terms of WordPress.PHP.DiscouragedPHPFunctions sniff -->
 		<exclude name="WordPress.PHP.DevelopmentFunctions.prevent_path_disclosure_error_reporting"/>
 	</rule>
-	<!-- https://vip.wordpress.com/documentation/vip/code-review-what-we-look-for/#settings-alteration -->
+	<!-- WordPress.com: https://lobby.vip.wordpress.com/wordpress-com-documentation/code-review-what-we-look-for/#settings-alteration -->
+	<!-- VIP-Go: https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/#settings-alteration -->
 	<rule ref="WordPress.PHP.DevelopmentFunctions.prevent_path_disclosure">
 		<type>error</type>
 	</rule>
@@ -99,10 +107,12 @@
 		<type>error</type>
 	</rule>
 
-	<!-- https://vip.wordpress.com/documentation/vip/code-review-what-we-look-for/#use-wp_parse_url-instead-of-parse_url -->
-	<!-- https://vip.wordpress.com/documentation/vip/code-review-what-we-look-for/#use-wp_json_encode-over-json_encode -->
-	<!-- https://vip.wordpress.com/documentation/vip/code-review-what-we-look-for/#filesystem-writes -->
-	<!-- https://vip.wordpress.com/documentation/vip/code-review-what-we-look-for/#remote-calls -->
+	<!-- WordPress.com: https://lobby.vip.wordpress.com/wordpress-com-documentation/code-review-what-we-look-for/#wp_json_encode-over-json_encode -->
+	<!-- WordPress.com: https://lobby.vip.wordpress.com/wordpress-com-documentation/code-review-what-we-look-for/#filesystem-writes -->
+	<!-- WordPress.com: https://lobby.vip.wordpress.com/wordpress-com-documentation/code-review-what-we-look-for/#remote-calls -->
+	<!-- VIP-Go: https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/#use-wp_json_encode-over-json_encode -->
+	<!-- VIP-Go: https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/#filesystem-operations -->
+	<!-- VIP-Go: https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/#remote-calls -->
 	<rule ref="WordPress.WP.AlternativeFunctions">
 		<exclude name="WordPress.WP.AlternativeFunctions.file_get_contents_file_get_contents"/>
 	</rule>


### PR DESCRIPTION
The WordPress.com VIP team moved the coding standards documentation around, since they now have different documents for their different platforms:

- [WPCOM platform](https://lobby.vip.wordpress.com/wordpress-com-documentation/code-review-what-we-look-for/) (only available to those with VIP Lobby access)
- [VIP-Go platform](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)

This updates the out of date references for links to the Lobby.

See https://github.com/Automattic/vip-issues/issues/160