### PR TITLE
Add StripTags sniff and amend rulesets and existing sniffs

### DIFF
--- a/WordPress-VIP-Go/ruleset.xml
+++ b/WordPress-VIP-Go/ruleset.xml
@@ -147,10 +147,9 @@
 		<type>warning</type>
 		<severity>7</severity>
 	</rule>
-	<rule ref="WordPressVIPMinimum.VIP.RestrictedFunctions.strip_tags_strip_tags">
+	<rule ref="WordPressVIPMinimum.Functions.StripTags">
 		<type>warning</type>
 		<severity>5</severity>
-		<message>We recommend using wp_kses() or wp_kses_post() instead https://codex.wordpress.org/Function_Reference/wp_kses</message>
 	</rule>
 	<rule ref="WordPress.WP.PostsPerPage.posts_per_page_posts_per_page">
 		<type>warning</type>

--- a/WordPressVIPMinimum/Sniffs/Functions/StripTagsSniff.php
+++ b/WordPressVIPMinimum/Sniffs/Functions/StripTagsSniff.php
@@ -50,15 +50,15 @@ class StripTagsSniff extends AbstractFunctionParameterSniff {
 	public function process_parameters( $stackPtr, $group_name, $matched_content, $parameters ) {
 		if ( 1 === count( $parameters ) ) {
 			$this->phpcsFile->addWarning(
-					sprintf( '`strip_tags()` does not strip CSS and JS in between the script and style tags. Use `wp_strip_all_tags()` to strip all tags.', $matched_content ),
-					$stackPtr,
-					'StripTagsOneParameter'
+				sprintf( '`strip_tags()` does not strip CSS and JS in between the script and style tags. Use `wp_strip_all_tags()` to strip all tags.', $matched_content ),
+				$stackPtr,
+				'StripTagsOneParameter'
 			);
 		} elseif ( isset( $parameters[2] ) ) {
 			$this->phpcsFile->addWarning(
-					sprintf( '`strip_tags()` does not strip CSS and JS in between the script and style tags. Use `wp_kses()` instead to allow only the HTML you need.', $matched_content ),
-					$stackPtr,
-					'StripTagsTwoParameters'
+				sprintf( '`strip_tags()` does not strip CSS and JS in between the script and style tags. Use `wp_kses()` instead to allow only the HTML you need.', $matched_content ),
+				$stackPtr,
+				'StripTagsTwoParameters'
 			);
 		}
 	}

--- a/WordPressVIPMinimum/Sniffs/Functions/StripTagsSniff.php
+++ b/WordPressVIPMinimum/Sniffs/Functions/StripTagsSniff.php
@@ -1,0 +1,65 @@
+<?php
+/**
+ * WordPressVIPMinimum Coding Standard.
+ *
+ * @package VIPCS\WordPressVIPMinimum
+ */
+
+namespace WordPressVIPMinimum\Sniffs\Functions;
+
+use WordPress\AbstractFunctionParameterSniff;
+
+/**
+ * This sniff ensures proper tag stripping.
+ *
+ * @package VIPCS\WordPressVIPMinimum
+ *
+ * @since 0.4.0
+ */
+class StripTagsSniff extends AbstractFunctionParameterSniff {
+
+	/**
+	 * The group name for this group of functions.
+	 *
+	 * @var string
+	 */
+	protected $group_name = 'strip_functions';
+
+	/**
+	 * Functions this sniff is looking for.
+	 *
+	 * @var array The only requirement for this array is that the top level
+	 *            array keys are the names of the functions you're looking for.
+	 *            Other than that, the array can have arbitrary content
+	 *            depending on your needs.
+	 */
+	protected $target_functions = [
+		'strip_tags'    => true,
+	];
+
+	/**
+	 * Process the parameters of a matched function.
+	 *
+	 * @param int    $stackPtr        The position of the current token in the stack.
+	 * @param array  $group_name      The name of the group which was matched.
+	 * @param string $matched_content The token content (function name) which was matched.
+	 * @param array  $parameters      Array with information about the parameters.
+	 * @return int|void Integer stack pointer to skip forward or void to continue
+	 *                  normal file processing.
+	 */
+	public function process_parameters( $stackPtr, $group_name, $matched_content, $parameters ) {
+		if ( 1 === count( $parameters ) ) {
+			$this->phpcsFile->addWarning(
+					sprintf( '`strip_tags()` does not strip CSS and JS in between the script and style tags. Use `wp_strip_all_tags()` to strip all tags.', $matched_content ),
+					$stackPtr,
+					'StripTagsOneParameter'
+			);
+		} elseif ( isset( $parameters[2] ) ) {
+			$this->phpcsFile->addWarning(
+					sprintf( '`strip_tags()` does not strip CSS and JS in between the script and style tags. Use `wp_kses()` instead to allow only the HTML you need.', $matched_content ),
+					$stackPtr,
+					'StripTagsTwoParameters'
+			);
+		}
+	}
+}

--- a/WordPressVIPMinimum/Sniffs/VIP/RestrictedFunctionsSniff.php
+++ b/WordPressVIPMinimum/Sniffs/VIP/RestrictedFunctionsSniff.php
@@ -77,14 +77,6 @@ class RestrictedFunctionsSniff extends AbstractFunctionRestrictionsSniff {
 					'attachment_url_to_postid',
 				),
 			),
-			// TODO: Add strip_tags sniff that checks based on parameters.
-			'strip_tags' => array(
-				'type'      => 'error',
-				'message'   => '`%s()` does not strip CSS and JS in between the script and style tags. `wp_strip_all_tags()` should be used instead.',
-				'functions' => array(
-					'strip_tags',
-				),
-			),
 			'dbDelta' => array(
 				'type'      => 'error',
 				'message'   => 'All database modifications have to approved by the WordPress.com VIP team.',

--- a/WordPressVIPMinimum/Tests/Functions/StripTagsUnitTest.inc
+++ b/WordPressVIPMinimum/Tests/Functions/StripTagsUnitTest.inc
@@ -1,0 +1,13 @@
+<?php
+
+$string = '<script>haxx0red</script>';
+$html = '<br><a><b><i>';
+
+strip_tag( 'Test', $html ); // Ok - similarly-named function.
+wp_strip_all_tags( $string ); // Ok.
+
+strip_tags( 'Testing' ); // Warning.
+strip_tags( 'Test', $html ); // Warning.
+strip_tags( 'Test' . ', ' . 'HTML' ); // Warning - concatenation on first parameter.
+strip_tags( 'Test, String', $html ); // Warning - comma in first parameter.
+strip_tags( $string ); // Warning.

--- a/WordPressVIPMinimum/Tests/Functions/StripTagsUnitTest.php
+++ b/WordPressVIPMinimum/Tests/Functions/StripTagsUnitTest.php
@@ -1,0 +1,43 @@
+<?php
+/**
+ * Unit test class for WordPressVIPMinimum Coding Standard.
+ *
+ * @package VIPCS\WordPressVIPMinimum
+ */
+
+namespace WordPressVIPMinimum\Tests\Functions;
+
+use PHP_CodeSniffer\Tests\Standards\AbstractSniffUnitTest;
+
+/**
+ * Unit test class for the StripTags sniff.
+ *
+ * @package VIPCS\WordPressVIPMinimum
+ */
+class StripTagsUnitTest extends AbstractSniffUnitTest {
+
+	/**
+	 * Returns the lines where errors should occur.
+	 *
+	 * @return array <int line number> => <int number of errors>
+	 */
+	public function getErrorList() {
+		return [];
+	}
+
+	/**
+	 * Returns the lines where warnings should occur.
+	 *
+	 * @return array <int line number> => <int number of warnings>
+	 */
+	public function getWarningList() {
+		return [
+			9  => 1,
+			10 => 1,
+			11 => 1,
+			12 => 1,
+			13 => 1,
+		];
+	}
+
+}

--- a/WordPressVIPMinimum/Tests/VIP/RestrictedFunctionsUnitTest.inc
+++ b/WordPressVIPMinimum/Tests/VIP/RestrictedFunctionsUnitTest.inc
@@ -45,9 +45,9 @@ flush_rewrite_rules(); // Error.
 wpcom_vip_attachment_url_to_postid( $url ); // Ok - VIP recommended version of attachment_url_to_postid().
 attachment_url_to_postid( $url ); // Error.
 
-wp_strip_tags( $test ); // Ok - VIP recommended version of strip_tags().
-wp_kses( $test_string, $allowed_html ); // Ok - VIP recommended version of strip_tags().
-strip_tags( $test_string ); // Error.
+
+
+
 
 db_delta(); // Ok - similarly-named function to dbDelta().
 dbDelta(); // Error.

--- a/WordPressVIPMinimum/Tests/VIP/RestrictedFunctionsUnitTest.php
+++ b/WordPressVIPMinimum/Tests/VIP/RestrictedFunctionsUnitTest.php
@@ -36,7 +36,6 @@ class RestrictedFunctionsUnitTest extends AbstractSniffUnitTest {
 			40  => 1,
 			43  => 1,
 			46  => 1,
-			50  => 1,
 			53  => 1,
 			56  => 1,
 			59  => 1,

--- a/WordPressVIPMinimum/ruleset.xml
+++ b/WordPressVIPMinimum/ruleset.xml
@@ -115,6 +115,7 @@
 	<!-- VIP-Go: https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/#remote-calls -->
 	<rule ref="WordPress.WP.AlternativeFunctions">
 		<exclude name="WordPress.WP.AlternativeFunctions.file_get_contents_file_get_contents"/>
+		<exclude name="WordPress.WP.AlternativeFunctions.strip_tags_strip_tags"/>
 	</rule>
 	<!-- VIP recommends other functions -->
 	<rule ref="WordPress.WP.AlternativeFunctions.curl">


### PR DESCRIPTION
This resolves #133.

What this PR does:
* add a StripTags sniff
* remove the WordPress.AlternativeFunctions rules for strip tags
* remove strip_tags from RestrictedFunctions sniff