### PR TITLE
Fix PHPCS violations in VIPCS

### DIFF
--- a/WordPressVIPMinimum/Sniffs/Classes/RestrictedExtendClassesSniff.php
+++ b/WordPressVIPMinimum/Sniffs/Classes/RestrictedExtendClassesSniff.php
@@ -28,7 +28,7 @@ class RestrictedExtendClassesSniff extends AbstractClassRestrictionsSniff {
 	public function getGroups() {
 		return array(
 			'wp_cli' => array(
-				'type' => 'warning',
+				'type'    => 'warning',
 				'message' => 'We recommend extending `WPCOM_VIP_CLI_Command` instead of `WP_CLI_Command` and using the helper functions available in it (such as `stop_the_insanity()`), see https://vip.wordpress.com/documentation/writing-bin-scripts/ for more information.',
 				'classes' => array(
 					'WP_CLI_Command',

--- a/WordPressVIPMinimum/Sniffs/Filters/RestrictedHookSniff.php
+++ b/WordPressVIPMinimum/Sniffs/Filters/RestrictedHookSniff.php
@@ -54,15 +54,15 @@ class RestrictedHookSniff extends AbstractFunctionParameterSniff {
 			// WordPress.com: https://lobby.vip.wordpress.com/wordpress-com-documentation/fetching-remote-data/.
 			// VIP Go: https://vip.wordpress.com/documentation/vip-go/fetching-remote-data/.
 			'type' => 'Warning',
-			'msg'     => 'Please ensure that the timeout being filtered is not greater than 3s since remote requests require the user to wait for completion before the rest of the page will load. Manual inspection required.',
-			'code'    => 'HighTimeout',
+			'msg'  => 'Please ensure that the timeout being filtered is not greater than 3s since remote requests require the user to wait for completion before the rest of the page will load. Manual inspection required.',
+			'code' => 'HighTimeout',
 		],
 		'http_request_args' => [
 			// WordPress.com: https://lobby.vip.wordpress.com/wordpress-com-documentation/fetching-remote-data/.
 			// VIP Go: https://vip.wordpress.com/documentation/vip-go/fetching-remote-data/.
 			'type' => 'Warning',
-			'msg'     => 'Please ensure that the timeout being filtered is not greater than 3s since remote requests require the user to wait for completion before the rest of the page will load. Manual inspection required.',
-			'code'    => 'HighTimeout',
+			'msg'  => 'Please ensure that the timeout being filtered is not greater than 3s since remote requests require the user to wait for completion before the rest of the page will load. Manual inspection required.',
+			'code' => 'HighTimeout',
 		],
 	];
 

--- a/WordPressVIPMinimum/Sniffs/Functions/StripTagsSniff.php
+++ b/WordPressVIPMinimum/Sniffs/Functions/StripTagsSniff.php
@@ -34,7 +34,7 @@ class StripTagsSniff extends AbstractFunctionParameterSniff {
 	 *            depending on your needs.
 	 */
 	protected $target_functions = [
-		'strip_tags'    => true,
+		'strip_tags' => true,
 	];
 
 	/**

--- a/WordPressVIPMinimum/Sniffs/JS/WindowSniff.php
+++ b/WordPressVIPMinimum/Sniffs/JS/WindowSniff.php
@@ -59,8 +59,8 @@ class WindowSniff implements Sniff {
 			'port'     => true,
 			'password' => true,
 		],
-		'name'   => true,
-		'status' => true,
+		'name'     => true,
+		'status'   => true,
 	];
 
 	/**
@@ -90,7 +90,7 @@ class WindowSniff implements Sniff {
 		}
 
 		$nextTokenPtr = $phpcsFile->findNext( Tokens::$emptyTokens, ( $stackPtr + 1 ), null, true, null, true );
-		$nextToken = $tokens[ $nextTokenPtr ]['code'];
+		$nextToken    = $tokens[ $nextTokenPtr ]['code'];
 		if ( T_OBJECT_OPERATOR !== $nextToken && T_OPEN_SQUARE_BRACKET !== $nextToken ) {
 			// No . or [' next, bail.
 			return;
@@ -109,7 +109,7 @@ class WindowSniff implements Sniff {
 		}
 
 		$nextNextNextTokenPtr = $phpcsFile->findNext( array_merge( [ T_CLOSE_SQUARE_BRACKET ], Tokens::$emptyTokens ), ( $nextNextTokenPtr + 1 ), null, true, null, true );
-		$nextNextNextToken = $tokens[ $nextNextNextTokenPtr ]['code'];
+		$nextNextNextToken    = $tokens[ $nextNextNextTokenPtr ]['code'];
 
 		$nextNextNextNextToken = false;
 		if ( T_OBJECT_OPERATOR === $nextNextNextToken || T_OPEN_SQUARE_BRACKET === $nextNextNextToken ) {
@@ -126,7 +126,7 @@ class WindowSniff implements Sniff {
 			}
 		}
 
-		$windowProperty = 'window.';
+		$windowProperty  = 'window.';
 		$windowProperty .= $nextNextNextNextToken ? $nextNextToken . '.' . $nextNextNextNextToken : $nextNextToken;
 
 		$prevTokenPtr = $phpcsFile->findPrevious( Tokens::$emptyTokens, ( $stackPtr - 1 ), null, true, null, true );

--- a/WordPressVIPMinimum/Sniffs/Variables/ServerVariablesSniff.php
+++ b/WordPressVIPMinimum/Sniffs/Variables/ServerVariablesSniff.php
@@ -24,11 +24,11 @@ class ServerVariablesSniff implements Sniff {
 	 * @var array
 	 */
 	public $restrictedVariables = array(
-		'authVariables' => array(
+		'authVariables'           => array(
 			'PHP_AUTH_USER' => true,
 			'PHP_AUTH_PW'   => true,
 		),
-		'userControlledVariables'  => array(
+		'userControlledVariables' => array(
 			'HTTP_X_IP_TRAIL'      => true,
 			'HTTP_X_FORWARDED_FOR' => true,
 			'REMOTE_ADDR'          => true,

--- a/WordPressVIPMinimum/Tests/Filters/AlwaysReturnUnitTest.php
+++ b/WordPressVIPMinimum/Tests/Filters/AlwaysReturnUnitTest.php
@@ -31,10 +31,10 @@ class AlwaysReturnUnitTest extends AbstractSniffUnitTest {
 	 */
 	public function getWarningList() {
 		return array(
-			15 => 1,
-			49 => 1,
-			88 => 1,
-			95 => 1,
+			15  => 1,
+			49  => 1,
+			88  => 1,
+			95  => 1,
 			105 => 1,
 		);
 	}

--- a/WordPressVIPMinimum/Tests/Filters/RestrictedHookUnitTest.php
+++ b/WordPressVIPMinimum/Tests/Filters/RestrictedHookUnitTest.php
@@ -33,9 +33,9 @@ class RestrictedHookUnitTest extends AbstractSniffUnitTest {
 	 */
 	public function getWarningList() {
 		return array(
-			7 => 1,
-			8 => 1,
-			9 => 1,
+			7  => 1,
+			8  => 1,
+			9  => 1,
 			10 => 1,
 			11 => 1,
 			12 => 1,

--- a/WordPressVIPMinimum/Tests/Variables/VariableAnalysisUnitTest.php
+++ b/WordPressVIPMinimum/Tests/Variables/VariableAnalysisUnitTest.php
@@ -32,7 +32,7 @@ class VariableAnalysisUnitTest extends AbstractSniffUnitTest {
 	 */
 	public function getWarningList() {
 		return [
-			5 => 2,
+			5  => 2,
 			18 => 2,
 		];
 	}

--- a/bin/phpcs
+++ b/bin/phpcs
@@ -9,4 +9,4 @@
 #
 #   ./bin/phpcs
 
-"$(pwd)/vendor/bin/phpcs" --runtime-set ignore_warnings_on_exit 1
+"$(pwd)/vendor/bin/phpcs"


### PR DESCRIPTION
Fixes whitespace-only violations in our own sniff and test code.

Stops ignoring warnings on exit when running PHPCS against our own code, so that these can't slip in again.