### PR TITLE
Add ACF templating function to warnings

### DIFF
--- a/WordPressVIPMinimum/Sniffs/VIP/RestrictedFunctionsSniff.php
+++ b/WordPressVIPMinimum/Sniffs/VIP/RestrictedFunctionsSniff.php
@@ -89,6 +89,14 @@ class RestrictedFunctionsSniff extends \WordPress\Sniffs\VIP\RestrictedFunctions
 					'is_multi_author',
 				),
 			),
+			'advanced_custom_fields'          => array(
+				'type'      => 'warning',
+				'message'   => '`%1$s` does not escape output by default, please echo and escape `get_%1$s` instead.',
+				'functions' => array(
+					'the_sub_field',
+					'the_field',
+				),
+			),
 		);
 
 		$deprecated_vip_helpers = array(

--- a/WordPressVIPMinimum/Sniffs/VIP/RestrictedFunctionsSniff.php
+++ b/WordPressVIPMinimum/Sniffs/VIP/RestrictedFunctionsSniff.php
@@ -91,7 +91,7 @@ class RestrictedFunctionsSniff extends \WordPress\Sniffs\VIP\RestrictedFunctions
 			),
 			'advanced_custom_fields'          => array(
 				'type'      => 'warning',
-				'message'   => '`%1$s` does not escape output by default, please echo and escape `get_%1$s` instead.',
+				'message'   => '`%1$s` does not escape output by default, please echo and escape with the `get_*()` variant function instead (i.e. `get_field()`).',
 				'functions' => array(
 					'the_sub_field',
 					'the_field',

--- a/WordPressVIPMinimum/Tests/VIP/RestrictedFunctionsUnitTest.inc
+++ b/WordPressVIPMinimum/Tests/VIP/RestrictedFunctionsUnitTest.inc
@@ -42,6 +42,8 @@ is_multi_author(); // Bad. Warning.
 
 opcache_reset(); // Bad.
 
-// Warning - ACF.
-the_field( 'field' );
-the_sub_field( 'field' );
+the_field( 'field' ); // Warning - ACF.
+the_sub_field( 'field' ); // Warning - ACF.
+
+echo esc_html( get_the_field( 'field' ) ); // Ok - ACF.
+echo '<img src="test.jpg" alt="' . esc_attr( get_sub_field( 'field' ) ) . '">'; // Ok - ACF.

--- a/WordPressVIPMinimum/Tests/VIP/RestrictedFunctionsUnitTest.inc
+++ b/WordPressVIPMinimum/Tests/VIP/RestrictedFunctionsUnitTest.inc
@@ -41,3 +41,7 @@ dbDelta(); // Bad. Warning.
 is_multi_author(); // Bad. Warning.
 
 opcache_reset(); // Bad.
+
+// Warning - ACF.
+the_field( 'field' );
+the_sub_field( 'field' );

--- a/WordPressVIPMinimum/Tests/VIP/RestrictedFunctionsUnitTest.php
+++ b/WordPressVIPMinimum/Tests/VIP/RestrictedFunctionsUnitTest.php
@@ -48,8 +48,8 @@ class RestrictedFunctionsUnitTest extends AbstractSniffUnitTest {
 			35 => 1,
 			37 => 1,
 			41 => 1,
+			45 => 1,
 			46 => 1,
-			47 => 1,
 		);
 	}
 

--- a/WordPressVIPMinimum/Tests/VIP/RestrictedFunctionsUnitTest.php
+++ b/WordPressVIPMinimum/Tests/VIP/RestrictedFunctionsUnitTest.php
@@ -48,6 +48,8 @@ class RestrictedFunctionsUnitTest extends AbstractSniffUnitTest {
 			35 => 1,
 			37 => 1,
 			41 => 1,
+			46 => 1,
+			47 => 1,
 		);
 	}
 

--- a/WordPressVIPMinimum/Tests/VIP/RestrictedFunctionsUnitTest.php
+++ b/WordPressVIPMinimum/Tests/VIP/RestrictedFunctionsUnitTest.php
@@ -29,14 +29,14 @@ class RestrictedFunctionsUnitTest extends AbstractSniffUnitTest {
 			11 => 1,
 			13 => 1,
 			39 => 1,
-			45 => 1,
-			46 => 1,
-			47 => 1,
-			48 => 1,
-			49 => 1,
-			50 => 1,
 			51 => 1,
 			52 => 1,
+			53 => 1,
+			54 => 1,
+			55 => 1,
+			56 => 1,
+			57 => 1,
+			58 => 1,
 		);
 	}
 
@@ -55,8 +55,8 @@ class RestrictedFunctionsUnitTest extends AbstractSniffUnitTest {
 			35 => 1,
 			37 => 1,
 			41 => 1,
-			45 => 1,
-			46 => 1,
+			43 => 1,
+			44 => 1,
 		);
 	}
 


### PR DESCRIPTION
Per #156, ACF's `the_field()` and `the_sub_field()` do not escape outputted.