### PR TITLE
Fix typo in error message for WordPressVIPMinimum.VIP.WPQueryParams.suppressFilters

### DIFF
--- a/WordPressVIPMinimum/Sniffs/VIP/WPQueryParamsSniff.php
+++ b/WordPressVIPMinimum/Sniffs/VIP/WPQueryParamsSniff.php
@@ -47,12 +47,14 @@ class WPQueryParamsSniff implements Sniff {
 			$next_token = $phpcsFile->findNext( array_merge( Tokens::$emptyTokens, array( T_EQUAL, T_CLOSE_SQUARE_BRACKET, T_DOUBLE_ARROW ) ), ( $stackPtr + 1 ), null, true );
 
 			if ( T_TRUE === $tokens[ $next_token ]['code'] ) {
-				$phpcsFile->addError( 'Setting `suppress_filters` to `true` is probihited.', $stackPtr, 'suppressFiltersTrue' );
+				// WordPress.com: https://lobby.vip.wordpress.com/wordpress-com-documentation/uncached-functions/.
+				// VIP Go: https://vip.wordpress.com/documentation/vip-go/uncached-functions/.
+				$phpcsFile->addError( 'Setting `suppress_filters` to `true` is prohibited.', $stackPtr, 'suppressFiltersTrue' );
 			}
 		}
 
 		if ( 'post__not_in' === trim( $tokens[ $stackPtr ]['content'], '\'' ) ) {
-			$phpcsFile->addWarning( 'Using `post__not_in` should be done with caution.', $stackPtr, 'post__not_in' );
+			$phpcsFile->addWarning( 'Using `post__not_in` should be done with caution, see https://vip.wordpress.com/documentation/performance-improvements-by-removing-usage-of-post__not_in/ for more information.', $stackPtr, 'post__not_in' );
 		}
 	}
 


### PR DESCRIPTION
Fixes #277.

Also:
* adds supporting documentation links in comments per platform.
* adds documentation link directly in error message for `post__not_in` warning.