### PR TITLE
Use PHPCS 3.x namespaced classes

### DIFF
--- a/WordPressVIPMinimum/Sniffs/Filters/AlwaysReturnSniff.php
+++ b/WordPressVIPMinimum/Sniffs/Filters/AlwaysReturnSniff.php
@@ -7,15 +7,16 @@
 
 namespace WordPressVIPMinimum\Sniffs\Filters;
 
-use PHP_CodeSniffer_File as File;
-use PHP_CodeSniffer_Tokens as Tokens;
+use PHP_CodeSniffer\Files\File;
+use PHP_CodeSniffer\Sniffs\Sniff;
+use PHP_CodeSniffer\Util\Tokens;
 
 /**
  * This sniff validates that filters always return a value
  *
  * @package VIPCS\WordPressVIPMinimum
  */
-class AlwaysReturnSniff implements \PHP_CodeSniffer_Sniff {
+class AlwaysReturnSniff implements Sniff {
 
 	/**
 	 * The tokens of the phpcsFile.

--- a/WordPressVIPMinimum/Sniffs/Functions/CreateFunctionSniff.php
+++ b/WordPressVIPMinimum/Sniffs/Functions/CreateFunctionSniff.php
@@ -7,8 +7,8 @@
 
 namespace WordPressVIPMinimum\Sniffs\Functions;
 
-use PHP_CodeSniffer_File as File;
-use PHP_CodeSniffer_Tokens as Tokens;
+use PHP_CodeSniffer\Files\File;
+use PHP_CodeSniffer\Sniffs\Sniff;
 
 /**
  * This function generates an error when
@@ -23,7 +23,7 @@ use PHP_CodeSniffer_Tokens as Tokens;
  *
  * See here: http://php.net/manual/en/function.create-function.php
  */
-class CreateFunctionSniff implements \PHP_CodeSniffer_Sniff {
+class CreateFunctionSniff implements Sniff {
 	/**
 	 * Returns the token types that this sniff is interested in.
 	 *

--- a/WordPressVIPMinimum/Sniffs/VIP/MergeConflictSniff.php
+++ b/WordPressVIPMinimum/Sniffs/VIP/MergeConflictSniff.php
@@ -7,8 +7,9 @@
 
 namespace WordPressVIPMinimum\Sniffs\VIP;
 
-use PHP_CodeSniffer_File as File;
-use PHP_CodeSniffer_Tokens as Tokens;
+use PHP_CodeSniffer\Files\File;
+use PHP_CodeSniffer\Sniffs\Sniff;
+use PHP_CodeSniffer\Util\Tokens;
 
 /**
  * WordPressVIPMinimum_Sniffs_Files_IncludingFileSniff.
@@ -17,7 +18,7 @@ use PHP_CodeSniffer_Tokens as Tokens;
  *
  * @package VIPCS\WordPressVIPMinimum
  */
-class MergeConflictSniff implements \PHP_CodeSniffer_Sniff {
+class MergeConflictSniff implements Sniff {
 
 	/**
 	 * A list of tokenizers this sniff supports.

--- a/WordPressVIPMinimum/Sniffs/VIP/RobotstxtSniff.php
+++ b/WordPressVIPMinimum/Sniffs/VIP/RobotstxtSniff.php
@@ -12,13 +12,12 @@ namespace WordPressVIPMinimum\Sniffs\VIP;
 use PHP_CodeSniffer\Files\File;
 use PHP_CodeSniffer\Sniffs\Sniff;
 use PHP_CodeSniffer\Util\Tokens;
-use PHP_CodeSniffer\Util;
 
 /**
  * This sniff searches for `do_robotstxt` action hooked callback and thows an internal reminder
  * for VIP devs to flush related caches in order to make the change actually happen in production
  */
-class RobotstxtSniff implements \PHP_CodeSniffer_Sniff {
+class RobotstxtSniff implements Sniff {
 
 	/**
 	 * Returns the token types that this sniff is interested in.


### PR DESCRIPTION
Remove use of PHPCS 2.x class names in favour of the namespaced classes from PHPCS 3.x.

Fixes #300.