### PR TITLE
AlwaysReturnSniff will trigger errors unless callback args is pass by reference

### DIFF
--- a/WordPressVIPMinimum/Sniffs/Filters/AlwaysReturnSniff.php
+++ b/WordPressVIPMinimum/Sniffs/Filters/AlwaysReturnSniff.php
@@ -217,7 +217,12 @@ class AlwaysReturnSniff implements Sniff {
 				$outsideConditionalReturn++;
 			}
 			if ( $this->isReturningVoid( $returnTokenPtr ) ) {
-				$this->phpcsFile->AddWarning( sprintf( 'Please, make sure that a callback to `%s` filter is returning void intentionally.', $filterName ), $functionBodyScopeStart, 'voidReturn' );
+				$this->phpcsFile->addError(
+					'Please, make sure that a callback to `%s` filter is returning void intentionally.',
+					$functionBodyScopeStart,
+					'voidReturn',
+					[ $filterName ]
+				);
 			}
 			$returnTokenPtr = $this->phpcsFile->findNext(
 				array( T_RETURN ), // types.
@@ -230,7 +235,12 @@ class AlwaysReturnSniff implements Sniff {
 		}
 
 		if ( 0 <= $insideIfConditionalReturn && 0 === $outsideConditionalReturn ) {
-			$this->phpcsFile->AddWarning( sprintf( 'Please, make sure that a callback to `%s` filter is always returning some value.', $filterName ), $functionBodyScopeStart, 'missingReturnStatement' );
+			$this->phpcsFile->addError(
+				'Please, make sure that a callback to `%s` filter is always returning some value.',
+				$functionBodyScopeStart,
+				'missingReturnStatement',
+				[ $filterName ]
+			);
 		}
 	}
 

--- a/WordPressVIPMinimum/Sniffs/Filters/AlwaysReturnSniff.php
+++ b/WordPressVIPMinimum/Sniffs/Filters/AlwaysReturnSniff.php
@@ -193,8 +193,22 @@ class AlwaysReturnSniff implements Sniff {
 	 */
 	private function processFunctionBody( $stackPtr ) {
 
-		$filterName = $this->tokens[ $this->filterNamePtr ]['content'];
+		$argPtr = $this->phpcsFile->findNext(
+			array_merge( Tokens::$emptyTokens, [ T_STRING, T_OPEN_PARENTHESIS ] ), // types.
+			$stackPtr + 1, // start.
+			null, // end.
+			true, // exclude.
+			null, // value.
+			true // local.
+		);
 
+		// If arg is being passed by reference, we can skip.
+		if ( T_BITWISE_AND === $this->tokens[ $argPtr ][ 'code' ] ) {
+			return;
+		}
+
+		$filterName = $this->tokens[ $this->filterNamePtr ]['content'];
+	
 		$functionBodyScopeStart = $this->tokens[ $stackPtr ]['scope_opener'];
 		$functionBodyScopeEnd   = $this->tokens[ $stackPtr ]['scope_closer'];
 

--- a/WordPressVIPMinimum/Sniffs/Filters/AlwaysReturnSniff.php
+++ b/WordPressVIPMinimum/Sniffs/Filters/AlwaysReturnSniff.php
@@ -203,12 +203,12 @@ class AlwaysReturnSniff implements Sniff {
 		);
 
 		// If arg is being passed by reference, we can skip.
-		if ( T_BITWISE_AND === $this->tokens[ $argPtr ][ 'code' ] ) {
+		if ( T_BITWISE_AND === $this->tokens[ $argPtr ]['code'] ) {
 			return;
 		}
 
 		$filterName = $this->tokens[ $this->filterNamePtr ]['content'];
-	
+
 		$functionBodyScopeStart = $this->tokens[ $stackPtr ]['scope_opener'];
 		$functionBodyScopeEnd   = $this->tokens[ $stackPtr ]['scope_closer'];
 

--- a/WordPressVIPMinimum/Tests/Filters/AlwaysReturnUnitTest.inc
+++ b/WordPressVIPMinimum/Tests/Filters/AlwaysReturnUnitTest.inc
@@ -1,6 +1,6 @@
 <?php
 
-function good_example_function() {
+function good_example_function() { // Ok.
 	if ( 1 === 0  ) {
 		if ( 1 === 1 ) {
 			return 'ahoj';
@@ -12,7 +12,7 @@ function good_example_function() {
 }
 add_filter( 'good_example_function_filter', 'good_example_function' );
 
-function bad_example_function() {
+function bad_example_function() { // Error.
 	if ( 1 === 0  ) {
 		if ( 1 === 1 ) {
 			return 'ahoj';
@@ -24,7 +24,7 @@ function bad_example_function() {
 }
 add_filter( 'bad_example_function_filter', 'bad_example_function' );
 
-class good_example_class {
+class good_example_class { // Ok.
 	public function __construct() {
 		add_filter( 'good_example_class_filter', array( $this, 'class_filter' ) );
 	}
@@ -41,7 +41,7 @@ class good_example_class {
 	}
 }
 
-class bad_example_class {
+class bad_example_class { // Error.
 	public function __construct() {
 		add_filter( 'bad_example_class_filter', array( $this, 'class_filter' ) );
 	}
@@ -58,7 +58,7 @@ class bad_example_class {
 	}
 }
 
-if ( ! class_exists( 'another_good_example_class' ) ) {
+if ( ! class_exists( 'another_good_example_class' ) ) { // Ok.
 	class another_good_example_class {
 		public function __construct() {
 			add_filter( 'another_good_example_class_filter', array( $this, 'class_filter' ) );
@@ -77,7 +77,7 @@ if ( ! class_exists( 'another_good_example_class' ) ) {
 	}
 }
 
-add_filter( 'good_example_closure', function() {
+add_filter( 'good_example_closure', function() { // Ok.
 	if ( 1 === 0 ) {
 		return 'Hello';
 	} else {
@@ -85,24 +85,60 @@ add_filter( 'good_example_closure', function() {
 	}
 } );
 
-add_filter( 'bad_example_closure', function() {
+add_filter( 'bad_example_closure', function() { // Error.
 	if ( 1 === 0 ) {
 		return 'hey';
 	}
 	// Missing else return;
 } );
 
-add_filter( 'another_bad_example_closure', function() {
+add_filter( 'another_bad_example_closure', function() { // Error.
 	return;
 } );
 
 if ( 1 === 1 ) {
-	add_filter( 'another_good_example_closure', function () {
+	add_filter( 'another_good_example_closure', function () { // Ok.
 		return 'hello';
 	} );
 }
 
-add_filter( 'bad_example_closure_with_no_returns', function( $input ) {
+add_filter( 'bad_example_closure_with_no_returns', function( $input ) { // Error.
+	$input = $input . ' hello!';
+
+	// But we never return _anywhere_
+}, 10, 2 );
+
+function good_example_arg_pass_by_ref( &$test ) { // Ok.
+	if ( 1 === 0  ) {
+		if ( 1 === 1 ) {
+			return 'ahoj';
+		} else {
+			return $test . 'hello';
+		}
+	}
+	// Missing universal return.
+}
+add_filter( 'good_example_filter', 'good_example_arg_pass_by_ref' );
+
+add_filter( 'good_anonymous_example_arg_pass_by_ref', function( &$input ) { // Ok.
+	$input = $input . ' hello!';
+
+	// But we never return _anywhere_
+}, 10, 2 );
+
+function bad_example_arg( $test ) { // Error.
+	if ( 1 === 0  ) {
+		if ( 1 === 1 ) {
+			return 'ahoj';
+		} else {
+			return $test . 'hello';
+		}
+	}
+	// Missing universal return.
+}
+add_filter( 'bad_example_filter', 'bad_example_arg' );
+
+add_filter( 'bad_anonymous_example_arg', function( $input ) { // Error.
 	$input = $input . ' hello!';
 
 	// But we never return _anywhere_

--- a/WordPressVIPMinimum/Tests/Filters/AlwaysReturnUnitTest.inc
+++ b/WordPressVIPMinimum/Tests/Filters/AlwaysReturnUnitTest.inc
@@ -137,9 +137,3 @@ function bad_example_arg( $test ) { // Error.
 	// Missing universal return.
 }
 add_filter( 'bad_example_filter', 'bad_example_arg' );
-
-add_filter( 'bad_anonymous_example_arg', function( $input ) { // Error.
-	$input = $input . ' hello!';
-
-	// But we never return _anywhere_
-}, 10, 2 );

--- a/WordPressVIPMinimum/Tests/Filters/AlwaysReturnUnitTest.php
+++ b/WordPressVIPMinimum/Tests/Filters/AlwaysReturnUnitTest.php
@@ -21,7 +21,13 @@ class AlwaysReturnUnitTest extends AbstractSniffUnitTest {
 	 * @return array <int line number> => <int number of errors>
 	 */
 	public function getErrorList() {
-		return array();
+		return [
+			15  => 1,
+			49  => 1,
+			88  => 1,
+			95  => 1,
+			105 => 1,
+		];
 	}
 
 	/**
@@ -30,13 +36,7 @@ class AlwaysReturnUnitTest extends AbstractSniffUnitTest {
 	 * @return array <int line number> => <int number of warnings>
 	 */
 	public function getWarningList() {
-		return array(
-			15  => 1,
-			49  => 1,
-			88  => 1,
-			95  => 1,
-			105 => 1,
-		);
+		return [];
 	}
 
 }

--- a/WordPressVIPMinimum/Tests/Filters/AlwaysReturnUnitTest.php
+++ b/WordPressVIPMinimum/Tests/Filters/AlwaysReturnUnitTest.php
@@ -27,6 +27,8 @@ class AlwaysReturnUnitTest extends AbstractSniffUnitTest {
 			88  => 1,
 			95  => 1,
 			105 => 1,
+			129 => 1,
+			141 => 1,
 		];
 	}
 

--- a/WordPressVIPMinimum/Tests/Filters/AlwaysReturnUnitTest.php
+++ b/WordPressVIPMinimum/Tests/Filters/AlwaysReturnUnitTest.php
@@ -28,7 +28,6 @@ class AlwaysReturnUnitTest extends AbstractSniffUnitTest {
 			95  => 1,
 			105 => 1,
 			129 => 1,
-			141 => 1,
 		];
 	}
 


### PR DESCRIPTION
Fixes #293.

* If no return, it will trigger an error instead of a warning.
* If a callback arg is being passed in by reference, it should not trigger.