### PR TITLE
Add opcache_reset() to list of restricted functions.

### DIFF
--- a/WordPressVIPMinimum/Sniffs/VIP/RestrictedFunctionsSniff.php
+++ b/WordPressVIPMinimum/Sniffs/VIP/RestrictedFunctionsSniff.php
@@ -29,6 +29,11 @@ class RestrictedFunctionsSniff extends \WordPress\Sniffs\VIP\RestrictedFunctions
 				'message'   => '`%s` is not supported on the WordPress.com VIP platform.',
 				'functions' => array( 'wp_cache_get_multi' ),
 			),
+			'opcache_reset'            => array(
+				'type'      => 'error',
+				'message'   => '`%s` is prohibited on the WordPress VIP platform due to memory corruption.',
+				'functions' => array( 'get_super_admins' ),
+			),
 			'get_super_admins'         => array(
 				'type'      => 'error',
 				'message'   => '`%s` is prohibited on the WordPress.com VIP platform',

--- a/WordPressVIPMinimum/Sniffs/VIP/RestrictedFunctionsSniff.php
+++ b/WordPressVIPMinimum/Sniffs/VIP/RestrictedFunctionsSniff.php
@@ -32,7 +32,7 @@ class RestrictedFunctionsSniff extends \WordPress\Sniffs\VIP\RestrictedFunctions
 			'opcache_reset'            => array(
 				'type'      => 'error',
 				'message'   => '`%s` is prohibited on the WordPress VIP platform due to memory corruption.',
-				'functions' => array( 'get_super_admins' ),
+				'functions' => array( 'opcache_reset' ),
 			),
 			'get_super_admins'         => array(
 				'type'      => 'error',

--- a/WordPressVIPMinimum/Tests/VIP/RestrictedFunctionsUnitTest.inc
+++ b/WordPressVIPMinimum/Tests/VIP/RestrictedFunctionsUnitTest.inc
@@ -39,3 +39,5 @@ mail(); // Bad. Warning.
 dbDelta(); // Bad. Warning.
 
 is_multi_author(); // Bad. Warning.
+
+opcache_reset(); // Bad.

--- a/WordPressVIPMinimum/Tests/VIP/RestrictedFunctionsUnitTest.php
+++ b/WordPressVIPMinimum/Tests/VIP/RestrictedFunctionsUnitTest.php
@@ -29,6 +29,7 @@ class RestrictedFunctionsUnitTest extends AbstractSniffUnitTest {
 			11 => 1,
 			13 => 1,
 			39 => 1,
+			43 => 1,
 		);
 	}
 


### PR DESCRIPTION
Per #239, we should never be calling `opcache_reset()`.