### PR TITLE
Make violation codes more consistent

### DIFF
--- a/WordPressVIPMinimum/Sniffs/Cache/BatcacheWhitelistedParamsSniff.php
+++ b/WordPressVIPMinimum/Sniffs/Cache/BatcacheWhitelistedParamsSniff.php
@@ -107,7 +107,7 @@ class BatcacheWhitelistedParamsSniff implements Sniff {
 		$variable_name = substr( $variable_name, 1, -1 );
 
 		if ( true === in_array( $variable_name, $this->whitelistes_batcache_params, true ) ) {
-			$phpcsFile->addWarning( sprintf( 'Batcache whitelisted GET param, `%s`, found. Batcache whitelisted parameters get stripped and are not available in PHP.', $variable_name ), $stackPtr, 'strippedGetParam' );
+			$phpcsFile->addWarning( sprintf( 'Batcache whitelisted GET param, `%s`, found. Batcache whitelisted parameters get stripped and are not available in PHP.', $variable_name ), $stackPtr, 'StrippedGetParam' );
 			return;
 		}
 	}

--- a/WordPressVIPMinimum/Sniffs/Filters/AlwaysReturnSniff.php
+++ b/WordPressVIPMinimum/Sniffs/Filters/AlwaysReturnSniff.php
@@ -234,7 +234,7 @@ class AlwaysReturnSniff implements Sniff {
 				$this->phpcsFile->addError(
 					'Please, make sure that a callback to `%s` filter is returning void intentionally.',
 					$functionBodyScopeStart,
-					'voidReturn',
+					'VoidReturn',
 					[ $filterName ]
 				);
 			}
@@ -252,7 +252,7 @@ class AlwaysReturnSniff implements Sniff {
 			$this->phpcsFile->addError(
 				'Please, make sure that a callback to `%s` filter is always returning some value.',
 				$functionBodyScopeStart,
-				'missingReturnStatement',
+				'MissingReturnStatement',
 				[ $filterName ]
 			);
 		}

--- a/WordPressVIPMinimum/Sniffs/JS/DangerouslySetInnerHTMLSniff.php
+++ b/WordPressVIPMinimum/Sniffs/JS/DangerouslySetInnerHTMLSniff.php
@@ -71,7 +71,7 @@ class DangerouslySetInnerHTMLSniff implements Sniff {
 			return;
 		}
 
-		$phpcsFile->addError( sprintf( "Any HTML passed to `%s` gets executed. Please make sure it's properly escaped.", $tokens[ $stackPtr ]['content'] ), $stackPtr, 'dangerouslySetInnerHTML' );
+		$phpcsFile->addError( sprintf( "Any HTML passed to `%s` gets executed. Please make sure it's properly escaped.", $tokens[ $stackPtr ]['content'] ), $stackPtr, 'Found' );
 	}
 
 }

--- a/WordPressVIPMinimum/Sniffs/JS/InnerHTMLSniff.php
+++ b/WordPressVIPMinimum/Sniffs/JS/InnerHTMLSniff.php
@@ -84,7 +84,7 @@ class InnerHTMLSniff implements Sniff {
 		}
 
 		if ( true === $foundVariable ) {
-			$phpcsFile->addWarning( sprintf( 'Any HTML passed to `%s` gets executed. Consider using `.textContent` or make sure that used variables are properly escaped.', $tokens[ $stackPtr ]['content'] ), $stackPtr, $tokens[ $stackPtr ]['content'] );
+			$phpcsFile->addWarning( sprintf( 'Any HTML passed to `%s` gets executed. Consider using `.textContent` or make sure that used variables are properly escaped.', $tokens[ $stackPtr ]['content'] ), $stackPtr, 'Found' );
 		}
 	}
 

--- a/WordPressVIPMinimum/Sniffs/JS/StringConcatSniff.php
+++ b/WordPressVIPMinimum/Sniffs/JS/StringConcatSniff.php
@@ -57,7 +57,7 @@ class StringConcatSniff implements Sniff {
 
 		if ( T_CONSTANT_ENCAPSED_STRING === $tokens[ $nextToken ]['code'] ) {
 			if ( false !== strpos( $tokens[ $nextToken ]['content'], '<' ) && 1 === preg_match( '/\<\/[a-zA-Z]+/', $tokens[ $nextToken ]['content'] ) ) {
-				$phpcsFile->addError( sprintf( 'HTML string concatenation detected, this is a security risk, use DOM node construction or a templating language instead: %s', '+' . $tokens[ $nextToken ]['content'] ), $stackPtr, 'StringConcatNext' );
+				$phpcsFile->addError( sprintf( 'HTML string concatenation detected, this is a security risk, use DOM node construction or a templating language instead: %s', '+' . $tokens[ $nextToken ]['content'] ), $stackPtr, 'Found' );
 			}
 		}
 
@@ -65,7 +65,7 @@ class StringConcatSniff implements Sniff {
 
 		if ( T_CONSTANT_ENCAPSED_STRING === $tokens[ $prevToken ]['code'] ) {
 			if ( false !== strpos( $tokens[ $prevToken ]['content'], '<' ) && 1 === preg_match( '/\<[a-zA-Z]+/', $tokens[ $prevToken ]['content'] ) ) {
-				$phpcsFile->addError( sprintf( 'HTML string concatenation detected, this is a security risk, use DOM node construction or a templating language instead: %s', $tokens[ $prevToken ]['content'] . '+' ), $stackPtr, 'StringConcatNext' );
+				$phpcsFile->addError( sprintf( 'HTML string concatenation detected, this is a security risk, use DOM node construction or a templating language instead: %s', $tokens[ $prevToken ]['content'] . '+' ), $stackPtr, 'Found' );
 			}
 		}
 	}

--- a/WordPressVIPMinimum/Sniffs/Plugins/ZoninatorSniff.php
+++ b/WordPressVIPMinimum/Sniffs/Plugins/ZoninatorSniff.php
@@ -78,7 +78,7 @@ class ZoninatorSniff implements Sniff {
 		$version = $this->remove_wrapping_quotation_marks( $tokens[ $version ]['content'] );
 
 		if ( true === version_compare( $version, '0.8', '>=' ) ) {
-			$phpcsFile->addWarning( 'Zoninator of version >= v0.8 requires WordPress core REST API. Please, make sure the `wpcom_vip_load_wp_rest_api()` is being called on all sites loading this file.', $stackPtr, 'Zoninator' );
+			$phpcsFile->addWarning( 'Zoninator of version >= v0.8 requires WordPress core REST API. Please, make sure the `wpcom_vip_load_wp_rest_api()` is being called on all sites loading this file.', $stackPtr, 'RequiresRESTAPI' );
 		}
 	}
 

--- a/WordPressVIPMinimum/Sniffs/TemplatingEngines/UnescapedOutputMustacheSniff.php
+++ b/WordPressVIPMinimum/Sniffs/TemplatingEngines/UnescapedOutputMustacheSniff.php
@@ -68,7 +68,7 @@ class UnescapedOutputMustacheSniff implements Sniff {
 		if ( false !== strpos( $tokens[ $stackPtr ]['content'], '{{=' ) ) {
 			// Mustache delimiter change.
 			$new_delimiter = trim( str_replace( [ '{{=', '=}}' ], '', substr( $tokens[ $stackPtr ]['content'], 0, ( strpos( $tokens[ $stackPtr ]['content'], '=}}' ) + 3 ) ) ) );
-			$phpcsFile->addWarning( sprintf( 'Found Mustache delimiter change notation. New delimiter is: %s', $new_delimiter ), $stackPtr, 'delimiterChange' );
+			$phpcsFile->addWarning( sprintf( 'Found Mustache delimiter change notation. New delimiter is: %s', $new_delimiter ), $stackPtr, 'DelimiterChange' );
 		}
 
 		if ( false !== strpos( $tokens[ $stackPtr ]['content'], 'SafeString' ) ) {

--- a/WordPressVIPMinimum/Sniffs/TemplatingEngines/UnescapedOutputTwigSniff.php
+++ b/WordPressVIPMinimum/Sniffs/TemplatingEngines/UnescapedOutputTwigSniff.php
@@ -61,7 +61,7 @@ class UnescapedOutputTwigSniff implements Sniff {
 
 		if ( 1 === preg_match( '/\|\s*raw/', $tokens[ $stackPtr ]['content'] ) ) {
 			// Twig default unescape filter.
-			$phpcsFile->addWarning( 'Found Twig default unescape filter: "|raw".', $stackPtr, 'raw' );
+			$phpcsFile->addWarning( 'Found Twig default unescape filter: "|raw".', $stackPtr, 'RawFound' );
 		}
 	}
 

--- a/WordPressVIPMinimum/Sniffs/TemplatingEngines/UnescapedOutputUnderscorejsSniff.php
+++ b/WordPressVIPMinimum/Sniffs/TemplatingEngines/UnescapedOutputUnderscorejsSniff.php
@@ -62,7 +62,7 @@ class UnescapedOutputUnderscorejsSniff implements Sniff {
 
 		if ( false !== strpos( $tokens[ $stackPtr ]['content'], 'interpolate' ) ) {
 			// Underscore.js unescaped output.
-			$phpcsFile->addWarning( 'Found Underscore.js delimiter change notation.', $stackPtr, 'interpolate' );
+			$phpcsFile->addWarning( 'Found Underscore.js delimiter change notation.', $stackPtr, 'InterpolateFound' );
 		}
 	}
 

--- a/WordPressVIPMinimum/Sniffs/TemplatingEngines/UnescapedOutputVuejsSniff.php
+++ b/WordPressVIPMinimum/Sniffs/TemplatingEngines/UnescapedOutputVuejsSniff.php
@@ -55,7 +55,7 @@ class UnescapedOutputVuejsSniff implements Sniff {
 
 		if ( false !== strpos( $tokens[ $stackPtr ]['content'], 'v-html' ) ) {
 			// Twig autoescape disabled.
-			$phpcsFile->addWarning( 'Found Vue.js non-escaped (raw) HTML directive.', $stackPtr, 'v-html' );
+			$phpcsFile->addWarning( 'Found Vue.js non-escaped (raw) HTML directive.', $stackPtr, 'RawHTMLDirectiveFound' );
 		}
 	}
 

--- a/WordPressVIPMinimum/Sniffs/VIP/ErrorControlSniff.php
+++ b/WordPressVIPMinimum/Sniffs/VIP/ErrorControlSniff.php
@@ -41,7 +41,7 @@ class ErrorControlSniff implements Sniff {
 
 		$tokens = $phpcsFile->getTokens();
 
-		$phpcsFile->addError( sprintf( 'The code shouldn\'t use error control operators (`%s`). The call should be wrapped in appropriate checks.', $tokens[ $stackPtr ]['content'] ), $stackPtr, 'ErrorControl' );
+		$phpcsFile->addError( sprintf( 'The code shouldn\'t use error control operators (`%s`). The call should be wrapped in appropriate checks.', $tokens[ $stackPtr ]['content'] ), $stackPtr, 'ErrorSilencingSignFound' );
 	}
 
 }

--- a/WordPressVIPMinimum/Sniffs/VIP/EscapingVoidReturnFunctionsSniff.php
+++ b/WordPressVIPMinimum/Sniffs/VIP/EscapingVoidReturnFunctionsSniff.php
@@ -62,7 +62,7 @@ class EscapingVoidReturnFunctionsSniff implements Sniff {
 		}
 
 		if ( 0 === strpos( $tokens[ $next_token ]['content'], '_e' ) ) {
-			$phpcsFile->addError( sprintf( 'Attempting to escape `%s()` which is printing its output.', $tokens[ $next_token ]['content'] ), $stackPtr, 'escapingVoidReturningFunction' );
+			$phpcsFile->addError( sprintf( 'Attempting to escape `%s()` which is printing its output.', $tokens[ $next_token ]['content'] ), $stackPtr, 'Found' );
 			return;
 		}
 	}

--- a/WordPressVIPMinimum/Sniffs/VIP/FetchingRemoteDataSniff.php
+++ b/WordPressVIPMinimum/Sniffs/VIP/FetchingRemoteDataSniff.php
@@ -50,7 +50,7 @@ class FetchingRemoteDataSniff implements Sniff {
 			$phpcsFile->addWarning(
 				'`%s()` is highly discouraged for remote requests, please use `wpcom_vip_file_get_contents()` or `vip_safe_wp_remote_get()` instead. If it\'s for a local file please use WP_Filesystem instead.',
 				$stackPtr,
-				'fileGetContentsUnknown',
+				'FileGetContentsUnknown',
 				[ $tokens[ $stackPtr ]['content'] ]
 			);
 		}
@@ -62,7 +62,7 @@ class FetchingRemoteDataSniff implements Sniff {
 			$phpcsFile->addWarning(
 				'`%s()` is highly discouraged for remote requests, please use `wpcom_vip_file_get_contents()` or `vip_safe_wp_remote_get()` instead.',
 				$stackPtr,
-				'fileGetContentsRemoteFile',
+				'FileGetContentsRemoteFile',
 				[ $tokens[ $stackPtr ]['content'] ]
 			);
 		}

--- a/WordPressVIPMinimum/Sniffs/VIP/RobotstxtSniff.php
+++ b/WordPressVIPMinimum/Sniffs/VIP/RobotstxtSniff.php
@@ -63,7 +63,7 @@ class RobotstxtSniff implements Sniff {
 		}
 
 		if ( 'do_robotstxt' === substr( $tokens[ $actionNamePtr ]['content'], 1, -1 ) ) {
-			$phpcsFile->addWarning( 'Internal note: remember to flush robots.txt nginx cache after deploying this revision', $stackPtr, 'RobotstxtSniff' );
+			$phpcsFile->addWarning( 'Internal note: remember to flush robots.txt nginx cache after deploying this revision', $stackPtr, 'DoRobotsTxtFound' );
 		}
 	}
 }

--- a/WordPressVIPMinimum/Sniffs/VIP/WPQueryParamsSniff.php
+++ b/WordPressVIPMinimum/Sniffs/VIP/WPQueryParamsSniff.php
@@ -49,12 +49,12 @@ class WPQueryParamsSniff implements Sniff {
 			if ( T_TRUE === $tokens[ $next_token ]['code'] ) {
 				// WordPress.com: https://lobby.vip.wordpress.com/wordpress-com-documentation/uncached-functions/.
 				// VIP Go: https://vip.wordpress.com/documentation/vip-go/uncached-functions/.
-				$phpcsFile->addError( 'Setting `suppress_filters` to `true` is prohibited.', $stackPtr, 'suppressFiltersTrue' );
+				$phpcsFile->addError( 'Setting `suppress_filters` to `true` is prohibited.', $stackPtr, 'SuppressFiltersTrue' );
 			}
 		}
 
 		if ( 'post__not_in' === trim( $tokens[ $stackPtr ]['content'], '\'' ) ) {
-			$phpcsFile->addWarning( 'Using `post__not_in` should be done with caution, see https://vip.wordpress.com/documentation/performance-improvements-by-removing-usage-of-post__not_in/ for more information.', $stackPtr, 'post__not_in' );
+			$phpcsFile->addWarning( 'Using `post__not_in` should be done with caution, see https://vip.wordpress.com/documentation/performance-improvements-by-removing-usage-of-post__not_in/ for more information.', $stackPtr, 'PostNotIn' );
 		}
 	}
 


### PR DESCRIPTION
- Make non-dynamic violation codes follow PascalCase
- Rename non-intuitive codes to be indicative of the issue, rather than repeating the class code.

The following changes were made:

- `WordPressVIPMinimum.Cache.BatcacheWhitelistedParams.strippedGetParam` was changed to `WordPressVIPMinimum.Cache.BatcacheWhitelistedParams.StrippedGetParam`
- `WordPressVIPMinimum.Filters.AlwaysReturn.voidReturn` was changed to `WordPressVIPMinimum.Filters.AlwaysReturn.VoidReturn`
- `WordPressVIPMinimum.Filters.AlwaysReturn.missingReturnStatement` was changed to `WordPressVIPMinimum.Filters.AlwaysReturn.MissingReturnStatement`
- `WordPressVIPMinimum.JS.DangerouslySetInnerHTML.dangerouslySetInnerHTML` was changed to `WordPressVIPMinimum.JS.DangerouslySetInnerHTML.Found`
- `WordPressVIPMinimum.JS.InnerHTML.innerHTML` was changed to `WordPressVIPMinimum.JS.InnerHTML.Found`
- `WordPressVIPMinimum.JS.StringConcat.StringConcatNext` was changed to `WordPressVIPMinimum.JS.StringConcat.Found`
- `WordPressVIPMinimum.Plugins.Zoninator.Zoninator` was changed to `WordPressVIPMinimum.Plugins.Zoninator.RequiresRESTAPI`
- `WordPressVIPMinimum.TemplatingEngines.UnescapedOutputMustache.delimeterChange` was changed to `WordPressVIPMinimum.TemplatingEngines.UnescapedOutputMustache.DelimeterChange`
- `WordPressVIPMinimum.TemplatingEngines.UnescapedOutputTwig.raw` was changed to `WordPressVIPMinimum.TemplatingEngines.UnescapedOutputTwig.RawFound`
- `WordPressVIPMinimum.TemplatingEngines.UnescapedOutputUnderscorejs.interpolate` was changed to `WordPressVIPMinimum.TemplatingEngines.UnescapedOutputUnderscorejs.InterpolateFound`
- `WordPressVIPMinimum.TemplatingEngines.UnescapedOutputVuejs.v-html` was changed to `WordPressVIPMinimum.TemplatingEngines.UnescapedOutputVuejs.Found`
- `WordPressVIPMinimum.VIP.ErrorControl.ErrorControl` was changed to `WordPressVIPMinimum.VIP.ErrorControl.ErrorSilencingSignFound`
- `WordPressVIPMinimum.VIP.ErrorControl.EscapingVoidReturnFunctions.escapingVoidReturnFunction` was changed to `WordPressVIPMinimum.VIP.ErrorControl.EscapingVoidReturnFunctions.Found`
- `WordPressVIPMinimum.VIP.FetchingRemoteData.fileGetContentsUnknown` was changed to `WordPressVIPMinimum.VIP.FetchingRemoteData.FileGetContentsUnknown`
- `WordPressVIPMinimum.VIP.FetchingRemoteData.fileGetContentsRemoteFile` was changed to `WordPressVIPMinimum.VIP.FetchingRemoteData.FileGetContentsRemoteFile`
- `WordPressVIPMinimum.VIP.Robotstxt.RobotstxtSniff` was changed to `WordPressVIPMinimum.VIP.Robotstxt.DoRobotsTxtFound`
- `WordPressVIPMinimum.VIP.WPQueryParams.suppressFiltersTrue` was changed to `WordPressVIPMinimum.VIP.WPQueryParams.SuppressFiltersTrue`
- `WordPressVIPMinimum.VIP.WPQueryParams.post__not_in` was changed to `WordPressVIPMinimum.VIP.WPQueryParams.PostNotIn`

Fixes #313.