### PR TITLE
PHPCS: Bump testVersion to match PHP requirement

### DIFF
--- a/.phpcs.xml.dist
+++ b/.phpcs.xml.dist
@@ -33,7 +33,7 @@
 	<rule ref="PSR2.Methods.FunctionClosingBrace"/>
 
 	<!-- Check code for cross-version PHP compatibility. -->
-	<config name="testVersion" value="5.4-"/>
+	<config name="testVersion" value="5.6-"/>
 	<rule ref="PHPCompatibility">
 		<!-- Exclude PHP constants back-filled by PHPCS. -->
 		<exclude name="PHPCompatibility.PHP.NewConstants.t_finallyFound"/>


### PR DESCRIPTION
We require PHP 5.6 or above (in `composer.json`), so we only need to check our code is compatible with PHP 5.6 and above.

Fixes #305