### PR TITLE
Fix unusual violation codes

### DIFF
--- a/WordPressVIPMinimum/Sniffs/TemplatingEngines/UnescapedOutputMustacheSniff.php
+++ b/WordPressVIPMinimum/Sniffs/TemplatingEngines/UnescapedOutputMustacheSniff.php
@@ -57,12 +57,12 @@ class UnescapedOutputMustacheSniff implements Sniff {
 
 		if ( false !== strpos( $tokens[ $stackPtr ]['content'], '{{{' ) || false !== strpos( $tokens[ $stackPtr ]['content'], '}}}' ) ) {
 			// Mustache unescaped output notation.
-			$phpcsFile->addWarning( 'Found Mustache unescaped output notation: "{{{}}}".', $stackPtr, '{{{' );
+			$phpcsFile->addWarning( 'Found Mustache unescaped output notation: "{{{}}}".', $stackPtr, 'OutputNotation' );
 		}
 
 		if ( false !== strpos( $tokens[ $stackPtr ]['content'], '{{&' ) ) {
 			// Mustache unescaped variable notation.
-			$phpcsFile->addWarning( 'Found Mustache unescape variable notation: "{{&".', $stackPtr, '{{&' );
+			$phpcsFile->addWarning( 'Found Mustache unescape variable notation: "{{&".', $stackPtr, 'VariableNotation' );
 		}
 
 		if ( false !== strpos( $tokens[ $stackPtr ]['content'], '{{=' ) ) {

--- a/WordPressVIPMinimum/Sniffs/TemplatingEngines/UnescapedOutputTwigSniff.php
+++ b/WordPressVIPMinimum/Sniffs/TemplatingEngines/UnescapedOutputTwigSniff.php
@@ -56,7 +56,7 @@ class UnescapedOutputTwigSniff implements Sniff {
 
 		if ( 1 === preg_match( '/autoescape\s+false/', $tokens[ $stackPtr ]['content'] ) ) {
 			// Twig autoescape disabled.
-			$phpcsFile->addWarning( 'Found Twig autoescape disabling notation.', $stackPtr, 'autoescape false' );
+			$phpcsFile->addWarning( 'Found Twig autoescape disabling notation.', $stackPtr, 'AutoescapeFalse' );
 		}
 
 		if ( 1 === preg_match( '/\|\s*raw/', $tokens[ $stackPtr ]['content'] ) ) {

--- a/WordPressVIPMinimum/Sniffs/TemplatingEngines/UnescapedOutputUnderscorejsSniff.php
+++ b/WordPressVIPMinimum/Sniffs/TemplatingEngines/UnescapedOutputUnderscorejsSniff.php
@@ -57,7 +57,7 @@ class UnescapedOutputUnderscorejsSniff implements Sniff {
 
 		if ( false !== strpos( $tokens[ $stackPtr ]['content'], '<%=' ) ) {
 			// Underscore.js unescaped output.
-			$phpcsFile->addWarning( 'Found Underscore.js unescaped output notation: "<%=".', $stackPtr, '<%=' );
+			$phpcsFile->addWarning( 'Found Underscore.js unescaped output notation: "<%=".', $stackPtr, 'OutputNotation' );
 		}
 
 		if ( false !== strpos( $tokens[ $stackPtr ]['content'], 'interpolate' ) ) {


### PR DESCRIPTION
Some violation codes seem unusual since they contain spaces or non-alphanumeric characters.

While they may work generally, there may be edge cases where they don't (perhaps certain report formats, for example), and they must not break the XML ruleset, so it would be better to change them to something "normal".

The following changes were made:

- `WordPressVIPMinimum.TemplatingEngines.UnescapedOutputMustache.{{{` was changed to `WordPressVIPMinimum.TemplatingEngines.UnescapedOutputMustache.OutputNotation`
- `WordPressVIPMinimum.TemplatingEngines.UnescapedOutputMustache.{{&` was changed to `WordPressVIPMinimum.TemplatingEngines.UnescapedOutputMustache.VariableNotation`
- `WordPressVIPMinimum.TemplatingEngines.UnescapedOutputTwig.autoescape false` was changed to `WordPressVIPMinimum.TemplatingEngines.UnescapedOutputTwig.AutoescapeFalse`
- `WordPressVIPMinimum.TemplatingEngines.UnescapedOutputUnderscorejs.<%=` was changed to `WordPressVIPMinimum.TemplatingEngines.UnescapedOutputUnderscorejs.OutputNotation`

Fixes #274.