### PR TITLE
Flag for low expiry cache time

### DIFF
--- a/WordPress-VIP-Go/ruleset.xml
+++ b/WordPress-VIP-Go/ruleset.xml
@@ -288,6 +288,10 @@
 		<severity>3</severity>
 		<message>Switch to blog may not work as you expect. It only changes the database context for the blog. It doesn't load the plugins or theme of that site. This means that filters or hooks that the blog you are switching to uses will not run.</message>
 	</rule>
+	<rule ref="WordPressVIPMinimum.Cache.LowExpiryCacheTime.LowCacheTime">
+		<type>warning</type>
+		<severity>3</severity>
+	</rule>
 	<rule ref="WordPressVIPMinimum.VIP.ErrorControl.ErrorControl">
 		<severity>1</severity>
 	</rule>

--- a/WordPressVIPMinimum/Sniffs/Cache/LowExpiryCacheTimeSniff.php
+++ b/WordPressVIPMinimum/Sniffs/Cache/LowExpiryCacheTimeSniff.php
@@ -1,0 +1,89 @@
+<?php
+/**
+ * WordPressVIPMinimum Coding Standard.
+ *
+ * @package VIPCS\WordPressVIPMinimum
+ */
+
+namespace WordPressVIPMinimum\Sniffs\Cache;
+
+use WordPress\AbstractFunctionParameterSniff;
+
+/**
+ * This sniff throws a warning when low cache times are set.
+ *
+ * @package VIPCS\WordPressVIPMinimum
+ *
+ * @since 0.4.0
+ */
+class LowExpiryCacheTimeSniff extends AbstractFunctionParameterSniff {
+
+	/**
+	 * The group name for this group of functions.
+	 *
+	 * @var string
+	 */
+	protected $group_name = 'cache_functions';
+
+	/**
+	 * Functions this sniff is looking for.
+	 *
+	 * @var array The only requirement for this array is that the top level
+	 *            array keys are the names of the functions you're looking for.
+	 *            Other than that, the array can have arbitrary content
+	 *            depending on your needs.
+	 */
+	protected $target_functions = [
+		'wp_cache_set' => true,
+	];
+
+	/**
+	 * List of WP time constants, see https://codex.wordpress.org/Easier_Expression_of_Time_Constants.
+	 *
+	 * @var array
+	 */
+	protected $wp_time_constants = array(
+		'MINUTE_IN_SECONDS' => 60,
+		'HOUR_IN_SECONDS'   => 3600,
+		'DAY_IN_SECONDS'    => 86400,
+		'WEEK_IN_SECONDS'   => 604800,
+		'MONTH_IN_SECONDS'  => 2592000,
+		'YEAR_IN_SECONDS'   => 31536000,
+	);
+
+	/**
+	 * Process the parameters of a matched function.
+	 *
+	 * @param int    $stackPtr        The position of the current token in the stack.
+	 * @param array  $group_name      The name of the group which was matched.
+	 * @param string $matched_content The token content (function name) which was matched.
+	 * @param array  $parameters      Array with information about the parameters.
+	 * @return int|void Integer stack pointer to skip forward or void to continue
+	 *                  normal file processing.
+	 */
+	public function process_parameters( $stackPtr, $group_name, $matched_content, $parameters ) {
+		if ( false === isset( $parameters[4] ) ) {
+			// If no cache expiry time, bail.
+			return;
+		}
+
+		$time = $parameters[4]['raw'];
+
+		if ( false === is_numeric( $time ) ) {
+			// If using time constants, we need to convert to a number.
+			$time = str_replace( array_keys( $this->wp_time_constants ), array_values( $this->wp_time_constants ), $time );
+			
+			if ( preg_match( '#^[\s\d+*/-]+$#', $time ) > 0 ) {
+				$time = eval( "return $time;" ); // @codingStandardsIgnoreLine - No harm here.
+			}
+		} 
+
+		if ( $time < 300 ) {
+			$this->phpcsFile->addWarning(
+				sprintf( 'Low cache expiry time of "%s", it is recommended to have 300 seconds or more.', $parameters[4]['raw'] ),
+				$stackPtr,
+				'LowCacheTime'
+			);
+		}
+	}
+}

--- a/WordPressVIPMinimum/Tests/Cache/LowExpiryCacheTimeUnitTest.inc
+++ b/WordPressVIPMinimum/Tests/Cache/LowExpiryCacheTimeUnitTest.inc
@@ -1,0 +1,18 @@
+<?php
+
+$data = [ 'test', 'banana', 'ice cream', '123' ];
+$testing = 'test_key';
+$group = 'test_group';
+
+// Ok.
+wp_cache_set( 'test', $data, $group, 300 );
+wp_cache_set( $testing, $data, 'test_group', 5*MINUTE_IN_SECONDS );
+wp_cache_set( 123, $data, 'test_group',  5 * MINUTE_IN_SECONDS );
+wp_cache_set( 1234, $data, '', 425 );
+wp_cache_set( $testing, $data, null, 350 );
+
+// Bad.
+wp_cache_set( 'test', $data, $group, 100 ); // Lower than 300.
+wp_cache_set( 'test', $data, $group,  2*MINUTE_IN_SECONDS  ); // Lower than 300.
+wp_cache_set( 123, $data, null, 1.5 * MINUTE_IN_SECONDS ); // Lower than 300.
+wp_cache_set( $testing, $data, '', 1.5 * MINUTE_IN_SECONDS ); // Lower than 300.

--- a/WordPressVIPMinimum/Tests/Cache/LowExpiryCacheTimeUnitTest.php
+++ b/WordPressVIPMinimum/Tests/Cache/LowExpiryCacheTimeUnitTest.php
@@ -1,0 +1,41 @@
+<?php
+/**
+ * Unit test class for WordPressVIPMinimum Coding Standard.
+ *
+ * @package VIPCS\WordPressVIPMinimum
+ */
+
+namespace WordPressVIPMinimum\Tests\Cache;
+
+use PHP_CodeSniffer\Tests\Standards\AbstractSniffUnitTest;
+
+/**
+ * Unit test class for the LowExpiryCacheTime sniff.
+ *
+ * @package VIPCS\WordPressVIPMinimum
+ */
+class LowExpiryCacheTimeUnitTest extends AbstractSniffUnitTest {
+
+	/**
+	 * Returns the lines where errors should occur.
+	 *
+	 * @return array <int line number> => <int number of errors>
+	 */
+	public function getErrorList() {
+		return [];
+	}
+
+	/**
+	 * Returns the lines where warnings should occur.
+	 *
+	 * @return array <int line number> => <int number of warnings>
+	 */
+	public function getWarningList() {
+		return [
+			15 => 1,
+			16 => 1,
+			17 => 1,
+			18 => 1,
+		];
+	}
+}


### PR DESCRIPTION
Per #81, we should flag for expiry times less than 300 (5 minutes).  