### PR TITLE
Use phpcodesniffer-composer-installer plugin

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -20,6 +20,7 @@
 		"wp-coding-standards/wpcs": "1.*"
 	},
 	"require-dev": {
+		"dealerdirect/phpcodesniffer-composer-installer": "^0.5",
 		"phpcompatibility/php-compatibility": "^9",
 		"phpunit/phpunit": "*"
 	},
@@ -28,9 +29,7 @@
 	},
 	"minimum-stability": "RC",
 	"scripts": {
-		"post-install-cmd": "@install-codestandards",
-		"post-update-cmd": "@install-codestandards",
-		"install-codestandards": "\"vendor/bin/phpcs\" --config-set installed_paths ../../..,../../wp-coding-standards/wpcs,../../phpcompatibility/php-compatibility",
+		"install-codestandards": "Dealerdirect\\Composer\\Plugin\\Installers\\PHPCodeSniffer\\Plugin::run",
 		"integration": "bin/integration-test",
 		"lint": [
 			"bin/php-lint",


### PR DESCRIPTION
Although we were suggesting the `dealerdirect/phpcodesniffer-composer-installer` Composer plugin during the `composer install`, it wasn't actually being used in VIPCS.

By using it, the `post-install-cmd` and `post-update-cmd` scripts are eliminated, and the manual `install-codestandards` script is updated to be available should a `composer ... --no-plugins` flag be used, and instead let the Composer plugin handle the registration.

Fixes #317