### PR TITLE
De-duplicate violation codes

### DIFF
--- a/WordPressVIPMinimum/Sniffs/Constants/ConstantRestrictionsSniff.php
+++ b/WordPressVIPMinimum/Sniffs/Constants/ConstantRestrictionsSniff.php
@@ -74,7 +74,7 @@ class ConstantRestrictionsSniff implements Sniff {
 		}
 
 		if ( T_STRING === $tokens[ $stackPtr ]['code'] && true === in_array( $constantName, $this->restrictedConstantNames, true ) ) {
-			$phpcsFile->addWarning( sprintf( 'Code is touching the `%s` constant. Make sure it\'s used appropriately.', $constantName ), $stackPtr, 'ConstantRestrictions' );
+			$phpcsFile->addWarning( sprintf( 'Code is touching the `%s` constant. Make sure it\'s used appropriately.', $constantName ), $stackPtr, 'UsingRestrictedConstant' );
 			return;
 		}
 
@@ -102,9 +102,9 @@ class ConstantRestrictionsSniff implements Sniff {
 
 		if ( true === in_array( $tokens[ $previous ]['code'], Tokens::$functionNameTokens, true ) ) {
 			if ( 'define' === $tokens[ $previous ]['content'] ) {
-				$phpcsFile->addError( sprintf( 'The definition of `%s` constant is prohibited. Please use a different name.', $constantName ), $previous, 'ConstantRestrictions' );
+				$phpcsFile->addError( sprintf( 'The definition of `%s` constant is prohibited. Please use a different name.', $constantName ), $previous, 'DefiningRestrictedConstant' );
 			} elseif ( true === in_array( $constantName, $this->restrictedConstantNames, true ) ) {
-				$phpcsFile->addWarning( sprintf( 'Code is touching the `%s` constant. Make sure it\'s used appropriately.', $constantName ), $previous, 'ConstantRestrictions' );
+				$phpcsFile->addWarning( sprintf( 'Code is touching the `%s` constant. Make sure it\'s used appropriately.', $constantName ), $previous, 'UsingRestrictedConstant' );
 			}
 		}
 	}

--- a/WordPressVIPMinimum/Sniffs/Files/IncludingFileSniff.php
+++ b/WordPressVIPMinimum/Sniffs/Files/IncludingFileSniff.php
@@ -106,7 +106,7 @@ class IncludingFileSniff extends AbstractFunctionRestrictionsSniff {
 		}
 
 		if ( T_VARIABLE === $tokens[ $nextToken ]['code'] ) {
-			$this->phpcsFile->addWarning( sprintf( 'File inclusion using variable (`%s`). Probably needs manual inspection.', $tokens[ $nextToken ]['content'] ), $nextToken, 'IncludingFile' );
+			$this->phpcsFile->addWarning( sprintf( 'File inclusion using variable (`%s`). Probably needs manual inspection.', $tokens[ $nextToken ]['content'] ), $nextToken, 'UsingVariable' );
 			return;
 		}
 
@@ -123,19 +123,19 @@ class IncludingFileSniff extends AbstractFunctionRestrictionsSniff {
 
 			if ( true === in_array( $tokens[ $nextToken ]['content'], array_keys( $this->restrictedConstants ), true ) ) {
 				// The construct is using one of the restricted constants.
-				$this->phpcsFile->addError( sprintf( '`%s` constant might not be defined or available. Use `%s()` instead.', $tokens[ $nextToken ]['content'], $this->restrictedConstants[ $tokens[ $nextToken ]['content'] ] ), $nextToken, 'IncludingFile' );
+				$this->phpcsFile->addError( sprintf( '`%s` constant might not be defined or available. Use `%s()` instead.', $tokens[ $nextToken ]['content'], $this->restrictedConstants[ $tokens[ $nextToken ]['content'] ] ), $nextToken, 'RestrictedConstant' );
 				return;
 			}
 
 			$nextNextToken = $this->phpcsFile->findNext( array_merge( Tokens::$emptyTokens, array( T_COMMENT ) ), ( $nextToken + 1 ), null, true, null, true );
 			if ( 1 === preg_match( '/^[a-zA-Z_\x7f-\xff][a-zA-Z0-9_\x7f-\xff]*$/', $tokens[ $nextToken ]['content'] ) && T_OPEN_PARENTHESIS !== $tokens[ $nextNextToken ]['code'] ) {
 				// The construct is using custom constant, which needs manual inspection.
-				$this->phpcsFile->addWarning( sprintf( 'File inclusion using custom constant (`%s`). Probably needs manual inspection.', $tokens[ $nextToken ]['content'] ), $nextToken, 'IncludingFile' );
+				$this->phpcsFile->addWarning( sprintf( 'File inclusion using custom constant (`%s`). Probably needs manual inspection.', $tokens[ $nextToken ]['content'] ), $nextToken, 'UsingCustomConstant' );
 				return;
 			}
 
 			if ( 0 === strpos( $tokens[ $nextToken ]['content'], '$' ) ) {
-				$this->phpcsFile->addWarning( sprintf( 'File inclusion using variable (`%s`). Probably needs manual inspection.', $tokens[ $nextToken ]['content'] ), $nextToken, 'IncludingFile' );
+				$this->phpcsFile->addWarning( sprintf( 'File inclusion using variable (`%s`). Probably needs manual inspection.', $tokens[ $nextToken ]['content'] ), $nextToken, 'UsingVariable' );
 				return;
 			}
 
@@ -145,19 +145,19 @@ class IncludingFileSniff extends AbstractFunctionRestrictionsSniff {
 			}
 
 			if ( $this->is_targetted_token( $nextToken ) ) {
-				$this->phpcsFile->addWarning( sprintf( 'File inclusion using custom function ( `%s()` ). Must return local file source, as external URLs are prohibited on WordPress VIP. Probably needs manual inspection.', $tokens[ $nextToken ]['content'] ), $nextToken, 'IncludingFile' );
+				$this->phpcsFile->addWarning( sprintf( 'File inclusion using custom function ( `%s()` ). Must return local file source, as external URLs are prohibited on WordPress VIP. Probably needs manual inspection.', $tokens[ $nextToken ]['content'] ), $nextToken, 'UsingCustomFunction' );
 				return;
 			}
 
-			$this->phpcsFile->addError( 'Absolute include path must be used. Use `get_template_directory()`, `get_stylesheet_directory()` or `plugin_dir_path()`.', $nextToken, 'IncludingFile' );
+			$this->phpcsFile->addError( 'Absolute include path must be used. Use `get_template_directory()`, `get_stylesheet_directory()` or `plugin_dir_path()`.', $nextToken, 'NotAbsolutePath' );
 			return;
 		} else {
 			if ( T_CONSTANT_ENCAPSED_STRING === $tokens[ $nextToken ]['code'] && filter_var( str_replace( [ '"', "'" ], '', $tokens[ $nextToken ]['content'] ), FILTER_VALIDATE_URL ) ) {
-				$this->phpcsFile->addError( 'Include path must be local file source, external URLs are prohibited on WordPress VIP.', $nextToken, 'IncludingFile' );
+				$this->phpcsFile->addError( 'Include path must be local file source, external URLs are prohibited on WordPress VIP.', $nextToken, 'ExternalURL' );
 				return;
 			}
 
-			$this->phpcsFile->addError( 'Absolute include path must be used. Use `get_template_directory()`, `get_stylesheet_directory()` or `plugin_dir_path()`.', $nextToken, 'IncludingFile' );
+			$this->phpcsFile->addError( 'Absolute include path must be used. Use `get_template_directory()`, `get_stylesheet_directory()` or `plugin_dir_path()`.', $nextToken, 'NotAbsolutePath' );
 			return;
 		}
 	}

--- a/WordPressVIPMinimum/Sniffs/Functions/CheckReturnValueSniff.php
+++ b/WordPressVIPMinimum/Sniffs/Functions/CheckReturnValueSniff.php
@@ -188,7 +188,7 @@ class CheckReturnValueSniff implements Sniff {
 		$next      = $phpcsFile->findNext( Tokens::$functionNameTokens, $startNext, $closeBracket, false, null, true );
 		while ( $next ) {
 			if ( true === in_array( $tokens[ $next ]['content'], $this->catch[ $functionName ], true ) ) {
-				$phpcsFile->addError( sprintf( "`%s`'s return type must be checked before calling `%s` using that value", $tokens[ $next ]['content'], $functionName ), $next, 'CheckReturnValue' );
+				$phpcsFile->addError( sprintf( "`%s`'s return type must be checked before calling `%s` using that value", $tokens[ $next ]['content'], $functionName ), $next, 'DirectFunctionCall' );
 			}
 			$next = $phpcsFile->findNext( Tokens::$functionNameTokens, ( $next + 1 ), $closeBracket, false, null, true );
 		}
@@ -296,7 +296,7 @@ class CheckReturnValueSniff implements Sniff {
 			if ( true === in_array( $tokens[ $nextFunctionCallWithVariable ]['code'], array_merge( Tokens::$functionNameTokens, $notFunctionsCallee ), true )
 				&& $tokens[ $nextFunctionCallWithVariable ]['content'] === $callee
 			) {
-				$phpcsFile->addError( sprintf( 'Type of `%s` must be checked before calling `%s()` using that variable', $variableName, $callee ), $nextFunctionCallWithVariable, 'CheckReturnValue' );
+				$phpcsFile->addError( sprintf( 'Type of `%s` must be checked before calling `%s()` using that variable', $variableName, $callee ), $nextFunctionCallWithVariable, 'NonCheckedVariable' );
 				return;
 			}
 
@@ -305,7 +305,7 @@ class CheckReturnValueSniff implements Sniff {
 			if ( true === in_array( $tokens[ $next ]['code'], Tokens::$functionNameTokens, true )
 				&& $tokens[ $next ]['content'] === $callee
 			) {
-				$phpcsFile->addError( sprintf( 'Type of `%s` must be checked before calling `%s()` using that variable', $variableName, $callee ), $next, 'CheckReturnValue' );
+				$phpcsFile->addError( sprintf( 'Type of `%s` must be checked before calling `%s()` using that variable', $variableName, $callee ), $next, 'NonCheckedVariable' );
 				return;
 			}
 		}

--- a/WordPressVIPMinimum/Sniffs/VIP/MergeConflictSniff.php
+++ b/WordPressVIPMinimum/Sniffs/VIP/MergeConflictSniff.php
@@ -66,18 +66,18 @@ class MergeConflictSniff implements Sniff {
 			if ( T_STRING !== $tokens[ $nextToken ]['code'] || '<<< HEAD' !== substr( $tokens[ $nextToken ]['content'], 0, 8 ) ) {
 				return;
 			}
-			$phpcsFile->addError( 'Merge conflict detected. Found "<<<<<<< HEAD" string.', $stackPtr, 'HEAD' );
+			$phpcsFile->addError( 'Merge conflict detected. Found "<<<<<<< HEAD" string.', $stackPtr, 'Start' );
 			return;
 		} elseif ( T_ENCAPSED_AND_WHITESPACE === $tokens[ $stackPtr ]['code'] ) {
 			if ( '=======' === substr( $tokens[ $stackPtr ]['content'], 0, 7 ) ) {
-				$phpcsFile->addError( 'Merge conflict detected. Found "=======" string.', $stackPtr, 'DELIMITER' );
+				$phpcsFile->addError( 'Merge conflict detected. Found "=======" string.', $stackPtr, 'Separator' );
 				return;
 			} elseif ( '>>>>>>>' === substr( $tokens[ $stackPtr ]['content'], 0, 7 ) ) {
-				$phpcsFile->addError( sprintf( 'Merge conflict detected. Found "%s" string.', trim( $tokens[ $stackPtr ]['content'] ) ), $stackPtr, 'DELIMITER' );
+				$phpcsFile->addError( sprintf( 'Merge conflict detected. Found "%s" string.', trim( $tokens[ $stackPtr ]['content'] ) ), $stackPtr, 'End' );
 				return;
 			}
 		} elseif ( T_IS_IDENTICAL === $tokens[ $stackPtr ]['code'] && T_IS_IDENTICAL === $tokens[ ( $stackPtr + 1 ) ]['code'] ) {
-			$phpcsFile->addError( 'Merge conflict detected. Found "=======" string.', $stackPtr, 'DELIMITER' );
+			$phpcsFile->addError( 'Merge conflict detected. Found "=======" string.', $stackPtr, 'Separator' );
 			return;
 		}
 	}

--- a/WordPressVIPMinimum/Sniffs/Variables/VariableAnalysisSniff.php
+++ b/WordPressVIPMinimum/Sniffs/Variables/VariableAnalysisSniff.php
@@ -861,10 +861,10 @@ class VariableAnalysisSniff implements Sniff {
 		if ( ( $tokens[$classNamePtr]['code'] === T_SELF ) ||
 			( $tokens[$classNamePtr]['code'] === T_STATIC ) ) {
 			if ( $tokens[$classNamePtr]['code'] === T_SELF ) {
-				$err_class = 'SelfOutsideClass';
+				$err_prefix = 'Self';
 				$err_desc  = 'self::';
 			} else {
-				$err_class = 'StaticOutsideClass';
+				$err_prefix = 'Static';
 				$err_desc  = 'static::';
 			}
 			if ( !empty( $token['conditions'] ) ) {
@@ -873,7 +873,7 @@ class VariableAnalysisSniff implements Sniff {
 					//  Note: have to fetch code from $tokens, T_CLOSURE isn't set for conditions codes.
 					if ( $tokens[$scopePtr]['code'] === T_CLOSURE ) {
 						$phpcsFile->addError( "Use of `{$err_desc}%s` inside closure.", $stackPtr,
-							$err_class,
+							$err_prefix . 'InsideClosure',
 							array( "\${$varName}" )
 						);
 						return true;
@@ -884,7 +884,7 @@ class VariableAnalysisSniff implements Sniff {
 				}
 			}
 			$phpcsFile->addError( "Use of `{$err_desc}%s` outside class definition.", $stackPtr,
-				$err_class,
+				$err_prefix . 'OutsideClass',
 				array( "\${$varName}" )
 			);
 			return true;


### PR DESCRIPTION
Sniffs checks that give different messages (excluding placeholders) or different types (error vs warning) should have a unique violation code.

This allows developers to granularly target these messages, so that they can change their type, exclude them or change their severity, etc.

If multiple messages use the same violation code, it's not possible to do this.

The following changes were made:

- `WordPressVIPMinimum.Constants.ConstantRestrictions.ConstantRestrictions` was split into:
  - `WordPressVIPMinimum.Constants.ConstantRestrictions.UsingRestrictedConstant`
  - `WordPressVIPMinimum.Constants.ConstantRestrictions.DefiningRestrictedContent`
- `WordPressVIPMinimum.Files.IncludingFile.IncludingFile` was split into:
  - `WordPressVIPMinimum.Files.IncludingFile.UsingVariable`
  - `WordPressVIPMinimum.Files.IncludingFile.RestrictedConstant`
  - `WordPressVIPMinimum.Files.IncludingFile.UsingCustomConstant`
  - `WordPressVIPMinimum.Files.IncludingFile.UsingCustomFunction`
  - `WordPressVIPMinimum.Files.IncludingFile.NotAbsolutePath`
  - `WordPressVIPMinimum.Files.IncludingFile.ExternalURL`
- `WordPressVIPMinimum.Functions.CheckReturnValue.CheckReturnValue` was split into:
  - `WordPressVIPMinimum.Functions.CheckReturnValue.DirectFunctionCall`
  - `WordPressVIPMinimum.Functions.CheckReturnValue.NonCheckedVariable`
- `WordPressVIPMinimum.Variables.VariableAnalysis.SelfOutsideClass` was split into:
  - `WordPressVIPMinimum.Variables.VariableAnalysis.SelfInsideClosure`
  - `WordPressVIPMinimum.Variables.VariableAnalysis.SelfOutsideClass`
- `WordPressVIPMinimum.Variables.VariableAnalysis.StaticOutsideClass` was split into:
  - `WordPressVIPMinimum.Variables.VariableAnalysis.StaticInsideClosure`
  - `WordPressVIPMinimum.Variables.VariableAnalysis.StaticOutsideClass`
- `WordPressVIPMinimum.VIP.MergeConflict.DELIMITER` was split into:
  - `WordPressVIPMinimum.VIP.MergeConflict.Separator`
  - `WordPressVIPMinimum.VIP.MergeConflict.End`
  - Also `WordPressVIPMinimum.VIP.MergeConflict.HEAD` was renamed to `WordPressVIPMinimum.VIP.MergeConflict.Start` for consistency.

Note that there are a few multiple instances of the same code + type + message combinations, and that's fine.

This is a breaking change, so any external rulesets or inline ignore messages referencing these should be updated as necessary.

Fixes #273.