### PR TITLE
Detect filter not passed in PHP filter_* functions

### DIFF
--- a/WordPress-VIP-Go/ruleset.xml
+++ b/WordPress-VIP-Go/ruleset.xml
@@ -108,6 +108,18 @@
 		<type>warning</type>
 		<severity>10</severity>
 	</rule>
+	<rule ref="WordPressVIPMinimum.VIP.PHPFilterFunctions.MissingSecondParameter">
+		<type>warning</type>
+		<severity>10</severity>
+	</rule>
+	<rule ref="WordPressVIPMinimum.VIP.PHPFilterFunctions.MissingThirdParameter">
+		<type>warning</type>
+		<severity>10</severity>
+	</rule>
+	<rule ref="WordPressVIPMinimum.VIP.PHPFilterFunctions.RestrictedFilter">
+		<type>warning</type>
+		<severity>10</severity>
+	</rule>
 	<rule ref="WordPressVIPMinimum.VIP.RestrictedFunctions.dbDelta_dbdelta">
 		<type>warning</type>
 		<severity>7</severity>

--- a/WordPressVIPMinimum/Sniffs/VIP/PHPFilterFunctionsSniff.php
+++ b/WordPressVIPMinimum/Sniffs/VIP/PHPFilterFunctionsSniff.php
@@ -34,9 +34,9 @@ class PHPFilterFunctionsSniff extends AbstractFunctionParameterSniff {
 	 *            depending on your needs.
 	 */
 	protected $target_functions = [
-		'filter_var' => true,
-		'filter_input' => true,
-		'filter_var_array' => true,
+		'filter_var'         => true,
+		'filter_input'       => true,
+		'filter_var_array'   => true,
 		'filter_input_array' => true,
 	];
 
@@ -46,7 +46,7 @@ class PHPFilterFunctionsSniff extends AbstractFunctionParameterSniff {
 	 * @var array
 	 */
 	private $restricted_filters = [
-		'FILTER_DEFAULT' => true,
+		'FILTER_DEFAULT'    => true,
 		'FILTER_UNSAFE_RAW' => true,
 	];
 

--- a/WordPressVIPMinimum/Sniffs/VIP/PHPFilterFunctionsSniff.php
+++ b/WordPressVIPMinimum/Sniffs/VIP/PHPFilterFunctionsSniff.php
@@ -1,0 +1,98 @@
+<?php
+/**
+ * WordPressVIPMinimum Coding Standard.
+ *
+ * @package VIPCS\WordPressVIPMinimum
+ */
+
+namespace WordPressVIPMinimum\Sniffs\VIP;
+
+use WordPress\AbstractFunctionParameterSniff;
+
+/**
+ * This sniff ensures that proper sanitization is occurring when PHP's filter_* functions are used.
+ *
+ * @package VIPCS\WordPressVIPMinimum
+ *
+ * @since 0.4.0
+ */
+class PHPFilterFunctionsSniff extends AbstractFunctionParameterSniff {
+
+	/**
+	 * The group name for this group of functions.
+	 *
+	 * @var string
+	 */
+	protected $group_name = 'php_filter_functions';
+
+	/**
+	 * Functions this sniff is looking for.
+	 *
+	 * @var array The only requirement for this array is that the top level
+	 *            array keys are the names of the functions you're looking for.
+	 *            Other than that, the array can have arbitrary content
+	 *            depending on your needs.
+	 */
+	protected $target_functions = [
+		'filter_var' => true,
+		'filter_input' => true,
+		'filter_var_array' => true,
+		'filter_input_array' => true,
+	];
+
+	/**
+	 * List of restricted filter names.
+	 *
+	 * @var array
+	 */
+	private $restricted_filters = [
+		'FILTER_DEFAULT' => true,
+		'FILTER_UNSAFE_RAW' => true,
+	];
+
+	/**
+	 * Process the parameters of a matched function.
+	 *
+	 * @param int    $stackPtr        The position of the current token in the stack.
+	 * @param array  $group_name      The name of the group which was matched.
+	 * @param string $matched_content The token content (function name) which was matched.
+	 * @param array  $parameters      Array with information about the parameters.
+	 * @return int|void Integer stack pointer to skip forward or void to continue
+	 *                  normal file processing.
+	 */
+	public function process_parameters( $stackPtr, $group_name, $matched_content, $parameters ) {
+		if ( 'filter_input' === $matched_content ) {
+			if ( 2 === count( $parameters ) ) {
+				$this->phpcsFile->addWarning(
+					sprintf( 'Missing third parameter for "%s".', $matched_content ),
+					$stackPtr,
+					'MissingThirdParameter'
+				);
+			}
+
+			if ( isset( $parameters[3] ) && isset( $this->restricted_filters[ $parameters[3]['raw'] ] ) ) {
+				$this->phpcsFile->addWarning(
+					sprintf( 'Please use an appropriate filter to sanitize, as "%s" does no filtering, see: http://php.net/manual/en/filter.filters.sanitize.php.', strtoupper( $parameters[3]['raw'] ) ),
+					$stackPtr,
+					'RestrictedFilter'
+				);
+			}
+		} else {
+			if ( 1 === count( $parameters ) ) {
+				$this->phpcsFile->addWarning(
+					sprintf( 'Missing second parameter for "%s".', $matched_content ),
+					$stackPtr,
+					'MissingSecondParameter'
+				);
+			}
+
+			if ( isset( $parameters[2] ) && isset( $this->restricted_filters[ $parameters[2]['raw'] ] ) ) {
+				$this->phpcsFile->addWarning(
+					sprintf( 'Please use an appropriate filter to sanitize, as "%s" does no filtering, see http://php.net/manual/en/filter.filters.sanitize.php.', strtoupper( $parameters[2]['raw'] ) ),
+					$stackPtr,
+					'RestrictedFilter'
+				);
+			}
+		}
+	}
+}

--- a/WordPressVIPMinimum/Tests/VIP/PHPFilterFunctionsUnitTest.inc
+++ b/WordPressVIPMinimum/Tests/VIP/PHPFilterFunctionsUnitTest.inc
@@ -9,16 +9,21 @@ filter_var( $url, FILTER_SANITIZE_URL );
 filter_var( 'test', FILTER_SANITIZE_STRING );
 filter_var(  "test", FILTER_SANITIZE_STRING );
 filter_input( INPUT_GET, 'foo', FILTER_SANITIZE_STRING );
+filter_input( INPUT_GET,  "foo"   , FILTER_SANITIZE_STRING );
 filter_var_array( $array, FILTER_SANITIZE_STRING );
 filter_input_array( $array, FILTER_SANITIZE_STRING );
+filter_input_array( $array,FILTER_SANITIZE_STRING      );
 
-// Errors.
+// Bad.
 filter_input( INPUT_GET, 'foo' ); // Missing third parameter.
 filter_input( INPUT_GET, 'foo', FILTER_DEFAULT ); // This filter ID does nothing.
-filter_input( INPUT_GET, "foo", FILTER_DEFAULT  ); // This filter ID does nothing.
+filter_input( INPUT_GET, "foo", FILTER_UNSAFE_RAW  ); // This filter ID does nothing.
 filter_var( $url ); // Missing second parameter.
 filter_var( $url, FILTER_DEFAULT ); // This filter ID does nothing.
 filter_var( 'https://google.com', FILTER_UNSAFE_RAW ); // This filter ID does nothing.
 filter_var_array( $array ); // Missing second parameter.
 filter_var_array( $array, FILTER_DEFAULT ); // This filter ID does nothing.
 filter_var_array( $array, FILTER_UNSAFE_RAW ); // This filter ID does nothing.
+filter_input_array( $array ); // Missing second parameter.
+filter_input_array( $array, FILTER_DEFAULT ); // This filter ID does nothing.
+filter_input_array( $array, FILTER_UNSAFE_RAW ); // This filter ID does nothing.

--- a/WordPressVIPMinimum/Tests/VIP/PHPFilterFunctionsUnitTest.inc
+++ b/WordPressVIPMinimum/Tests/VIP/PHPFilterFunctionsUnitTest.inc
@@ -1,0 +1,24 @@
+<?php
+
+$url = 'http://www.google.ca';
+$_GET['foo'] = 'bar';
+$array = [ 'something_something', 'https://www.google.com', '6' ];
+
+// Ok.
+filter_var( $url, FILTER_SANITIZE_URL );
+filter_var( 'test', FILTER_SANITIZE_STRING );
+filter_var(  "test", FILTER_SANITIZE_STRING );
+filter_input( INPUT_GET, 'foo', FILTER_SANITIZE_STRING );
+filter_var_array( $array, FILTER_SANITIZE_STRING );
+filter_input_array( $array, FILTER_SANITIZE_STRING );
+
+// Errors.
+filter_input( INPUT_GET, 'foo' ); // Missing third parameter.
+filter_input( INPUT_GET, 'foo', FILTER_DEFAULT ); // This filter ID does nothing.
+filter_input( INPUT_GET, "foo", FILTER_DEFAULT  ); // This filter ID does nothing.
+filter_var( $url ); // Missing second parameter.
+filter_var( $url, FILTER_DEFAULT ); // This filter ID does nothing.
+filter_var( 'https://google.com', FILTER_UNSAFE_RAW ); // This filter ID does nothing.
+filter_var_array( $array ); // Missing second parameter.
+filter_var_array( $array, FILTER_DEFAULT ); // This filter ID does nothing.
+filter_var_array( $array, FILTER_UNSAFE_RAW ); // This filter ID does nothing.

--- a/WordPressVIPMinimum/Tests/VIP/PHPFilterFunctionsUnitTest.php
+++ b/WordPressVIPMinimum/Tests/VIP/PHPFilterFunctionsUnitTest.php
@@ -1,0 +1,47 @@
+<?php
+/**
+ * Unit test class for WordPressVIPMinimum Coding Standard.
+ *
+ * @package VIPCS\WordPressVIPMinimum
+ */
+
+namespace WordPressVIPMinimum\Tests\VIP;
+
+use PHP_CodeSniffer\Tests\Standards\AbstractSniffUnitTest;
+
+/**
+ * Unit test class for the WP_Query params sniff.
+ *
+ * @package VIPCS\WordPressVIPMinimum
+ */
+class PHPFilterFunctionsUnitTest extends AbstractSniffUnitTest {
+
+	/**
+	 * Returns the lines where errors should occur.
+	 *
+	 * @return array <int line number> => <int number of errors>
+	 */
+	public function getErrorList() {
+		return array();
+	}
+
+	/**
+	 * Returns the lines where warnings should occur.
+	 *
+	 * @return array <int line number> => <int number of warnings>
+	 */
+	public function getWarningList() {
+		return array(
+			16 => 1,
+			17 => 1,
+			18 => 1,
+			19 => 1,
+			20 => 1,
+			21 => 1,
+			22 => 1,
+			23 => 1,
+			24 => 1,
+		);
+	}
+
+}

--- a/WordPressVIPMinimum/Tests/VIP/PHPFilterFunctionsUnitTest.php
+++ b/WordPressVIPMinimum/Tests/VIP/PHPFilterFunctionsUnitTest.php
@@ -22,7 +22,7 @@ class PHPFilterFunctionsUnitTest extends AbstractSniffUnitTest {
 	 * @return array <int line number> => <int number of errors>
 	 */
 	public function getErrorList() {
-		return array();
+		return [];
 	}
 
 	/**
@@ -32,8 +32,6 @@ class PHPFilterFunctionsUnitTest extends AbstractSniffUnitTest {
 	 */
 	public function getWarningList() {
 		return array(
-			16 => 1,
-			17 => 1,
 			18 => 1,
 			19 => 1,
 			20 => 1,
@@ -41,6 +39,11 @@ class PHPFilterFunctionsUnitTest extends AbstractSniffUnitTest {
 			22 => 1,
 			23 => 1,
 			24 => 1,
+			25 => 1,
+			26 => 1,
+			27 => 1,
+			28 => 1,
+			29 => 1,
 		);
 	}
 


### PR DESCRIPTION
Per #222, this detects if there is an invalid filter ID passed into the PHP filter_* functions or none passed in for `filter_var`, `filter_input`, `filter_var_array`, `filter_input_array`.

@GaryJones Let me know if you think it's better to check against a whitelist for an invalid filter.