### PR TITLE
Change Composer test script order

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -40,9 +40,9 @@
 		"phpunit": "bin/unit-tests",
 		"test": [
 			"@lint",
-			"@phpcs",
 			"@integration",
-			"@phpunit"
+			"@phpunit",
+			"@phpcs"
 		]
 	},
 	"support": {


### PR DESCRIPTION
The `@phpcs` Composer script takes the longest to execute, and is less critical than the integration and unit tests, so move the `@phpcs` to be the last item in the `test` Composer script.