### PR TITLE
Remove string concatenation from message for better readability.

### DIFF
--- a/WordPressVIPMinimum/Sniffs/Functions/CreateFunctionSniff.php
+++ b/WordPressVIPMinimum/Sniffs/Functions/CreateFunctionSniff.php
@@ -80,8 +80,7 @@ class CreateFunctionSniff implements \PHP_CodeSniffer_Sniff {
 		}
 
 		$phpcsFile->addError(
-			'create_function() is deprecated as of ' .
-				'PHP 7.2.0',
+			'create_function() is deprecated as of PHP 7.2.0.',
 			$functionName,
 			'CreateFunction'
 		);

--- a/WordPressVIPMinimum/Sniffs/Functions/DynamicCallsSniff.php
+++ b/WordPressVIPMinimum/Sniffs/Functions/DynamicCallsSniff.php
@@ -251,17 +251,10 @@ class DynamicCallsSniff implements Sniff {
 
 		// We do, so report.
 		$this->_phpcsFile->addError(
-			sprintf(
-				'Dynamic calling is not recommended ' .
-					'in the case of %s',
-				$this->_variables_arr[
-					$this->_tokens[
-						$this->_stackPtr
-					]['content']
-				]
-			),
+			'Dynamic calling is not recommended in the case of %s',
 			$t_item_key,
-			'DynamicCalls'
+			'DynamicCalls',
+			[ $this->_variables_arr[ $this->_tokens[ $this->_stackPtr ]['content'] ] ]
 		);
 	}
 }

--- a/WordPressVIPMinimum/Sniffs/JS/WindowSniff.php
+++ b/WordPressVIPMinimum/Sniffs/JS/WindowSniff.php
@@ -132,11 +132,21 @@ class WindowSniff implements Sniff {
 		$prevTokenPtr = $phpcsFile->findPrevious( Tokens::$emptyTokens, ( $stackPtr - 1 ), null, true, null, true );
 		if ( T_EQUAL === $tokens[ $prevTokenPtr ]['code'] ) {
 			// Variable assignment.
-			$phpcsFile->addWarning( sprintf( 'Data from JS global "' . $windowProperty . '" may contain user-supplied values and should be checked.', $tokens[ $stackPtr ]['content'] ), $stackPtr, 'VarAssignment' );
+			$phpcsFile->addWarning(
+				'Data from JS global "%s" may contain user-supplied values and should be checked.',
+				$stackPtr,
+				'VarAssignment',
+				[ $windowProperty ]
+			);
 			return;
 		}
 
-		$phpcsFile->addError( sprintf( 'Data from JS global "' . $windowProperty . '" may contain user-supplied values and should be sanitized before output to prevent XSS.', $tokens[ $stackPtr ]['content'] ), $stackPtr, $nextNextToken );
+		$phpcsFile->addError(
+			'Data from JS global "%s" may contain user-supplied values and should be sanitized before output to prevent XSS.',
+			$stackPtr,
+			$nextNextToken,
+			[ $windowProperty ]
+		);
 	}
 
 }


### PR DESCRIPTION
Fixes #275. Also removes any `sprintf()` usage.