### PR TITLE
Switch to phpcodesniffer-composer-installer v0.5.0

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -24,7 +24,7 @@
 		"phpunit/phpunit": "*"
 	},
 	"suggest": {
-		"dealerdirect/phpcodesniffer-composer-installer": "^0.4.3 || This Composer plugin will sort out the PHPCS 'installed_paths' automatically."
+		"dealerdirect/phpcodesniffer-composer-installer": "^0.5 || This Composer plugin will sort out the PHPCS 'installed_paths' automatically."
 	},
 	"minimum-stability": "RC",
 	"scripts": {


### PR DESCRIPTION
https://github.com/Dealerdirect/phpcodesniffer-composer-installer/releases/tag/v0.5.0 was released back in October, with a few fixes and improvements.

Fixes #314.