### PR TITLE
Flag filters for changing timeouts

### DIFF
--- a/WordPress-VIP-Go/ruleset.xml
+++ b/WordPress-VIP-Go/ruleset.xml
@@ -159,10 +159,6 @@
 		<severity>5</severity>
 		<message>Having more than 100 posts returned per page can lead to severe performance problems.</message>
 	</rule>
-	<rule ref="WordPressVIPMinimum.Filters.RestrictedHook.HighTimeout">
-		<type>warning</type>
-		<severity>5</severity>
-	</rule>
 	<rule ref="WordPressVIPMinimum.Classes.RestrictedExtendClasses.wp_cli">
 		<type>warning</type>
 		<severity>5</severity>

--- a/WordPress-VIP-Go/ruleset.xml
+++ b/WordPress-VIP-Go/ruleset.xml
@@ -159,6 +159,10 @@
 		<severity>5</severity>
 		<message>Having more than 100 posts returned per page can lead to severe performance problems.</message>
 	</rule>
+	<rule ref="WordPressVIPMinimum.Filters.RestrictedHook.HighTimeout">
+		<type>warning</type>
+		<severity>5</severity>
+	</rule>
 	<rule ref="WordPressVIPMinimum.Classes.RestrictedExtendClasses.wp_cli">
 		<type>warning</type>
 		<severity>5</severity>

--- a/WordPressVIPMinimum/Sniffs/Filters/RestrictedHookSniff.php
+++ b/WordPressVIPMinimum/Sniffs/Filters/RestrictedHookSniff.php
@@ -46,8 +46,23 @@ class RestrictedHookSniff extends AbstractFunctionParameterSniff {
 	private $restricted_hooks = [
 		'upload_mimes' => [
 			// TODO: This error message needs a link to the VIP Documentation, see https://github.com/Automattic/VIP-Coding-Standards/issues/235.
-			'error'     => 'Please ensure that the mimes being filtered do not include insecure types (i.e. SVG, SWF, etc.). Manual inspection required.',
-			'error_code' => 'UploadMimes',
+			'type' => 'Warning',
+			'msg'  => 'Please ensure that the mimes being filtered do not include insecure types (i.e. SVG, SWF, etc.). Manual inspection required.',
+			'code' => 'UploadMimes',
+		],
+		'http_request_timeout' => [
+			// WordPress.com: https://lobby.vip.wordpress.com/wordpress-com-documentation/fetching-remote-data/.
+			// VIP Go: https://vip.wordpress.com/documentation/vip-go/fetching-remote-data/.
+			'type' => 'Warning',
+			'msg'     => 'Please ensure that the timeout being filtered is not greater than 3s since remote requests require the user to wait for completion before the rest of the page will load. Manual inspection required.',
+			'code'    => 'HighTimeout',
+		],
+		'http_request_args' => [
+			// WordPress.com: https://lobby.vip.wordpress.com/wordpress-com-documentation/fetching-remote-data/.
+			// VIP Go: https://vip.wordpress.com/documentation/vip-go/fetching-remote-data/.
+			'type' => 'Warning',
+			'msg'     => 'Please ensure that the timeout being filtered is not greater than 3s since remote requests require the user to wait for completion before the rest of the page will load. Manual inspection required.',
+			'code'    => 'HighTimeout',
 		],
 	];
 
@@ -64,7 +79,8 @@ class RestrictedHookSniff extends AbstractFunctionParameterSniff {
 	public function process_parameters( $stackPtr, $group_name, $matched_content, $parameters ) {
 		foreach ( $this->restricted_hooks as $restricted_hook => $hook_args ) {
 			if ( $this->normalize_hook_name_from_parameter( $parameters[1] ) === $restricted_hook ) {
-				$this->phpcsFile->addWarning( $hook_args['error'], $stackPtr, $hook_args['error_code'] );
+				$addMethod = 'add' . $hook_args['type'];
+				$this->phpcsFile->{$addMethod}( $hook_args['msg'], $stackPtr, $hook_args['code'] );
 			}
 		}
 	}

--- a/WordPressVIPMinimum/Tests/Filters/RestrictedHookUnitTest.inc
+++ b/WordPressVIPMinimum/Tests/Filters/RestrictedHookUnitTest.inc
@@ -17,3 +17,5 @@ add_filter( 'upload_mimes', function() { // Anonymous callback.
 	// Do stuff.
 });
 add_action( 'upload_mimes', 'bad_example_function' ); // Check `add_action()`, which is an alias for `add_filter()`.
+add_filter( 'http_request_timeout', 'bad_example_function' ); // Simple string.
+add_filter('http_request_args', 'bad_example_function' ); // Simple string + incorrect spacing.

--- a/WordPressVIPMinimum/Tests/Filters/RestrictedHookUnitTest.php
+++ b/WordPressVIPMinimum/Tests/Filters/RestrictedHookUnitTest.php
@@ -44,6 +44,8 @@ class RestrictedHookUnitTest extends AbstractSniffUnitTest {
 			15 => 1,
 			16 => 1,
 			19 => 1,
+			20 => 1,
+			21 => 1,
 		);
 	}
 


### PR DESCRIPTION
Fixes #45.  

Also changes RestrictedHookSniff to have different error types on a hook basis.  I chose a severity of 5 since it matches the other performance issues flagged with a warning of 5.