### PR TITLE
Fix AlwaysReturnSniff for missing return statement

### DIFF
--- a/WordPressVIPMinimum/Sniffs/Filters/AlwaysReturnSniff.php
+++ b/WordPressVIPMinimum/Sniffs/Filters/AlwaysReturnSniff.php
@@ -228,7 +228,7 @@ class AlwaysReturnSniff implements \PHP_CodeSniffer_Sniff {
 			);
 		}
 
-		if ( 0 < $insideIfConditionalReturn && 0 === $outsideConditionalReturn ) {
+		if ( 0 <= $insideIfConditionalReturn && 0 === $outsideConditionalReturn ) {
 			$this->phpcsFile->AddWarning( sprintf( 'Please, make sure that a callback to `%s` filter is always returning some value.', $filterName ), $functionBodyScopeStart, 'missingReturnStatement' );
 		}
 	}

--- a/WordPressVIPMinimum/Tests/Filters/AlwaysReturnUnitTest.inc
+++ b/WordPressVIPMinimum/Tests/Filters/AlwaysReturnUnitTest.inc
@@ -101,3 +101,9 @@ if ( 1 === 1 ) {
 		return 'hello';
 	} );
 }
+
+add_filter( 'bad_example_closure_with_no_returns', function( $input ) {
+	$input = $input . ' hello!';
+
+	// But we never return _anywhere_
+}, 10, 2 );

--- a/WordPressVIPMinimum/Tests/Filters/AlwaysReturnUnitTest.php
+++ b/WordPressVIPMinimum/Tests/Filters/AlwaysReturnUnitTest.php
@@ -35,6 +35,7 @@ class AlwaysReturnUnitTest extends AbstractSniffUnitTest {
 			49 => 1,
 			88 => 1,
 			95 => 1,
+			105 => 1,
 		);
 	}
 


### PR DESCRIPTION
Now properly catches filter callbacks that don't `return` _anywhere_ inside the function body

Fixes #290 