### PR TITLE
Remove get_page_by_path sniff and refactor RestrictedFunctions sniff without parent

### DIFF
--- a/WordPress-VIP-Go/ruleset.xml
+++ b/WordPress-VIP-Go/ruleset.xml
@@ -163,9 +163,8 @@
 
 
 	<!-- VIP Uncached warnings -->
-	<rule ref="WordPress.VIP.RestrictedFunctions.get_posts">
+	<rule ref="WordPressVIPMinimum.VIP.RestrictedFunctions.get_posts">
 		<severity>3</severity>
-		<message>%s() is uncached unless the 'suppress_filters' parameter is set to false. If the suppress_filter parameter is set to false this can be safely ignored. More Info: https://vip.wordpress.com/documentation/vip-go/uncached-functions/</message>
 	</rule>
 	<rule ref="WordPressVIPMinimum.VIP.RestrictedFunctions.get_posts_get_children">
 		<type>warning</type>

--- a/WordPressVIPMinimum/Sniffs/VIP/RestrictedFunctionsSniff.php
+++ b/WordPressVIPMinimum/Sniffs/VIP/RestrictedFunctionsSniff.php
@@ -7,12 +7,15 @@
 
 namespace WordPressVIPMinimum\Sniffs\VIP;
 
+use WordPress\AbstractFunctionRestrictionsSniff;
+use WordPress\AbstractFunctionRestrictionSniff;
+
 /**
  * Restricts usage of some functions in VIP context.
  *
  * @package VIPCS\WordPressVIPMinimum
  */
-class RestrictedFunctionsSniff extends \WordPress\Sniffs\VIP\RestrictedFunctionsSniff {
+class RestrictedFunctionsSniff extends AbstractFunctionRestrictionsSniff {
 
 	/**
 	 * Groups of functions to restrict.
@@ -21,9 +24,7 @@ class RestrictedFunctionsSniff extends \WordPress\Sniffs\VIP\RestrictedFunctions
 	 */
 	public function getGroups() {
 
-		$original_groups = parent::getGroups();
-
-		$new_groups = array(
+		$groups = array(
 			'wp_cache_get_multi'       => array(
 				'type'      => 'error',
 				'message'   => '`%s` is not supported on the WordPress.com VIP platform.',
@@ -50,7 +51,9 @@ class RestrictedFunctionsSniff extends \WordPress\Sniffs\VIP\RestrictedFunctions
 			'get_super_admins'         => array(
 				'type'      => 'error',
 				'message'   => '`%s` is prohibited on the WordPress.com VIP platform',
-				'functions' => array( 'get_super_admins' ),
+				'functions' => array( 
+					'get_super_admins' 
+				),
 			),
 			'internal'                 => array(
 				'type'      => 'error',
@@ -59,6 +62,7 @@ class RestrictedFunctionsSniff extends \WordPress\Sniffs\VIP\RestrictedFunctions
 					'wpcom_vip_irc',
 				),
 			),
+			// @link WordPress.com: https://lobby.vip.wordpress.com/wordpress-com-documentation/code-review-what-we-look-for/#flush_rewrite_rules
 			'rewrite_rules'            => array(
 				'type'      => 'error',
 				'message'   => '`%s` should not be used in any normal circumstances in the theme code.',
@@ -73,11 +77,109 @@ class RestrictedFunctionsSniff extends \WordPress\Sniffs\VIP\RestrictedFunctions
 					'attachment_url_to_postid',
 				),
 			),
+			// TODO: Add strip_tags sniff that checks based on parameters.
 			'strip_tags'               => array(
 				'type'      => 'error',
 				'message'   => '`%s()` does not strip CSS and JS in between the script and style tags. `wp_strip_all_tags()` should be used instead.',
 				'functions' => array(
 					'strip_tags',
+				),
+			),
+			'dbDelta'                  => array(
+				'type'      => 'error',
+				'message'   => 'All database modifications have to approved by the WordPress.com VIP team.',
+				'functions' => array(
+					'dbDelta',
+				),
+			),
+			// @link WordPress.com: https://vip.wordpress.com/documentation/vip/code-review-what-we-look-for/#switch_to_blog
+			// @link VIP Go: https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/#switch_to_blog
+			'switch_to_blog' => array(
+				'type'      => 'error',
+				'message'   => '%s() is not something you should ever need to do in a VIP theme context. Instead use an API (XML-RPC, REST) to interact with other sites if needed.',
+				'functions' => array( 'switch_to_blog' ),
+			),
+			'get_page_by_title' => array(
+				'type'      => 'error',
+				'message'   => '%s() is prohibited, please use wpcom_vip_get_page_by_title() instead.',
+				'functions' => array(
+					'get_page_by_title',
+				),
+			),
+			'url_to_postid' => array(
+				'type'      => 'error',
+				'message'   => '%s() is prohibited, please use wpcom_vip_url_to_postid() instead.',
+				'functions' => array(
+					'url_to_postid',
+					'url_to_post_id',
+				),
+			),
+			// @link WordPress.com: https://lobby.vip.wordpress.com/wordpress-com-documentation/code-review-what-we-look-for/#custom-roles
+			// @link VIP Go: https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/#custom-roles
+			'custom_role' => array(
+				'type'      => 'error',
+				'message'   => 'Use wpcom_vip_add_role() instead of %s()',
+				'functions' => array(
+					'add_role',
+				),
+			),
+			// @link WordPress.com: https://lobby.vip.wordpress.com/wordpress-com-documentation/code-review-what-we-look-for/#wp_users-and-user_meta
+			'user_meta' => array(
+				'type'      => 'error',
+				'message'   => '%s() usage is highly discouraged on WordPress.com VIP due to it being a multisite, please see https://lobby.vip.wordpress.com/wordpress-com-documentation/code-review-what-we-look-for/#wp_users-and-user_meta.',
+				'functions' => array(
+					'get_user_meta',
+					'update_user_meta',
+					'delete_user_meta',
+					'add_user_meta',
+				),
+			),
+			'term_exists' => array(
+				'type'      => 'error',
+				'message'   => '%s() is highly discouraged due to not being cached; please use wpcom_vip_term_exists() instead.',
+				'functions' => array(
+					'term_exists',
+				),
+			),
+			'count_user_posts' => array(
+				'type'      => 'error',
+				'message'   => '%s() is highly discouraged due to not being cached; please use wpcom_vip_count_user_posts() instead.',
+				'functions' => array(
+					'count_user_posts',
+				),
+			),
+			'wp_old_slug_redirect' => array(
+				'type'      => 'error',
+				'message'   => '%s() is highly discouraged due to not being cached; please use wpcom_vip_old_slug_redirect() instead.',
+				'functions' => array(
+					'wp_old_slug_redirect',
+				),
+			),
+			'get_adjacent_post' => array(
+				'type'      => 'error',
+				'message'   => '%s() is highly discouraged due to not being cached; please use wpcom_vip_get_adjacent_post() instead.',
+				'functions' => array(
+					'get_adjacent_post',
+					'get_previous_post',
+					'get_previous_post_link',
+					'get_next_post',
+					'get_next_post_link',
+				),
+			),
+			'get_intermediate_image_sizes' => array(
+				'type'      => 'error',
+				'message'   => 'Intermediate images do not exist on the VIP platform, and thus get_intermediate_image_sizes() returns an empty array() on the platform. This behavior is intentional to prevent WordPress from generating multiple thumbnails when images are uploaded.',
+				'functions' => array(
+					'get_intermediate_image_sizes',
+				),
+			),
+			// @link WordPress.com: https://lobby.vip.wordpress.com/wordpress-com-documentation/code-review-what-we-look-for/#mobile-detection
+			// @link VIP Go: https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/#mobile-detection
+			'wp_is_mobile' => array(
+				'type'      => 'error',
+				'message'   => '%s() found. When targeting mobile visitors, jetpack_is_mobile() should be used instead of wp_is_mobile. It is more robust and works better with full page caching.',
+				'functions' => array(
+					'wp_is_mobile',
 				),
 			),
 			'wp_mail'                  => array(
@@ -86,13 +188,6 @@ class RestrictedFunctionsSniff extends \WordPress\Sniffs\VIP\RestrictedFunctions
 				'functions' => array(
 					'wp_mail',
 					'mail',
-				),
-			),
-			'dbDelta'                  => array(
-				'type'      => 'error',
-				'message'   => 'All database modifications have to approved by the WordPress.com VIP team.',
-				'functions' => array(
-					'dbDelta',
 				),
 			),
 			'is_multi_author'          => array(
@@ -110,6 +205,34 @@ class RestrictedFunctionsSniff extends \WordPress\Sniffs\VIP\RestrictedFunctions
 					'the_field',
 				),
 			),
+			// @link WordPress.com: https://lobby.vip.wordpress.com/wordpress-com-documentation/code-review-what-we-look-for/#remote-calls
+			// @link VIP Go: https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/#remote-calls
+			'wp_remote_get' => array(
+				'type'      => 'warning',
+				'message'   => '%s() is highly discouraged, please use vip_safe_wp_remote_get() instead.',
+				'functions' => array(
+					'wp_remote_get',
+				),
+			),
+			// @link WordPress.com: https://lobby.vip.wordpress.com/wordpress-com-documentation/code-review-what-we-look-for/#custom-roles
+			// @link VIP Go: https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/#cache-constraints
+			'cookies' => array(
+				'type'      => 'warning',
+				'message'   => 'Due to using Batcache, server side based client related logic will not work, use JS instead.',
+				'functions' => array(
+					'setcookie',
+				),
+			),
+			// @todo Introduce a sniff specific to get_posts() that checks for suppress_filters=>false being supplied.
+			'get_posts' => array(
+				'type'      => 'warning',
+				'message'   => '%s() is uncached unless the "suppress_filters" parameter is set to false. If the suppress_filter parameter is set to false this can be safely ignored. More Info: https://vip.wordpress.com/documentation/vip-go/uncached-functions/',
+				'functions' => array(
+					'get_posts',
+					'wp_get_recent_posts',
+					'get_children',
+				),
+			),
 		);
 
 		$deprecated_vip_helpers = array(
@@ -118,18 +241,16 @@ class RestrictedFunctionsSniff extends \WordPress\Sniffs\VIP\RestrictedFunctions
 			'get_category_by_slug' => 'wpcom_vip_get_category_by_slug',
 		);
 		foreach ( $deprecated_vip_helpers as $restricted => $helper ) {
-			$new_groups[ $helper ] = array(
+			$groups[ $helper ] = array(
 				'type'      => 'warning',
-				'message'   => "`%s()` is deprecated, please use {$restricted} instead.",
+				'message'   => "`%s()` is deprecated, please use `{$restricted}()` instead.",
 				'functions' => array(
 					$helper,
 				),
 			);
-			unset( $original_groups[ $restricted ] );
+			unset( $groups[ $restricted ] );
 		}
 
-		unset( $original_groups['file_get_contents'] );
-
-		return array_merge( $original_groups, $new_groups );
+		return $groups;
 	}
 }

--- a/WordPressVIPMinimum/Sniffs/VIP/RestrictedFunctionsSniff.php
+++ b/WordPressVIPMinimum/Sniffs/VIP/RestrictedFunctionsSniff.php
@@ -25,12 +25,12 @@ class RestrictedFunctionsSniff extends AbstractFunctionRestrictionsSniff {
 	public function getGroups() {
 
 		$groups = array(
-			'wp_cache_get_multi'       => array(
+			'wp_cache_get_multi' => array(
 				'type'      => 'error',
 				'message'   => '`%s` is not supported on the WordPress.com VIP platform.',
 				'functions' => array( 'wp_cache_get_multi' ),
 			),
-			'opcache'            => array(
+			'opcache' => array(
 				'type'      => 'error',
 				'message'   => '`%s` is prohibited on the WordPress VIP platform due to memory corruption.',
 				'functions' => array(
@@ -39,7 +39,7 @@ class RestrictedFunctionsSniff extends AbstractFunctionRestrictionsSniff {
 					'opcache_compile_file',
 				),
 			),
-			'config_settings'       => array(
+			'config_settings' => array(
 				'type'      => 'error',
 				'message'   => '`%s` is not recommended for use on the WordPress VIP platform due to potential setting changes.',
 				'functions' => array(
@@ -48,14 +48,14 @@ class RestrictedFunctionsSniff extends AbstractFunctionRestrictionsSniff {
 					'opcache_​get_​configuration',
 				),
 			),
-			'get_super_admins'         => array(
+			'get_super_admins' => array(
 				'type'      => 'error',
 				'message'   => '`%s` is prohibited on the WordPress.com VIP platform',
-				'functions' => array( 
-					'get_super_admins' 
+				'functions' => array(
+					'get_super_admins',
 				),
 			),
-			'internal'                 => array(
+			'internal' => array(
 				'type'      => 'error',
 				'message'   => '`%1$s()` is for internal use only.',
 				'functions' => array(
@@ -63,7 +63,7 @@ class RestrictedFunctionsSniff extends AbstractFunctionRestrictionsSniff {
 				),
 			),
 			// @link WordPress.com: https://lobby.vip.wordpress.com/wordpress-com-documentation/code-review-what-we-look-for/#flush_rewrite_rules
-			'rewrite_rules'            => array(
+			'rewrite_rules' => array(
 				'type'      => 'error',
 				'message'   => '`%s` should not be used in any normal circumstances in the theme code.',
 				'functions' => array(
@@ -78,14 +78,14 @@ class RestrictedFunctionsSniff extends AbstractFunctionRestrictionsSniff {
 				),
 			),
 			// TODO: Add strip_tags sniff that checks based on parameters.
-			'strip_tags'               => array(
+			'strip_tags' => array(
 				'type'      => 'error',
 				'message'   => '`%s()` does not strip CSS and JS in between the script and style tags. `wp_strip_all_tags()` should be used instead.',
 				'functions' => array(
 					'strip_tags',
 				),
 			),
-			'dbDelta'                  => array(
+			'dbDelta' => array(
 				'type'      => 'error',
 				'message'   => 'All database modifications have to approved by the WordPress.com VIP team.',
 				'functions' => array(
@@ -182,7 +182,7 @@ class RestrictedFunctionsSniff extends AbstractFunctionRestrictionsSniff {
 					'wp_is_mobile',
 				),
 			),
-			'wp_mail'                  => array(
+			'wp_mail' => array(
 				'type'      => 'warning',
 				'message'   => '`%s` should be used sparingly. For any bulk emailing should be handled by a 3rd party service, in order to prevent domain or IP addresses being flagged as spam.',
 				'functions' => array(
@@ -190,14 +190,14 @@ class RestrictedFunctionsSniff extends AbstractFunctionRestrictionsSniff {
 					'mail',
 				),
 			),
-			'is_multi_author'          => array(
+			'is_multi_author' => array(
 				'type'      => 'warning',
 				'message'   => '`%s` can be very slow on large sites and likely not needed on many VIP sites since they tend to have more than one author.',
 				'functions' => array(
 					'is_multi_author',
 				),
 			),
-			'advanced_custom_fields'          => array(
+			'advanced_custom_fields' => array(
 				'type'      => 'warning',
 				'message'   => '`%1$s` does not escape output by default, please echo and escape with the `get_*()` variant function instead (i.e. `get_field()`).',
 				'functions' => array(
@@ -248,7 +248,6 @@ class RestrictedFunctionsSniff extends AbstractFunctionRestrictionsSniff {
 					$helper,
 				),
 			);
-			unset( $groups[ $restricted ] );
 		}
 
 		return $groups;

--- a/WordPressVIPMinimum/Tests/VIP/RestrictedFunctionsUnitTest.inc
+++ b/WordPressVIPMinimum/Tests/VIP/RestrictedFunctionsUnitTest.inc
@@ -1,63 +1,139 @@
 <?php
 
-wpcom_vip_irc(); // Bad.
-
-get_children(); // Bad. Warning.
-
-wp_cache_get_multi(); // Bad.
-
-get_super_admins(); // Bad.
-
-flush_rewrite_rules(); // Bad.
-
-attachment_url_to_postid(); // Bad.
-
-wpcom_vip_attachment_url_to_postid(); // OK.
-
-get_term_link(); // Ok.
-
-get_term_by(); // Ok.
-
-get_category_by_slug(); // Ok.
-
-get_tag_link(); // Ok.
-
-get_category_link(); // Ok.
-
-get_cat_ID(); // Ok.
-
-wpcom_vip_get_category_by_slug(); // Bad. Deprecated.
-
-wpcom_vip_get_term_by(); // Bad. Deprecated.
-
-wpcom_vip_get_term_link(); // Bad. Deprecated.
-
-wp_mail(); // Bad. Warning.
-
-mail(); // Bad. Warning.
-
-dbDelta(); // Bad. Warning.
-
-is_multi_author(); // Bad. Warning.
-
-the_field( 'field' ); // Warning - ACF.
-the_sub_field( 'field' ); // Warning - ACF.
-
-echo esc_html( get_the_field( 'field' ) ); // Ok - ACF.
-echo '<img src="test.jpg" alt="' . esc_attr( get_sub_field( 'field' ) ) . '">'; // Ok - ACF.
-
 $test_script = '$test_script.php';
+$test_string = '<i>Random string</i>';
+$test = 'Test123';
+$int = 123;
+$allowed_html = [
+    'a' => [
+        'href' => [],
+        'title' => [],
+    ],
+    'br' => [],
+    'em' => [],
+    'strong' => [],
+];
+$url = 'http://www.google.ca';
 
-opcache_reset(); // Bad.
-opcache_invalidate( 'test_script.php' ); // Bad.
-opcache_invalidate( $test_script, true ); // Bad.
-opcache_compile_file( $test_script ); // Bad.
-opcache_​is_​script_​cached( 'test_script.php' ); // Bad.
-opcache_​get_​status(); // Bad.
-opcache_​get_​status( false ); // Bad.
-opcache_​get_​configuration(); // Bad.
+wp_cache_get_mult(); // Ok - similarly-named function to wp_cache_get_multi().
+wp_cache_get_multi(); // Error.
 
-opcache_resets(); // Ok, similarly-named custom function.
-foo_opcache_get_status( $test_script ); // Ok, similarly-named custom function.
-opcach_invalidate ( $test_script ); // Ok, similarly-named custom function.
-okcache_is_​script_​cached( 'test_script.php' ); // Ok, similarly-named custom function.
+opcache_resets(); // Ok - similarly-named custom function to opcache_reset().
+opcach_invalidate ( $test_script ); // Ok - similarly-named custom function to opcache_invalidate().
+opcache_compil_file(); // Ok - similarly-named custom function to opcache_compile_file().
+okcache_is_​script_​cached( 'test_script.php' ); // Ok - similarly-named custom function to opcache_is_script_cached().
+foo_opcache_get_status( $test_script ); // Ok - similarly-named custom function to opcache_get_status().
+opcache_get_config( $test_script ); // Ok - similary-named custom function to opcache_get_configuration().
+opcache_reset(); // Error.
+opcache_invalidate( 'test_script.php' ); // Error - one parameter.
+opcache_invalidate( $test_script, true ); // Error - two parameters.
+opcache_compile_file( $test_script ); // Error - one parameter.
+opcache_​is_​script_​cached( 'test_script.php' ); // Error - one parameter.
+opcache_​get_​status(); // Error.
+opcache_​get_​status( false ); // Error.
+opcache_​get_​configuration(); // Error.
+
+get_super_admin(); // Ok - similarly-named function to get_super_admins().
+get_super_admins(); // Error.
+
+vip_irc(); // Ok - similarly-named function to wpcom_vip_irc().
+wpcom_vip_irc(); // Error.
+
+flush_rewrite_rule(); // Ok - similarly-named function to flush_rewrite_rules().
+flush_rewrite_rules(); // Error.
+
+wpcom_vip_attachment_url_to_postid( $url ); // Ok - VIP recommended version of attachment_url_to_postid().
+attachment_url_to_postid( $url ); // Error.
+
+wp_strip_tags( $test ); // Ok - VIP recommended version of strip_tags().
+wp_kses( $test_string, $allowed_html ); // Ok - VIP recommended version of strip_tags().
+strip_tags( $test_string ); // Error.
+
+db_delta(); // Ok - similarly-named function to dbDelta().
+dbDelta(); // Error.
+
+switch_blog(); // Ok - similarly-named function to switch_to_blog().
+switch_to_blog( $blogid ); // Error.
+
+wpcom_vip_get_page_by_title(); // Ok - VIP recommended version of get_page_by_title().
+get_page_by_title( $page_title ); // Error.
+
+wpcom_vip_url_to_postid( $url ); // Ok - VIP recommended version of url_to_postid().
+url_to_postid( $url ); // Error.
+
+wpcom_vip_add_role(); // Ok - VIP recommended version of add_role().
+class Foo {
+	function add_role() {}
+}
+$x = new Foo();
+$x->add_role(); // Ok - calling an instantiated method of another class and not actual WP add_role().
+class Bar {
+	static function add_role() {}
+}
+$y = Bar::add_role(); // Ok - calling static function of another class and not actual WP add_role().
+\SomeNamespace\add_role(); // Ok - calling namespaced function and not actual WP add_role().
+add_role( 'test' ); // Error.
+\add_role(); // Error.
+
+get_post_meta( 123, 'test' ); // Ok - not using get_user_meta().
+update_post_meta( 1234, 'test', $test ); // Ok - not using update_user_meta().
+delete_post_meta( $int, $test ); // Ok - not using delete_user_meta().
+add_post_meta( $int, $test, $test ); // Ok - not using add_user_meta().
+get_user_meta(); // Error.
+update_user_meta(); // Error.
+delete_user_meta(); // Error.
+add_user_meta(); // Error.
+
+wpcom_vip_term_exists(); // Ok - VIP recommended version of term_exists().
+term_exists(); // Error.
+
+wpcom_vip_count_user_posts(); // Ok - VIP recommended version of count_user_posts().
+count_user_posts(); // Error.
+
+wpcom_vip_old_slug_redirect(); // Ok - VIP recommended version of wp_old_slug_redirect().
+wp_old_slug_redirect(); // Error.
+
+wpcom_vip_get_adjacent_post(); // Ok - VIP recommended version of get_adjacent_post(), get_previous_post(), get_previous_post_link(), get_next_post() and get_next_post_link().
+get_adjacent_post(); // Error.
+get_previous_post(); // Error.
+get_next_post(); // Error.
+get_previous_post_link(); // Error.
+get_next_post_link(); // Error.
+
+get_intermediate_images(); // Ok - similarly-named function to get_intermediate_image_sizes().
+get_intermediate_image_sizes(); // Error.
+
+jetpack_is_mobile(); // Ok - VIP recommended version of wp_is_mobile().
+wp_is_mobile(); // Error.
+
+send_mail(); // Ok - similarly-named function to wp_mail() and mail().
+wp_mail(); // Warning.
+mail(); // Warning.
+
+multi_author(); // Ok - similarly-named function to is_multi_author().
+is_multi_author(); // Warning.
+
+echo esc_html( get_the_field( 'field' ) ); // Ok - ACF echoing and escape via get_* equivalent.
+echo '<img src="test.jpg" alt="' . esc_attr( get_sub_field( 'field' ) ) . '">'; // Ok - ACF echoing and escape via get_* equivalent.
+the_field( 'field' ); // Warning - ACF unescaped template tag.
+the_sub_field( 'field' ); // Warning - ACF unescaped template tag.
+
+vip_safe_wp_remote_get(); // Ok - VIP recommended version of wp_remote_get().
+wp_remote_get( $url ); // Warning.
+
+cookie( $_GET['test'] ); // Ok - similarly-named function to setcookie().
+setcookie( 'cookie[three]', 'cookiethree' ); // Warning.
+
+get_post( 123 ); // Ok - not using get_posts().
+wp_get_recent_post(); // Ok - similarly-named function to wp_get_recent_posts().
+get_child(); // Ok - similarly-named function to get_children().
+get_posts(); // Warning.
+wp_get_recent_posts(); // Warning.
+get_children(); // Warning.
+
+get_term_link(); // Ok - non-deprecated version of wpcom_vip_get_term_link().
+get_term_by(); // Ok - non-deprecated version of wpcom_vip_get_term_by().
+get_category_by_slug(); // Ok - non-deprecated version of wpcom_vip_get_category_by_slug().
+wpcom_vip_get_category_by_slug(); // Warning - deprecated.
+wpcom_vip_get_term_by(); // Warning - deprecated.
+wpcom_vip_get_term_link(); // Warning - deprecated.

--- a/WordPressVIPMinimum/Tests/VIP/RestrictedFunctionsUnitTest.php
+++ b/WordPressVIPMinimum/Tests/VIP/RestrictedFunctionsUnitTest.php
@@ -22,22 +22,42 @@ class RestrictedFunctionsUnitTest extends AbstractSniffUnitTest {
 	 * @return array <int line number> => <int number of errors>
 	 */
 	public function getErrorList() {
-		return array(
-			3  => 1,
-			7  => 1,
-			9  => 1,
-			11 => 1,
-			13 => 1,
-			39 => 1,
-			51 => 1,
-			52 => 1,
-			53 => 1,
-			54 => 1,
-			55 => 1,
-			56 => 1,
-			57 => 1,
-			58 => 1,
-		);
+		return [
+			19  => 1,
+			27  => 1,
+			28  => 1,
+			29  => 1,
+			30  => 1,
+			31  => 1,
+			32  => 1,
+			33  => 1,
+			34  => 1,
+			37  => 1,
+			40  => 1,
+			43  => 1,
+			46  => 1,
+			50  => 1,
+			53  => 1,
+			56  => 1,
+			59  => 1,
+			62  => 1,
+			75  => 1,
+			76  => 1,
+			82  => 1,
+			83  => 1,
+			84  => 1,
+			85  => 1,
+			88  => 1,
+			91  => 1,
+			94  => 1,
+			97  => 1,
+			98  => 1,
+			99  => 1,
+			100 => 1,
+			101 => 1,
+			104 => 1,
+			107 => 1,
+		];
 	}
 
 	/**
@@ -46,18 +66,21 @@ class RestrictedFunctionsUnitTest extends AbstractSniffUnitTest {
 	 * @return array <int line number> => <int number of warnings>
 	 */
 	public function getWarningList() {
-		return array(
-			1  => 1,
-			5  => 1,
-			29 => 1,
-			31 => 1,
-			33 => 1,
-			35 => 1,
-			37 => 1,
-			41 => 1,
-			43 => 1,
-			44 => 1,
-		);
+		return [
+			110 => 1,
+			111 => 1,
+			114 => 1,
+			118 => 1,
+			119 => 1,
+			122 => 1,
+			125 => 1,
+			130 => 1,
+			131 => 1,
+			132 => 1,
+			137 => 1,
+			138 => 1,
+			139 => 1,
+		];
 	}
 
 }


### PR DESCRIPTION
This PR resolves #252.

* Since the sniff for `WordPressVIPMinimum.VIP.RestrictedFunctions.get_page_by_path_get_page_by_path` was being called by the parent class function:
https://github.com/Automattic/VIP-Coding-Standards/blob/f8cd4b5be5b70de1ae009d75404cea205cec0839/WordPressVIPMinimum/Sniffs/VIP/RestrictedFunctionsSniff.php#L24
I ended up removing the dependency of the [already deprecated since WPCS 1.0](https://github.com/WordPress-Coding-Standards/WordPress-Coding-Standards/blob/1cb6a74615be51390776c3c22438c21b010c1737/WordPress/Sniffs/VIP/RestrictedFunctionsSniff.php#L1) `WordPress.VIP.RestrictedFunctions` sniff (see #187) and refactored it into the (no-longer child) `WordPressVIPMinimum.VIP.RestrictedFunctions` sniff: https://github.com/Automattic/VIP-Coding-Standards/blob/f8cd4b5be5b70de1ae009d75404cea205cec0839/WordPressVIPMinimum/Sniffs/VIP/RestrictedFunctionsSniff.php#L1

* In doing so, I ended up re-organizing the unit tests and removing the `file_get_contents()` from the groups since we were just unsetting it:

https://github.com/Automattic/VIP-Coding-Standards/blob/f8cd4b5be5b70de1ae009d75404cea205cec0839/WordPressVIPMinimum/Sniffs/VIP/RestrictedFunctionsSniff.php#L131 

...plus, we already had a sniff for it in `WordPressVIPMinimum.VIP.FetchingRemoteData.fileGetContentsUknown`.

