### PR TITLE
PHPCS: Add XSD reference and validate rulesets

### DIFF
--- a/.phpcs.xml.dist
+++ b/.phpcs.xml.dist
@@ -1,6 +1,6 @@
 <?xml version="1.0"?>
-<ruleset name="VIP Coding Standards">
-	<description>The Coding standard for the VIP Coding Standards itself.</description>
+<ruleset xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" name="VIP Coding Standards" xsi:noNamespaceSchemaLocation="https://raw.githubusercontent.com/squizlabs/PHP_CodeSniffer/master/phpcs.xsd">
+	<description>The custom ruleset for the VIP Coding Standards itself.</description>
 
 	<file>.</file>
 	<!-- Exclude Composer vendor directory. -->

--- a/.travis.yml
+++ b/.travis.yml
@@ -58,6 +58,8 @@ jobs:
         # Lint the PHP files against parse errors.
         - ./bin/php-lint
 
+        # Add PHPCS locally for the XSD.
+        - composer require squizlabs/php_codesniffer
         # Validate the XML files and check the code-style consistency of the XML files.
         - ./bin/xml-lint
 

--- a/WordPress-VIP-Go/ruleset.xml
+++ b/WordPress-VIP-Go/ruleset.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0"?>
-<ruleset name="WordPress VIP Go">
+<ruleset xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" name="WordPress VIP Go" xsi:noNamespaceSchemaLocation="https://raw.githubusercontent.com/squizlabs/PHP_CodeSniffer/master/phpcs.xsd">
 	<description>WordPress VIP Go Coding Standards</description>
 
 	<!-- Include the base VIP Minimum ruleset -->
@@ -39,17 +39,17 @@
 	 -->
 	<rule ref="WordPressVIPMinimum.VIP.RestrictedFunctions.file_get_contents_file_get_contents">
 		<type>error</type>
-		<Severity>5</Severity>
+		<severity>5</severity>
 		<message>%s() is uncached. If this is being used to query a remote file please use wpcom_vip_file_get_contents() instead. If it's used for a local file please use WP_Filesystem instead. Read more here: https://vip.wordpress.com/documentation/using-wp_filesystem-instead-of-direct-file-access-functions/</message>
 	</rule>
 	<rule ref="WordPress.WP.AlternativeFunctions.file_system_read_file_get_contents">
 		<type>error</type>
-		<Severity>5</Severity>
+		<severity>5</severity>
 		<message>%s() is uncached. If this is being used to query a remote file please use wpcom_vip_file_get_contents() instead. If it's used for a local file please use WP_Filesystem instead. Read more here: https://vip.wordpress.com/documentation/using-wp_filesystem-instead-of-direct-file-access-functions/</message>
 	</rule>
 	<rule ref="WordPressVIPMinimum.VIP.FetchingRemoteData.fileGetContentsUknown">
 		<type>error</type>
-		<Severity>5</Severity>
+		<severity>5</severity>
 	</rule>
 	<rule ref="WordPress.WP.AlternativeFunctions.file_system_read_fopen">
 		<type>error</type>

--- a/WordPressVIPMinimum/ruleset.xml
+++ b/WordPressVIPMinimum/ruleset.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0"?>
-<ruleset name="WordPress VIP Minimum">
+<ruleset xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" name="WordPress VIP Minimum" xsi:noNamespaceSchemaLocation="https://raw.githubusercontent.com/squizlabs/PHP_CodeSniffer/master/phpcs.xsd">
 	<description>WordPress VIP Minimum Coding Standards</description>
 
 	<!-- Link references are platform-specific. See

--- a/bin/xml-lint
+++ b/bin/xml-lint
@@ -9,7 +9,8 @@
 #   ./bin/xml-lint
 
 # Validate the ruleset XML files.
-xmllint --noout ./*/ruleset.xml
+#xmllint --noout --schema ./vendor/squizlabs/php_codesniffer/phpcs.xsd ./*/ruleset.xml
+xmllint --noout --schema ./vendor/squizlabs/php_codesniffer/phpcs.xsd ./*/ruleset.xml
 
 # Check the code-style consistency of the XML files.
 export XMLLINT_INDENT="	" # This is a tab character.


### PR DESCRIPTION
As of PHPCS 3.2.0, PHPCS includes an XSD schema for rulesets which defines what can be used in the XML ruleset file.

In PHPCS 3.3.0 a new array format for properties was introduced and as of PHPCS 3.3.2, the new array format is now also covered by this schema.

This commit:

- Adds the schema tags to the `ruleset.xml` files, and the VIPCS native `.phpcs.xml.dist` file.
- Adds validation against the schema for the `ruleset.xml` files to the Travis build.
- Fixes invalid markup in the `WordPress-VIP-Go` ruleset flagged by the validation procedure.

Note:
The schema used in the tags points to the online schema in PHPCS master for two reasons:

1. While VIPCS has a minimum requirement of PHPCS 3.2.3, the schema in PHPCS master contains the changes which were made in PHPCS 3.3.2, so we can safely validate the rulesets against the schema.
2. While installation via Composer is supported for WPCS, it is not the only supported installation method, so pointing to the version of the XSD schema in the vendor directory would be presumptuous.

At the same time, using the URL in the Travis script appears to be problematic and as we're doing a `composer install` there anyway, we may as well use the version in the vendor directory for the actual validation. As the validation is done on a build with PHPCS master, there will be no difference anyway.

Fixes #302.

Much kudos to @jrfnl for her work and words that this commit is highly based on.