### PR TITLE
Add .editorconfig

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,14 @@
+	# This file is for unifying the coding style for different editors and IDEs
+	# editorconfig.org
+
+	root = true
+
+	[*]
+	charset = utf-8
+	end_of_line = lf
+	insert_final_newline = true
+	trim_trailing_whitespace = true
+	indent_style = tab
+
+	[*.md]
+	trim_trailing_whitespace = false


### PR DESCRIPTION
Fixes #249.

See https://editorconfig.org - plugins are available for many editors to take advantage of this.

Simplified down from the WP core `.editorconfig`.