### PR TITLE
IncludingFile Sniff is more accurate

### DIFF
--- a/WordPressVIPMinimum/Tests/Files/IncludingFileUnitTest.inc
+++ b/WordPressVIPMinimum/Tests/Files/IncludingFileUnitTest.inc
@@ -11,3 +11,13 @@ include ( MY_CONSTANT . "my_file.php" ); // Warning.
 require_once ( MY_CONSTANT . "my_file.php" ); // Warning.
 
 include( locate_template('index-loop.php') ); // Ok.
+
+include( 'http://www.google.com/bad_file.php' ); // Bad.
+
+include("http://www.google.com/bad_file.php"); // Bad.
+
+require_once( custom_function( 'test_string.php' ) ); // Warning.
+
+function custom_function( $string ) {
+	return 'http://www.google.com/' . $string;
+}

--- a/WordPressVIPMinimum/Tests/Files/IncludingFileUnitTest.php
+++ b/WordPressVIPMinimum/Tests/Files/IncludingFileUnitTest.php
@@ -21,9 +21,11 @@ class IncludingFileUnitTest extends AbstractSniffUnitTest {
 	 * @return array <int line number> => <int number of errors>
 	 */
 	public function getErrorList() {
-		return array(
-			5 => 1,
-		);
+		return [
+			5  => 1,
+			15 => 1,
+			17 => 1,
+		];
 	}
 
 	/**
@@ -32,10 +34,11 @@ class IncludingFileUnitTest extends AbstractSniffUnitTest {
 	 * @return array <int line number> => <int number of warnings>
 	 */
 	public function getWarningList() {
-		return array(
+		return [
 			9  => 1,
 			11 => 1,
-		);
+			19 => 1,
+		];
 	}
 
 }


### PR DESCRIPTION
Including files with external URL or custom function (which may possibly return external URL) returned inaccurate warnings.  With this snippet as an example test:

```
require_once(wpcom_vip_theme_url('/my-theme/my-file.php', 'my-other-theme'));

require_once( 'http://example.com/my-file.php' );
```

Before:

```
------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
FOUND 1 ERROR AND 1 WARNING AFFECTING 2 LINES
------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
--------------------------------------------------------------------------------
FOUND 0 ERRORS AND 2 WARNINGS AFFECTING 2 LINES
--------------------------------------------------------------------------------
 3 | WARNING | File inclusion using custom constant (`wpcom_vip_theme_url`).
   |         | Probably needs manual inspection.
   |         | (WordPressVIPMinimum.Files.IncludingFile.IncludingFile)
 5 | WARNING | Absolute include path must be used. Use
   |         | `get_template_directory()`, `get_stylesheet_directory()` or
   |         | `plugin_dir_path()`.
   |         | (WordPressVIPMinimum.Files.IncludingFile.IncludingFile)
--------------------------------------------------------------------------------

------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
```

After:

```
--------------------------------------------------------------------------------
FOUND 0 ERRORS AND 2 WARNINGS AFFECTING 2 LINES
--------------------------------------------------------------------------------
 3 | WARNING | File inclusion using custom function ( `wpcom_vip_theme_url()`
   |         | ). Must return local file source, as external URLs are
   |         | prohibited on WordPress VIP. Probably needs manual
   |         | inspection.
   |         | (WordPressVIPMinimum.Files.IncludingFile.IncludingFile)
 5 | WARNING | Include path must be local file source, external URLs are
   |         | probibited on WordPress VIP.
   |         | (WordPressVIPMinimum.Files.IncludingFile.IncludingFile)
--------------------------------------------------------------------------------
```