### PR TITLE
Disallow long array syntax

### DIFF
--- a/.phpcs.xml.dist
+++ b/.phpcs.xml.dist
@@ -32,6 +32,9 @@
 
 	<rule ref="PSR2.Methods.FunctionClosingBrace"/>
 
+	<!-- Disallow long array syntax -->
+	<rule ref="Generic.Arrays.DisallowLongArraySyntax"/>
+
 	<!-- Check code for cross-version PHP compatibility. -->
 	<config name="testVersion" value="5.6-"/>
 	<rule ref="PHPCompatibility">

--- a/WordPressVIPMinimum/Sniffs/Actions/PreGetPostsSniff.php
+++ b/WordPressVIPMinimum/Sniffs/Actions/PreGetPostsSniff.php
@@ -67,7 +67,7 @@ class PreGetPostsSniff implements Sniff {
 		}
 
 		$actionNamePtr = $this->_phpcsFile->findNext(
-			array_merge( Tokens::$emptyTokens, array( T_OPEN_PARENTHESIS ) ), // types.
+			array_merge( Tokens::$emptyTokens, [ T_OPEN_PARENTHESIS ] ), // types.
 			$stackPtr + 1, // start.
 			null, // end.
 			true, // exclude.
@@ -86,7 +86,7 @@ class PreGetPostsSniff implements Sniff {
 		}
 
 		$callbackPtr = $this->_phpcsFile->findNext(
-			array_merge( Tokens::$emptyTokens, array( T_COMMA ) ), // types.
+			array_merge( Tokens::$emptyTokens, [ T_COMMA ] ), // types.
 			$actionNamePtr + 1, // start.
 			null, // end.
 			true, // exclude.
@@ -161,7 +161,7 @@ class PreGetPostsSniff implements Sniff {
 	private function processFunction( $stackPtr ) {
 
 		$wpQueryObjectNamePtr = $this->_phpcsFile->findNext(
-			array( T_VARIABLE ), // types.
+			[ T_VARIABLE ], // types.
 			$stackPtr + 1, // start.
 			null, // end.
 			false, // exclude.
@@ -177,7 +177,7 @@ class PreGetPostsSniff implements Sniff {
 		$wpQueryObjectVariableName = $this->_tokens[ $wpQueryObjectNamePtr ]['content'];
 
 		$functionDefinitionPtr = $this->_phpcsFile->findPrevious(
-			array( T_FUNCTION ), // types.
+			[ T_FUNCTION ], // types.
 			$wpQueryObjectNamePtr - 1, // start.
 			null, // end.
 			false, // exlcude.
@@ -201,7 +201,7 @@ class PreGetPostsSniff implements Sniff {
 	private function processClosure( $stackPtr ) {
 
 		$wpQueryObjectNamePtr = $this->_phpcsFile->findNext(
-			array( T_VARIABLE ), // types.
+			[ T_VARIABLE ], // types.
 			$stackPtr + 1, // start.
 			null, // end.
 			false, // exclude.
@@ -229,7 +229,7 @@ class PreGetPostsSniff implements Sniff {
 		$functionBodyScopeEnd   = $this->_tokens[ $stackPtr ]['scope_closer'];
 
 		$wpQueryVarUsed = $this->_phpcsFile->findNext(
-			array( T_VARIABLE ), // types.
+			[ T_VARIABLE ], // types.
 			( $functionBodyScopeStart + 1 ), // start.
 			$functionBodyScopeEnd, // end.
 			false, // exclude.
@@ -249,7 +249,7 @@ class PreGetPostsSniff implements Sniff {
 				$this->_phpcsFile->addWarning( 'Main WP_Query is being modified without `$query->is_main_query()` check. Needs manual inspection.', $wpQueryVarUsed, 'PreGetPosts' );
 			}
 			$wpQueryVarUsed = $this->_phpcsFile->findNext(
-				array( T_VARIABLE ), // types.
+				[ T_VARIABLE ], // types.
 				( $wpQueryVarUsed + 1 ), // start.
 				$functionBodyScopeEnd, // end.
 				false, // exclude.
@@ -281,7 +281,7 @@ class PreGetPostsSniff implements Sniff {
 		while ( T_IF === $this->_tokens[ $stackPtr ]['conditions'][ $lastConditionStackPtr ] ) {
 
 			$next = $this->_phpcsFile->findNext(
-				array( T_VARIABLE ), // types.
+				[ T_VARIABLE ], // types.
 				( $lastConditionStackPtr + 1 ), // start.
 				null, // end.
 				false, // exclude.
@@ -293,7 +293,7 @@ class PreGetPostsSniff implements Sniff {
 					return true;
 				}
 				$next = $this->_phpcsFile->findNext(
-					array( T_VARIABLE ), // types.
+					[ T_VARIABLE ], // types.
 					( $next + 1 ), // start.
 					null, // end.
 					false, // exclude.
@@ -334,7 +334,7 @@ class PreGetPostsSniff implements Sniff {
 		}
 
 		$next = $this->_phpcsFile->findNext(
-			array( T_RETURN ), // types.
+			[ T_RETURN ], // types.
 			$this->_tokens[ $this->_tokens[ $nestedParenthesisEnd ]['parenthesis_owner'] ]['scope_opener'], // start.
 			$this->_tokens[ $this->_tokens[ $nestedParenthesisEnd ]['parenthesis_owner'] ]['scope_closer'], // end.
 			false, // exclude.
@@ -408,7 +408,7 @@ class PreGetPostsSniff implements Sniff {
 			&& false === empty( $this->_tokens[ $stackPtr ]['nested_parenthesis'] )
 		) {
 			$previousLocalIf = $this->_phpcsFile->findPrevious(
-				array( T_IF ), // types.
+				[ T_IF ], // types.
 				$stackPtr - 1, // start.
 				null, // end.
 				false, // exclude.

--- a/WordPressVIPMinimum/Sniffs/Cache/BatcacheWhitelistedParamsSniff.php
+++ b/WordPressVIPMinimum/Sniffs/Cache/BatcacheWhitelistedParamsSniff.php
@@ -24,7 +24,7 @@ class BatcacheWhitelistedParamsSniff implements Sniff {
 	 *
 	 * @var array
 	 */
-	public $whitelistes_batcache_params = array(
+	public $whitelistes_batcache_params = [
 		'hpt',
 		'eref',
 		'iref',
@@ -69,7 +69,7 @@ class BatcacheWhitelistedParamsSniff implements Sniff {
 		'__rmid',
 		'sr_share',
 		'ia_share_url',
-	);
+	];
 
 	/**
 	 * Returns an array of tokens this test wants to listen for.
@@ -77,7 +77,7 @@ class BatcacheWhitelistedParamsSniff implements Sniff {
 	 * @return array
 	 */
 	public function register() {
-		return array( T_VARIABLE );
+		return [ T_VARIABLE ];
 	}
 
 	/**
@@ -96,7 +96,7 @@ class BatcacheWhitelistedParamsSniff implements Sniff {
 			return;
 		}
 
-		$key = $phpcsFile->findNext( array_merge( Tokens::$emptyTokens, array( T_OPEN_SQUARE_BRACKET ) ), ( $stackPtr + 1 ), null, true );
+		$key = $phpcsFile->findNext( array_merge( Tokens::$emptyTokens, [ T_OPEN_SQUARE_BRACKET ] ), ( $stackPtr + 1 ), null, true );
 
 		if ( T_CONSTANT_ENCAPSED_STRING !== $tokens[ $key ]['code'] ) {
 			return;

--- a/WordPressVIPMinimum/Sniffs/Cache/CacheValueOverrideSniff.php
+++ b/WordPressVIPMinimum/Sniffs/Cache/CacheValueOverrideSniff.php
@@ -29,7 +29,7 @@ class CacheValueOverrideSniff implements Sniff {
 	 *
 	 * @var array
 	 */
-	private $_tokens = array();
+	private $_tokens = [];
 
 	/**
 	 * Returns the token types that this sniff is interested in.

--- a/WordPressVIPMinimum/Sniffs/Cache/LowExpiryCacheTimeSniff.php
+++ b/WordPressVIPMinimum/Sniffs/Cache/LowExpiryCacheTimeSniff.php
@@ -44,14 +44,14 @@ class LowExpiryCacheTimeSniff extends AbstractFunctionParameterSniff {
 	 *
 	 * @var array
 	 */
-	protected $wp_time_constants = array(
+	protected $wp_time_constants = [
 		'MINUTE_IN_SECONDS' => 60,
 		'HOUR_IN_SECONDS'   => 3600,
 		'DAY_IN_SECONDS'    => 86400,
 		'WEEK_IN_SECONDS'   => 604800,
 		'MONTH_IN_SECONDS'  => 2592000,
 		'YEAR_IN_SECONDS'   => 31536000,
-	);
+	];
 
 	/**
 	 * Process the parameters of a matched function.

--- a/WordPressVIPMinimum/Sniffs/Classes/DeclarationCompatibilitySniff.php
+++ b/WordPressVIPMinimum/Sniffs/Classes/DeclarationCompatibilitySniff.php
@@ -29,151 +29,151 @@ class DeclarationCompatibilitySniff extends AbstractScopeSniff {
 	 *
 	 * @var string[]
 	 */
-	private $_functionList = array();
+	private $_functionList = [];
 
 	/**
 	 * A list of classes and methods to check.
 	 *
 	 * @var array
 	 */
-	public $checkClasses = array(
-		'WP_Widget' => array(
-			'widget'                => array( 'args', 'instance' ),
-			'update'                => array( 'new_instance', 'old_instance' ),
-			'form'                  => array( 'instance' ),
-			'WP_Widget'             => array(
+	public $checkClasses = [
+		'WP_Widget' => [
+			'widget'                => [ 'args', 'instance' ],
+			'update'                => [ 'new_instance', 'old_instance' ],
+			'form'                  => [ 'instance' ],
+			'WP_Widget'             => [
 				'id_base',
 				'name',
-				'widget_options'  => array(
+				'widget_options'  => [
 					'default' => 'array()',
-				),
-				'constol_options' => array(
+				],
+				'constol_options' => [
 					'default' => 'array()',
-				),
-			),
-			'get_field_name'        => array( 'field_name' ),
-			'get_field_id'          => array( 'field_name' ),
-			'_register'             => array(),
-			'_set'                  => array( 'number' ),
-			'_get_display_callback' => array(),
-			'_get_update_callback'  => array(),
-			'_get_form_callback'    => array(),
-			'is_preview'            => array(),
-			'display_callback'      => array(
+				],
+			],
+			'get_field_name'        => [ 'field_name' ],
+			'get_field_id'          => [ 'field_name' ],
+			'_register'             => [],
+			'_set'                  => [ 'number' ],
+			'_get_display_callback' => [],
+			'_get_update_callback'  => [],
+			'_get_form_callback'    => [],
+			'is_preview'            => [],
+			'display_callback'      => [
 				'args',
-				'widget_args' => array(
+				'widget_args' => [
 					'default' => '1',
-				),
-			),
-			'update_callback'       => array(
-				'deprecated' => array(
+				],
+			],
+			'update_callback'       => [
+				'deprecated' => [
 					'default' => '1',
-				),
-			),
-			'form_callback'         => array(
-				'widget_args' => array(
+				],
+			],
+			'form_callback'         => [
+				'widget_args' => [
 					'default' => '1',
-				),
-			),
-			'register_one'          => array(
-				'number' => array(
+				],
+			],
+			'register_one'          => [
+				'number' => [
 					'default' => '-1',
-				),
-			),
-			'save_settings'         => array( 'settings' ),
-			'get_settings'          => array(),
-		),
-		'Walker'    => array(
-			'start_lvl'                   => array(
-				'output' => array(
+				],
+			],
+			'save_settings'         => [ 'settings' ],
+			'get_settings'          => [],
+		],
+		'Walker'    => [
+			'start_lvl'                   => [
+				'output' => [
 					'pass_by_reference' => true,
-				),
-				'depth'  => array(
+				],
+				'depth'  => [
 					'default' => '0',
-				),
-				'args'   => array(
+				],
+				'args'   => [
 					'default' => 'array()',
-				),
-			),
-			'end_lvl'                     => array(
-				'output' => array(
+				],
+			],
+			'end_lvl'                     => [
+				'output' => [
 					'pass_by_reference' => true,
-				),
-				'depth'  => array(
+				],
+				'depth'  => [
 					'default' => '0',
-				),
-				'args'   => array(
+				],
+				'args'   => [
 					'default' => 'array()',
-				),
-			),
-			'start_el'                    => array(
-				'output'            => array(
+				],
+			],
+			'start_el'                    => [
+				'output'            => [
 					'pass_by_reference' => true,
-				),
+				],
 				'object',
-				'depth'             => array(
+				'depth'             => [
 					'default' => '0',
-				),
-				'args'              => array(
+				],
+				'args'              => [
 					'default' => 'array()',
-				),
-				'current_object_id' => array(
+				],
+				'current_object_id' => [
 					'default' => '0',
-				),
-			),
-			'end_el'                      => array(
-				'output' => array(
+				],
+			],
+			'end_el'                      => [
+				'output' => [
 					'pass_by_reference' => true,
-				),
+				],
 				'object',
-				'depth'  => array(
+				'depth'  => [
 					'default' => '0',
-				),
-				'args'   => array(
+				],
+				'args'   => [
 					'default' => 'array()',
-				),
-			),
-			'display_element'             => array(
+				],
+			],
+			'display_element'             => [
 				'element',
-				'children_elements' => array(
+				'children_elements' => [
 					'pass_by_reference' => true,
-				),
+				],
 				'max_depth',
 				'depth',
 				'args',
-				'output'            => array(
+				'output'            => [
 					'pass_by_reference' => true,
-				),
-			),
-			'walk'                        => array(
+				],
+			],
+			'walk'                        => [
 				'elements',
 				'max_depth',
-			),
-			'paged_walk'                  => array(
+			],
+			'paged_walk'                  => [
 				'elements',
 				'max_depth',
 				'page_num',
 				'per_page',
-			),
-			'get_number_of_root_elements' => array(
+			],
+			'get_number_of_root_elements' => [
 				'elements',
-			),
-			'unset_children'              => array(
+			],
+			'unset_children'              => [
 				'el',
-				'children_elements' => array(
+				'children_elements' => [
 					'pass_by_reference' => true,
-				),
-			),
-		),
-	);
+				],
+			],
+		],
+	];
 
 	/**
 	 * List of grouped classes with same methods (as they extend the same parent class)
 	 *
 	 * @var array
 	 */
-	public $checkClassesGroups = array(
-		'Walker' => array(
+	public $checkClassesGroups = [
+		'Walker' => [
 			'Walker_Category_Checklist',
 			'Walker_Category',
 			'Walker_CategoryDropdown',
@@ -181,14 +181,14 @@ class DeclarationCompatibilitySniff extends AbstractScopeSniff {
 			'Walker_Nav_Menu',
 			'Walker_Page',
 			'Walker_Comment',
-		),
-	);
+		],
+	];
 
 	/**
 	 * Constructs the test with the tokens it wishes to listen for.
 	 */
 	public function __construct() {
-		parent::__construct( array( T_CLASS ), array( T_FUNCTION ), true );
+		parent::__construct( [ T_CLASS ], [ T_FUNCTION ], true );
 	}
 
 	/**
@@ -310,7 +310,7 @@ class DeclarationCompatibilitySniff extends AbstractScopeSniff {
 	 * @return array
 	 */
 	private function generateParamList( $methodSignature ) {
-		$paramList = array();
+		$paramList = [];
 		foreach ( $methodSignature as $param => $options ) {
 			$paramName = '$';
 			if ( false === is_array( $options ) ) {
@@ -347,7 +347,7 @@ class DeclarationCompatibilitySniff extends AbstractScopeSniff {
 	 * @return void
 	 */
 	protected function loadFunctionNamesInScope( File $phpcsFile, $currScope ) {
-		$this->_functionList = array();
+		$this->_functionList = [];
 		$tokens              = $phpcsFile->getTokens();
 
 		for ( $i = ( $tokens[ $currScope ]['scope_opener'] + 1 ); $i < $tokens[ $currScope ]['scope_closer']; $i++ ) {

--- a/WordPressVIPMinimum/Sniffs/Classes/RestrictedExtendClassesSniff.php
+++ b/WordPressVIPMinimum/Sniffs/Classes/RestrictedExtendClassesSniff.php
@@ -26,15 +26,15 @@ class RestrictedExtendClassesSniff extends AbstractClassRestrictionsSniff {
 	 * @return array
 	 */
 	public function getGroups() {
-		return array(
-			'wp_cli' => array(
+		return [
+			'wp_cli' => [
 				'type'    => 'warning',
 				'message' => 'We recommend extending `WPCOM_VIP_CLI_Command` instead of `WP_CLI_Command` and using the helper functions available in it (such as `stop_the_insanity()`), see https://vip.wordpress.com/documentation/writing-bin-scripts/ for more information.',
-				'classes' => array(
+				'classes' => [
 					'WP_CLI_Command',
-				),
-			),
-		);
+				],
+			],
+		];
 	}
 
 	/**

--- a/WordPressVIPMinimum/Sniffs/Constants/ConstantRestrictionsSniff.php
+++ b/WordPressVIPMinimum/Sniffs/Constants/ConstantRestrictionsSniff.php
@@ -24,19 +24,19 @@ class ConstantRestrictionsSniff implements Sniff {
 	 *
 	 * @var array
 	 */
-	public $restrictedConstantNames = array(
+	public $restrictedConstantNames = [
 		'A8C_PROXIED_REQUEST',
-	);
+	];
 
 	/**
 	 * List of restricted constant declarations.
 	 *
 	 * @var array
 	 */
-	public $restrictedConstantDeclaration = array(
+	public $restrictedConstantDeclaration = [
 		'JETPACK_DEV_DEBUG',
 		'WP_CRON_CONTROL_SECRET',
-	);
+	];
 
 	/**
 	 * Returns an array of tokens this test wants to listen for.
@@ -44,10 +44,10 @@ class ConstantRestrictionsSniff implements Sniff {
 	 * @return array
 	 */
 	public function register() {
-		return array(
+		return [
 			T_CONSTANT_ENCAPSED_STRING,
 			T_STRING,
-		);
+		];
 	}
 
 	/**

--- a/WordPressVIPMinimum/Sniffs/Constants/ConstantStringSniff.php
+++ b/WordPressVIPMinimum/Sniffs/Constants/ConstantStringSniff.php
@@ -25,9 +25,9 @@ class ConstantStringSniff implements Sniff {
 	 * @return array
 	 */
 	public function register() {
-		return array(
+		return [
 			T_STRING,
-		);
+		];
 	}
 
 	/**
@@ -42,7 +42,7 @@ class ConstantStringSniff implements Sniff {
 
 		$tokens = $phpcsFile->getTokens();
 
-		if ( false === in_array( $tokens[ $stackPtr ]['content'], array( 'define', 'defined' ), true ) ) {
+		if ( false === in_array( $tokens[ $stackPtr ]['content'], [ 'define', 'defined' ], true ) ) {
 			return;
 		}
 

--- a/WordPressVIPMinimum/Sniffs/Files/IncludingFileSniff.php
+++ b/WordPressVIPMinimum/Sniffs/Files/IncludingFileSniff.php
@@ -127,7 +127,7 @@ class IncludingFileSniff extends AbstractFunctionRestrictionsSniff {
 				return;
 			}
 
-			$nextNextToken = $this->phpcsFile->findNext( array_merge( Tokens::$emptyTokens, array( T_COMMENT ) ), ( $nextToken + 1 ), null, true, null, true );
+			$nextNextToken = $this->phpcsFile->findNext( array_merge( Tokens::$emptyTokens, [ T_COMMENT ] ), ( $nextToken + 1 ), null, true, null, true );
 			if ( 1 === preg_match( '/^[a-zA-Z_\x7f-\xff][a-zA-Z0-9_\x7f-\xff]*$/', $tokens[ $nextToken ]['content'] ) && T_OPEN_PARENTHESIS !== $tokens[ $nextNextToken ]['code'] ) {
 				// The construct is using custom constant, which needs manual inspection.
 				$this->phpcsFile->addWarning( sprintf( 'File inclusion using custom constant (`%s`). Probably needs manual inspection.', $tokens[ $nextToken ]['content'] ), $nextToken, 'UsingCustomConstant' );

--- a/WordPressVIPMinimum/Sniffs/Files/IncludingNonPHPFileSniff.php
+++ b/WordPressVIPMinimum/Sniffs/Files/IncludingNonPHPFileSniff.php
@@ -59,11 +59,11 @@ class IncludingNonPHPFileSniff implements Sniff {
 			}
 
 			$extension = $regexMatches[1];
-			if ( true === in_array( $extension, array( '.php', '.inc' ), true ) ) {
+			if ( true === in_array( $extension, [ '.php', '.inc' ], true ) ) {
 				return;
 			}
 
-			if ( true === in_array( $extension, array( '.svg', '.css' ), true ) ) {
+			if ( true === in_array( $extension, [ '.svg', '.css' ], true ) ) {
 				$phpcsFile->addError( sprintf( 'Local SVG and CSS files should be loaded via `file_get_contents` rather than via `%s`.', $tokens[ $stackPtr ]['content'] ), $curStackPtr, 'IncludingSVGCSSFile' );
 			} else {
 				$phpcsFile->addError( sprintf( 'Local non-PHP file should be loaded via `file_get_contents` rather than via `%s`', $tokens[ $stackPtr ]['content'] ), $curStackPtr, 'IncludingNonPHPFile' );

--- a/WordPressVIPMinimum/Sniffs/Filters/AlwaysReturnSniff.php
+++ b/WordPressVIPMinimum/Sniffs/Filters/AlwaysReturnSniff.php
@@ -70,7 +70,7 @@ class AlwaysReturnSniff implements Sniff {
 		}
 
 		$this->filterNamePtr = $this->phpcsFile->findNext(
-			array_merge( Tokens::$emptyTokens, array( T_OPEN_PARENTHESIS ) ), // types.
+			array_merge( Tokens::$emptyTokens, [ T_OPEN_PARENTHESIS ] ), // types.
 			$stackPtr + 1, // start.
 			null, // end.
 			true, // exclude.
@@ -84,7 +84,7 @@ class AlwaysReturnSniff implements Sniff {
 		}
 
 		$callbackPtr = $this->phpcsFile->findNext(
-			array_merge( Tokens::$emptyTokens, array( T_COMMA ) ), // types.
+			array_merge( Tokens::$emptyTokens, [ T_COMMA ] ), // types.
 			$this->filterNamePtr + 1, // start.
 			null, // end.
 			true, // exclude.
@@ -174,7 +174,7 @@ class AlwaysReturnSniff implements Sniff {
 		$functionName = $this->tokens[ $stackPtr ]['content'];
 
 		$offset = $start;
-		while ( $functionStackPtr = $this->phpcsFile->findNext( array( T_FUNCTION ), $offset, $end, false, null, false ) ) {
+		while ( $functionStackPtr = $this->phpcsFile->findNext( [ T_FUNCTION ], $offset, $end, false, null, false ) ) {
 			$functionNamePtr = $this->phpcsFile->findNext( Tokens::$emptyTokens, $functionStackPtr + 1, null, true, null, true );
 			if ( T_STRING === $this->tokens[ $functionNamePtr ]['code'] ) {
 				if ( $this->tokens[ $functionNamePtr ]['content'] === $functionName ) {
@@ -213,7 +213,7 @@ class AlwaysReturnSniff implements Sniff {
 		$functionBodyScopeEnd   = $this->tokens[ $stackPtr ]['scope_closer'];
 
 		$returnTokenPtr = $this->phpcsFile->findNext(
-			array( T_RETURN ), // types.
+			[ T_RETURN ], // types.
 			( $functionBodyScopeStart + 1 ), // start.
 			$functionBodyScopeEnd, // end.
 			false, // exclude.
@@ -239,7 +239,7 @@ class AlwaysReturnSniff implements Sniff {
 				);
 			}
 			$returnTokenPtr = $this->phpcsFile->findNext(
-				array( T_RETURN ), // types.
+				[ T_RETURN ], // types.
 				( $returnTokenPtr + 1 ), // start.
 				$functionBodyScopeEnd, // end.
 				false, // exclude.
@@ -304,7 +304,7 @@ class AlwaysReturnSniff implements Sniff {
 	private function isReturningVoid( $stackPtr ) {
 
 		$nextToReturnTokenPtr = $this->phpcsFile->findNext(
-			array( Tokens::$emptyTokens ), // types.
+			[ Tokens::$emptyTokens ], // types.
 			( $stackPtr + 1 ), // start.
 			null, // end.
 			true, // exclude.

--- a/WordPressVIPMinimum/Sniffs/Functions/CheckReturnValueSniff.php
+++ b/WordPressVIPMinimum/Sniffs/Functions/CheckReturnValueSniff.php
@@ -27,40 +27,40 @@ class CheckReturnValueSniff implements Sniff {
 	 *
 	 * @var array
 	 */
-	private $_tokens = array();
+	private $_tokens = [];
 
 	/**
 	 * Pairs we are about to check.
 	 *
 	 * @var array
 	 */
-	public $catch = array(
-		'esc_url'          => array(
+	public $catch = [
+		'esc_url'          => [
 			'get_term_link',
-		),
-		'wp_list_pluck'    => array(
+		],
+		'wp_list_pluck'    => [
 			'get_the_tags',
 			'get_the_terms',
-		),
-		'foreach'          => array(
+		],
+		'foreach'          => [
 			'get_post_meta',
 			'get_term_meta',
 			'get_the_terms',
 			'get_the_tags',
-		),
-		'array_key_exists' => array(
+		],
+		'array_key_exists' => [
 			'get_option',
-		),
-	);
+		],
+	];
 
 	/**
 	 * Tokens we are about to examine, which are not functions.
 	 *
 	 * @var array
 	 */
-	public $notFunctions = array(
+	public $notFunctions = [
 		'foreach' => T_FOREACH,
-	);
+	];
 
 	/**
 	 * Returns the token types that this sniff is interested in.
@@ -213,7 +213,7 @@ class CheckReturnValueSniff implements Sniff {
 
 		$isFunctionWeLookFor = false;
 
-		$callees = array();
+		$callees = [];
 
 		foreach ( $this->catch as $callee => $checkReturnArray ) {
 			if ( true === in_array( $functionName, $checkReturnArray, true ) ) {
@@ -248,9 +248,9 @@ class CheckReturnValueSniff implements Sniff {
 		// Find the closing bracket.
 		$closeBracket = $tokens[ $openBracket ]['parenthesis_closer'];
 
-		if ( true === in_array( $functionName, array( 'get_post_meta', 'get_term_meta' ), true ) ) {
+		if ( true === in_array( $functionName, [ 'get_post_meta', 'get_term_meta' ], true ) ) {
 			// Since the get_post_meta and get_term_meta always returns an array if $single is set to `true` we need to check for the value of it's third param before proceeding.
-			$params       = array();
+			$params       = [];
 			$paramNo      = 1;
 			$prevCommaPos = $openBracket + 1;
 
@@ -261,12 +261,12 @@ class CheckReturnValueSniff implements Sniff {
 				}
 
 				if ( T_COMMA === $tokens[ $i ]['code'] ) {
-					$params[ $paramNo++ ] = trim( array_reduce( array_slice( $tokens, $prevCommaPos, $i - $prevCommaPos ), array( $this, 'reduce_array' ) ) );
+					$params[ $paramNo++ ] = trim( array_reduce( array_slice( $tokens, $prevCommaPos, $i - $prevCommaPos ), [ $this, 'reduce_array' ] ) );
 					$prevCommaPos         = $i + 1;
 				}
 
 				if ( $i === $closeBracket ) {
-					$params[ $paramNo ] = trim( array_reduce( array_slice( $tokens, $prevCommaPos, $i - $prevCommaPos ), array( $this, 'reduce_array' ) ) );
+					$params[ $paramNo ] = trim( array_reduce( array_slice( $tokens, $prevCommaPos, $i - $prevCommaPos ), [ $this, 'reduce_array' ] ) );
 					break;
 				}
 			}
@@ -291,7 +291,7 @@ class CheckReturnValueSniff implements Sniff {
 		$nextFunctionCallWithVariable = $phpcsFile->findPrevious( $search, ( $nextVariableOccurrence - 1 ), null, true );
 
 		foreach ( $callees as $callee ) {
-			$notFunctionsCallee = array_key_exists( $callee, $this->notFunctions ) ? (array) $this->notFunctions[ $callee ] : array();
+			$notFunctionsCallee = array_key_exists( $callee, $this->notFunctions ) ? (array) $this->notFunctions[ $callee ] : [];
 			// Check whether the found token is one of the function calls (or foreach call) we are interested in.
 			if ( true === in_array( $tokens[ $nextFunctionCallWithVariable ]['code'], array_merge( Tokens::$functionNameTokens, $notFunctionsCallee ), true )
 				&& $tokens[ $nextFunctionCallWithVariable ]['content'] === $callee
@@ -300,7 +300,7 @@ class CheckReturnValueSniff implements Sniff {
 				return;
 			}
 
-			$search = array_merge( Tokens::$emptyTokens, array( T_EQUAL ) );
+			$search = array_merge( Tokens::$emptyTokens, [ T_EQUAL ] );
 			$next   = $phpcsFile->findNext( $search, ( $nextVariableOccurrence + 1 ), null, true, null, false );
 			if ( true === in_array( $tokens[ $next ]['code'], Tokens::$functionNameTokens, true )
 				&& $tokens[ $next ]['content'] === $callee

--- a/WordPressVIPMinimum/Sniffs/Functions/DynamicCallsSniff.php
+++ b/WordPressVIPMinimum/Sniffs/Functions/DynamicCallsSniff.php
@@ -32,7 +32,7 @@ class DynamicCallsSniff implements Sniff {
 	 *
 	 * @var array
 	 */
-	private $_blacklisted_functions = array(
+	private $_blacklisted_functions = [
 		'assert',
 		'compact',
 		'extract',
@@ -42,7 +42,7 @@ class DynamicCallsSniff implements Sniff {
 		'get_defined_vars',
 		'mb_parse_str',
 		'parse_str',
-	);
+	];
 
 	/**
 	 * Array of functions encountered, along with their values.
@@ -50,7 +50,7 @@ class DynamicCallsSniff implements Sniff {
 	 *
 	 * @var array
 	 */
-	private $_variables_arr = array();
+	private $_variables_arr = [];
 
 	/**
 	 * Returns the token types that this sniff is interested in.
@@ -60,7 +60,7 @@ class DynamicCallsSniff implements Sniff {
 	 * @return array(int)
 	 */
 	public function register() {
-		return array( T_VARIABLE => T_VARIABLE );
+		return [ T_VARIABLE => T_VARIABLE ];
 	}
 
 	/**
@@ -115,7 +115,7 @@ class DynamicCallsSniff implements Sniff {
 		 */
 
 		$t_item_key = $this->_phpcsFile->findNext(
-			array( T_WHITESPACE ),
+			[ T_WHITESPACE ],
 			$this->_stackPtr + 1,
 			null,
 			true,
@@ -139,7 +139,7 @@ class DynamicCallsSniff implements Sniff {
 		 * Find encapsed string ( "" )
 		 */
 		$t_item_key = $this->_phpcsFile->findNext(
-			array( T_CONSTANT_ENCAPSED_STRING ),
+			[ T_CONSTANT_ENCAPSED_STRING ],
 			$t_item_key + 1,
 			null,
 			false,

--- a/WordPressVIPMinimum/Sniffs/JS/DangerouslySetInnerHTMLSniff.php
+++ b/WordPressVIPMinimum/Sniffs/JS/DangerouslySetInnerHTMLSniff.php
@@ -25,9 +25,9 @@ class DangerouslySetInnerHTMLSniff implements Sniff {
 	 *
 	 * @var array
 	 */
-	public $supportedTokenizers = array(
+	public $supportedTokenizers = [
 		'JS',
-	);
+	];
 
 	/**
 	 * Returns an array of tokens this test wants to listen for.
@@ -35,9 +35,9 @@ class DangerouslySetInnerHTMLSniff implements Sniff {
 	 * @return array
 	 */
 	public function register() {
-		return array(
+		return [
 			T_STRING,
-		);
+		];
 	}
 
 	/**

--- a/WordPressVIPMinimum/Sniffs/JS/HTMLExecutingFunctionsSniff.php
+++ b/WordPressVIPMinimum/Sniffs/JS/HTMLExecutingFunctionsSniff.php
@@ -25,21 +25,21 @@ class HTMLExecutingFunctionsSniff implements Sniff {
 	 *
 	 * @var array
 	 */
-	public $HTMLExecutingFunctions = array(
+	public $HTMLExecutingFunctions = [
 		'html',
 		'append',
 		'write',
 		'writeln',
-	);
+	];
 
 	/**
 	 * A list of tokenizers this sniff supports.
 	 *
 	 * @var array
 	 */
-	public $supportedTokenizers = array(
+	public $supportedTokenizers = [
 		'JS',
-	);
+	];
 
 	/**
 	 * Returns an array of tokens this test wants to listen for.
@@ -47,9 +47,9 @@ class HTMLExecutingFunctionsSniff implements Sniff {
 	 * @return array
 	 */
 	public function register() {
-		return array(
+		return [
 			T_STRING,
-		);
+		];
 	}
 
 	/**

--- a/WordPressVIPMinimum/Sniffs/JS/InnerHTMLSniff.php
+++ b/WordPressVIPMinimum/Sniffs/JS/InnerHTMLSniff.php
@@ -25,9 +25,9 @@ class InnerHTMLSniff implements Sniff {
 	 *
 	 * @var array
 	 */
-	public $supportedTokenizers = array(
+	public $supportedTokenizers = [
 		'JS',
-	);
+	];
 
 	/**
 	 * Returns an array of tokens this test wants to listen for.
@@ -35,9 +35,9 @@ class InnerHTMLSniff implements Sniff {
 	 * @return array
 	 */
 	public function register() {
-		return array(
+		return [
 			T_STRING,
-		);
+		];
 	}
 
 	/**

--- a/WordPressVIPMinimum/Sniffs/JS/StringConcatSniff.php
+++ b/WordPressVIPMinimum/Sniffs/JS/StringConcatSniff.php
@@ -25,9 +25,9 @@ class StringConcatSniff implements Sniff {
 	 *
 	 * @var array
 	 */
-	public $supportedTokenizers = array(
+	public $supportedTokenizers = [
 		'JS',
-	);
+	];
 
 	/**
 	 * Returns an array of tokens this test wants to listen for.
@@ -35,9 +35,9 @@ class StringConcatSniff implements Sniff {
 	 * @return array
 	 */
 	public function register() {
-		return array(
+		return [
 			T_PLUS,
-		);
+		];
 	}
 
 

--- a/WordPressVIPMinimum/Sniffs/JS/StrippingTagsSniff.php
+++ b/WordPressVIPMinimum/Sniffs/JS/StrippingTagsSniff.php
@@ -25,9 +25,9 @@ class StrippingTagsSniff implements Sniff {
 	 *
 	 * @var array
 	 */
-	public $supportedTokenizers = array(
+	public $supportedTokenizers = [
 		'JS',
-	);
+	];
 
 	/**
 	 * Returns an array of tokens this test wants to listen for.
@@ -35,9 +35,9 @@ class StrippingTagsSniff implements Sniff {
 	 * @return array
 	 */
 	public function register() {
-		return array(
+		return [
 			T_STRING,
-		);
+		];
 	}
 
 

--- a/WordPressVIPMinimum/Sniffs/JS/WindowSniff.php
+++ b/WordPressVIPMinimum/Sniffs/JS/WindowSniff.php
@@ -25,9 +25,9 @@ class WindowSniff implements Sniff {
 	 *
 	 * @var array
 	 */
-	public $supportedTokenizers = array(
+	public $supportedTokenizers = [
 		'JS',
-	);
+	];
 
 	/**
 	 * Returns an array of tokens this test wants to listen for.

--- a/WordPressVIPMinimum/Sniffs/TemplatingEngines/UnescapedOutputMustacheSniff.php
+++ b/WordPressVIPMinimum/Sniffs/TemplatingEngines/UnescapedOutputMustacheSniff.php
@@ -24,10 +24,10 @@ class UnescapedOutputMustacheSniff implements Sniff {
 	 *
 	 * @var array
 	 */
-	public $supportedTokenizers = array(
+	public $supportedTokenizers = [
 		'JS',
 		'PHP',
-	);
+	];
 
 	/**
 	 * Returns an array of tokens this test wants to listen for.
@@ -35,12 +35,12 @@ class UnescapedOutputMustacheSniff implements Sniff {
 	 * @return array
 	 */
 	public function register() {
-		return array(
+		return [
 			T_CONSTANT_ENCAPSED_STRING,
 			T_STRING,
 			T_INLINE_HTML,
 			T_HEREDOC,
-		);
+		];
 	}
 
 	/**
@@ -67,7 +67,7 @@ class UnescapedOutputMustacheSniff implements Sniff {
 
 		if ( false !== strpos( $tokens[ $stackPtr ]['content'], '{{=' ) ) {
 			// Mustache delimiter change.
-			$new_delimiter = trim( str_replace( array( '{{=', '=}}' ), '', substr( $tokens[ $stackPtr ]['content'], 0, ( strpos( $tokens[ $stackPtr ]['content'], '=}}' ) + 3 ) ) ) );
+			$new_delimiter = trim( str_replace( [ '{{=', '=}}' ], '', substr( $tokens[ $stackPtr ]['content'], 0, ( strpos( $tokens[ $stackPtr ]['content'], '=}}' ) + 3 ) ) ) );
 			$phpcsFile->addWarning( sprintf( 'Found Mustache delimiter change notation. New delimiter is: %s', $new_delimiter ), $stackPtr, 'delimiterChange' );
 		}
 

--- a/WordPressVIPMinimum/Sniffs/TemplatingEngines/UnescapedOutputTwigSniff.php
+++ b/WordPressVIPMinimum/Sniffs/TemplatingEngines/UnescapedOutputTwigSniff.php
@@ -24,10 +24,10 @@ class UnescapedOutputTwigSniff implements Sniff {
 	 *
 	 * @var array
 	 */
-	public $supportedTokenizers = array(
+	public $supportedTokenizers = [
 		'JS',
 		'PHP',
-	);
+	];
 
 	/**
 	 * Returns an array of tokens this test wants to listen for.
@@ -35,11 +35,11 @@ class UnescapedOutputTwigSniff implements Sniff {
 	 * @return array
 	 */
 	public function register() {
-		return array(
+		return [
 			T_CONSTANT_ENCAPSED_STRING,
 			T_INLINE_HTML,
 			T_HEREDOC,
-		);
+		];
 	}
 
 	/**

--- a/WordPressVIPMinimum/Sniffs/TemplatingEngines/UnescapedOutputUnderscorejsSniff.php
+++ b/WordPressVIPMinimum/Sniffs/TemplatingEngines/UnescapedOutputUnderscorejsSniff.php
@@ -24,10 +24,10 @@ class UnescapedOutputUnderscorejsSniff implements Sniff {
 	 *
 	 * @var array
 	 */
-	public $supportedTokenizers = array(
+	public $supportedTokenizers = [
 		'JS',
 		'PHP',
-	);
+	];
 
 	/**
 	 * Returns an array of tokens this test wants to listen for.
@@ -35,12 +35,12 @@ class UnescapedOutputUnderscorejsSniff implements Sniff {
 	 * @return array
 	 */
 	public function register() {
-		return array(
+		return [
 			T_CONSTANT_ENCAPSED_STRING,
 			T_PROPERTY,
 			T_INLINE_HTML,
 			T_HEREDOC,
-		);
+		];
 	}
 
 	/**

--- a/WordPressVIPMinimum/Sniffs/TemplatingEngines/UnescapedOutputVuejsSniff.php
+++ b/WordPressVIPMinimum/Sniffs/TemplatingEngines/UnescapedOutputVuejsSniff.php
@@ -24,10 +24,10 @@ class UnescapedOutputVuejsSniff implements Sniff {
 	 *
 	 * @var array
 	 */
-	public $supportedTokenizers = array(
+	public $supportedTokenizers = [
 		'JS',
 		'PHP',
-	);
+	];
 
 	/**
 	 * Returns an array of tokens this test wants to listen for.
@@ -35,10 +35,10 @@ class UnescapedOutputVuejsSniff implements Sniff {
 	 * @return array
 	 */
 	public function register() {
-		return array(
+		return [
 			T_CONSTANT_ENCAPSED_STRING,
 			T_INLINE_HTML,
-		);
+		];
 	}
 
 	/**

--- a/WordPressVIPMinimum/Sniffs/VIP/ErrorControlSniff.php
+++ b/WordPressVIPMinimum/Sniffs/VIP/ErrorControlSniff.php
@@ -24,9 +24,9 @@ class ErrorControlSniff implements Sniff {
 	 * @return array
 	 */
 	public function register() {
-		return array(
+		return [
 			T_ASPERAND,
-		);
+		];
 	}
 
 	/**

--- a/WordPressVIPMinimum/Sniffs/VIP/EscapingVoidReturnFunctionsSniff.php
+++ b/WordPressVIPMinimum/Sniffs/VIP/EscapingVoidReturnFunctionsSniff.php
@@ -25,9 +25,9 @@ class EscapingVoidReturnFunctionsSniff implements Sniff {
 	 * @return array
 	 */
 	public function register() {
-		return array(
+		return [
 			T_STRING,
-		);
+		];
 	}
 
 	/**

--- a/WordPressVIPMinimum/Sniffs/VIP/ExitAfterRedirectSniff.php
+++ b/WordPressVIPMinimum/Sniffs/VIP/ExitAfterRedirectSniff.php
@@ -50,7 +50,7 @@ class ExitAfterRedirectSniff implements Sniff {
 			return;
 		}
 
-		$next_token = $phpcsFile->findNext( array_merge( Tokens::$emptyTokens, array( T_SEMICOLON, T_CLOSE_PARENTHESIS ) ), ( $tokens[ $openBracket ]['parenthesis_closer'] + 1 ), null, true );
+		$next_token = $phpcsFile->findNext( array_merge( Tokens::$emptyTokens, [ T_SEMICOLON, T_CLOSE_PARENTHESIS ] ), ( $tokens[ $openBracket ]['parenthesis_closer'] + 1 ), null, true );
 
 		if ( T_OPEN_CURLY_BRACKET === $tokens[ $next_token ]['code'] ) {
 			$is_exit_in_scope = false;

--- a/WordPressVIPMinimum/Sniffs/VIP/MergeConflictSniff.php
+++ b/WordPressVIPMinimum/Sniffs/VIP/MergeConflictSniff.php
@@ -25,11 +25,11 @@ class MergeConflictSniff implements Sniff {
 	 *
 	 * @var array
 	 */
-	public $supportedTokenizers = array(
+	public $supportedTokenizers = [
 		'PHP',
 		'JS',
 		'CSS',
-	);
+	];
 
 	/**
 	 * Returns an array of tokens this test wants to listen for.
@@ -37,11 +37,11 @@ class MergeConflictSniff implements Sniff {
 	 * @return array
 	 */
 	public function register() {
-		return array(
+		return [
 			T_SL,
 			T_ENCAPSED_AND_WHITESPACE,
 			T_IS_IDENTICAL,
-		);
+		];
 	}
 
 

--- a/WordPressVIPMinimum/Sniffs/VIP/ProperEscapingFunctionSniff.php
+++ b/WordPressVIPMinimum/Sniffs/VIP/ProperEscapingFunctionSniff.php
@@ -24,11 +24,11 @@ class ProperEscapingFunctionSniff implements Sniff {
 	 *
 	 * @var array
 	 */
-	public $escaping_functions = array(
+	public $escaping_functions = [
 		'esc_url',
 		'esc_attr',
 		'esc_html',
-	);
+	];
 
 	/**
 	 * Returns an array of tokens this test wants to listen for.
@@ -103,13 +103,13 @@ class ProperEscapingFunctionSniff implements Sniff {
 	 */
 	public function is_href_or_src( $content ) {
 		$is_href_or_src = false;
-		foreach ( array( 'href', 'src', 'url' ) as $attr ) {
-			foreach ( array(
+		foreach ( [ 'href', 'src', 'url' ] as $attr ) {
+			foreach ( [
 				'="',
 				"='",
 				'=\'"', // The tokenizer does some fun stuff when it comes to mixing double and single quotes.
 				'="\'', // The tokenizer does some fun stuff when it comes to mixing double and single quotes.
-			) as $ending ) {
+			] as $ending ) {
 				if ( true === $this->endswith( $content, $attr . $ending ) ) {
 					$is_href_or_src = true;
 					break;
@@ -128,12 +128,12 @@ class ProperEscapingFunctionSniff implements Sniff {
 	 */
 	public function is_html_attr( $content ) {
 		$is_html_attr = false;
-		foreach ( array(
+		foreach ( [
 			'="',
 			"='",
 			'=\'"', // The tokenizer does some fun stuff when it comes to mixing double and single quotes.
 			'="\'', // The tokenizer does some fun stuff when it comes to mixing double and single quotes.
-		) as $ending ) {
+		] as $ending ) {
 			if ( true === $this->endswith( $content, $ending ) ) {
 				$is_html_attr = true;
 				break;

--- a/WordPressVIPMinimum/Sniffs/VIP/RegexpCompareSniff.php
+++ b/WordPressVIPMinimum/Sniffs/VIP/RegexpCompareSniff.php
@@ -31,15 +31,15 @@ class RegexpCompareSniff extends \WordPress\AbstractArrayAssignmentRestrictionsS
 	 * @return array
 	 */
 	public function getGroups() {
-		return array(
-			'compare' => array(
+		return [
+			'compare' => [
 				'type' => 'error',
-				'keys' => array(
+				'keys' => [
 					'compare',
 					'meta_compare',
-				),
-			),
-		);
+				],
+			],
+		];
 	}
 
 	/**
@@ -56,7 +56,7 @@ class RegexpCompareSniff extends \WordPress\AbstractArrayAssignmentRestrictionsS
 	public function callback( $key, $val, $line, $group ) {
 		if ( 0 === strpos( $val, 'NOT REGEXP' )
 			|| 0 === strpos( $val, 'REGEXP' )
-			|| true === in_array( $val, array( 'REGEXP', 'NOT REGEXP' ), true )
+			|| true === in_array( $val, [ 'REGEXP', 'NOT REGEXP' ], true )
 		) {
 			return 'Detected regular expression comparison. `%s` is set to `%s`.';
 		}

--- a/WordPressVIPMinimum/Sniffs/VIP/RemoteRequestTimeoutSniff.php
+++ b/WordPressVIPMinimum/Sniffs/VIP/RemoteRequestTimeoutSniff.php
@@ -31,14 +31,14 @@ class RemoteRequestTimeoutSniff extends \WordPress\AbstractArrayAssignmentRestri
 	 * @return array
 	 */
 	public function getGroups() {
-		return array(
-			'timeout' => array(
+		return [
+			'timeout' => [
 				'type' => 'error',
-				'keys' => array(
+				'keys' => [
 					'timeout',
-				),
-			),
-		);
+				],
+			],
+		];
 	}
 
 	/**

--- a/WordPressVIPMinimum/Sniffs/VIP/RestrictedFunctionsSniff.php
+++ b/WordPressVIPMinimum/Sniffs/VIP/RestrictedFunctionsSniff.php
@@ -24,222 +24,222 @@ class RestrictedFunctionsSniff extends AbstractFunctionRestrictionsSniff {
 	 */
 	public function getGroups() {
 
-		$groups = array(
-			'wp_cache_get_multi' => array(
+		$groups = [
+			'wp_cache_get_multi' => [
 				'type'      => 'error',
 				'message'   => '`%s` is not supported on the WordPress.com VIP platform.',
-				'functions' => array( 'wp_cache_get_multi' ),
-			),
-			'opcache' => array(
+				'functions' => [ 'wp_cache_get_multi' ],
+			],
+			'opcache' => [
 				'type'      => 'error',
 				'message'   => '`%s` is prohibited on the WordPress VIP platform due to memory corruption.',
-				'functions' => array(
+				'functions' => [
 					'opcache_reset',
 					'opcache_invalidate',
 					'opcache_compile_file',
-				),
-			),
-			'config_settings' => array(
+				],
+			],
+			'config_settings' => [
 				'type'      => 'error',
 				'message'   => '`%s` is not recommended for use on the WordPress VIP platform due to potential setting changes.',
-				'functions' => array(
+				'functions' => [
 					'opcache_​is_​script_​cached',
 					'opcache_​get_​status',
 					'opcache_​get_​configuration',
-				),
-			),
-			'get_super_admins' => array(
+				],
+			],
+			'get_super_admins' => [
 				'type'      => 'error',
 				'message'   => '`%s` is prohibited on the WordPress.com VIP platform',
-				'functions' => array(
+				'functions' => [
 					'get_super_admins',
-				),
-			),
-			'internal' => array(
+				],
+			],
+			'internal' => [
 				'type'      => 'error',
 				'message'   => '`%1$s()` is for internal use only.',
-				'functions' => array(
+				'functions' => [
 					'wpcom_vip_irc',
-				),
-			),
+				],
+			],
 			// @link WordPress.com: https://lobby.vip.wordpress.com/wordpress-com-documentation/code-review-what-we-look-for/#flush_rewrite_rules
-			'rewrite_rules' => array(
+			'rewrite_rules' => [
 				'type'      => 'error',
 				'message'   => '`%s` should not be used in any normal circumstances in the theme code.',
-				'functions' => array(
+				'functions' => [
 					'flush_rewrite_rules',
-				),
-			),
-			'attachment_url_to_postid' => array(
+				],
+			],
+			'attachment_url_to_postid' => [
 				'type'      => 'error',
 				'message'   => '`%s()` is prohibited, please use `wpcom_vip_attachment_url_to_postid()` instead.',
-				'functions' => array(
+				'functions' => [
 					'attachment_url_to_postid',
-				),
-			),
-			'dbDelta' => array(
+				],
+			],
+			'dbDelta' => [
 				'type'      => 'error',
 				'message'   => 'All database modifications have to approved by the WordPress.com VIP team.',
-				'functions' => array(
+				'functions' => [
 					'dbDelta',
-				),
-			),
+				],
+			],
 			// @link WordPress.com: https://vip.wordpress.com/documentation/vip/code-review-what-we-look-for/#switch_to_blog
 			// @link VIP Go: https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/#switch_to_blog
-			'switch_to_blog' => array(
+			'switch_to_blog' => [
 				'type'      => 'error',
 				'message'   => '%s() is not something you should ever need to do in a VIP theme context. Instead use an API (XML-RPC, REST) to interact with other sites if needed.',
-				'functions' => array( 'switch_to_blog' ),
-			),
-			'get_page_by_title' => array(
+				'functions' => [ 'switch_to_blog' ],
+			],
+			'get_page_by_title' => [
 				'type'      => 'error',
 				'message'   => '%s() is prohibited, please use wpcom_vip_get_page_by_title() instead.',
-				'functions' => array(
+				'functions' => [
 					'get_page_by_title',
-				),
-			),
-			'url_to_postid' => array(
+				],
+			],
+			'url_to_postid' => [
 				'type'      => 'error',
 				'message'   => '%s() is prohibited, please use wpcom_vip_url_to_postid() instead.',
-				'functions' => array(
+				'functions' => [
 					'url_to_postid',
 					'url_to_post_id',
-				),
-			),
+				],
+			],
 			// @link WordPress.com: https://lobby.vip.wordpress.com/wordpress-com-documentation/code-review-what-we-look-for/#custom-roles
 			// @link VIP Go: https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/#custom-roles
-			'custom_role' => array(
+			'custom_role' => [
 				'type'      => 'error',
 				'message'   => 'Use wpcom_vip_add_role() instead of %s()',
-				'functions' => array(
+				'functions' => [
 					'add_role',
-				),
-			),
+				],
+			],
 			// @link WordPress.com: https://lobby.vip.wordpress.com/wordpress-com-documentation/code-review-what-we-look-for/#wp_users-and-user_meta
-			'user_meta' => array(
+			'user_meta' => [
 				'type'      => 'error',
 				'message'   => '%s() usage is highly discouraged on WordPress.com VIP due to it being a multisite, please see https://lobby.vip.wordpress.com/wordpress-com-documentation/code-review-what-we-look-for/#wp_users-and-user_meta.',
-				'functions' => array(
+				'functions' => [
 					'get_user_meta',
 					'update_user_meta',
 					'delete_user_meta',
 					'add_user_meta',
-				),
-			),
-			'term_exists' => array(
+				],
+			],
+			'term_exists' => [
 				'type'      => 'error',
 				'message'   => '%s() is highly discouraged due to not being cached; please use wpcom_vip_term_exists() instead.',
-				'functions' => array(
+				'functions' => [
 					'term_exists',
-				),
-			),
-			'count_user_posts' => array(
+				],
+			],
+			'count_user_posts' => [
 				'type'      => 'error',
 				'message'   => '%s() is highly discouraged due to not being cached; please use wpcom_vip_count_user_posts() instead.',
-				'functions' => array(
+				'functions' => [
 					'count_user_posts',
-				),
-			),
-			'wp_old_slug_redirect' => array(
+				],
+			],
+			'wp_old_slug_redirect' => [
 				'type'      => 'error',
 				'message'   => '%s() is highly discouraged due to not being cached; please use wpcom_vip_old_slug_redirect() instead.',
-				'functions' => array(
+				'functions' => [
 					'wp_old_slug_redirect',
-				),
-			),
-			'get_adjacent_post' => array(
+				],
+			],
+			'get_adjacent_post' => [
 				'type'      => 'error',
 				'message'   => '%s() is highly discouraged due to not being cached; please use wpcom_vip_get_adjacent_post() instead.',
-				'functions' => array(
+				'functions' => [
 					'get_adjacent_post',
 					'get_previous_post',
 					'get_previous_post_link',
 					'get_next_post',
 					'get_next_post_link',
-				),
-			),
-			'get_intermediate_image_sizes' => array(
+				],
+			],
+			'get_intermediate_image_sizes' => [
 				'type'      => 'error',
 				'message'   => 'Intermediate images do not exist on the VIP platform, and thus get_intermediate_image_sizes() returns an empty array() on the platform. This behavior is intentional to prevent WordPress from generating multiple thumbnails when images are uploaded.',
-				'functions' => array(
+				'functions' => [
 					'get_intermediate_image_sizes',
-				),
-			),
+				],
+			],
 			// @link WordPress.com: https://lobby.vip.wordpress.com/wordpress-com-documentation/code-review-what-we-look-for/#mobile-detection
 			// @link VIP Go: https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/#mobile-detection
-			'wp_is_mobile' => array(
+			'wp_is_mobile' => [
 				'type'      => 'error',
 				'message'   => '%s() found. When targeting mobile visitors, jetpack_is_mobile() should be used instead of wp_is_mobile. It is more robust and works better with full page caching.',
-				'functions' => array(
+				'functions' => [
 					'wp_is_mobile',
-				),
-			),
-			'wp_mail' => array(
+				],
+			],
+			'wp_mail' => [
 				'type'      => 'warning',
 				'message'   => '`%s` should be used sparingly. For any bulk emailing should be handled by a 3rd party service, in order to prevent domain or IP addresses being flagged as spam.',
-				'functions' => array(
+				'functions' => [
 					'wp_mail',
 					'mail',
-				),
-			),
-			'is_multi_author' => array(
+				],
+			],
+			'is_multi_author' => [
 				'type'      => 'warning',
 				'message'   => '`%s` can be very slow on large sites and likely not needed on many VIP sites since they tend to have more than one author.',
-				'functions' => array(
+				'functions' => [
 					'is_multi_author',
-				),
-			),
-			'advanced_custom_fields' => array(
+				],
+			],
+			'advanced_custom_fields' => [
 				'type'      => 'warning',
 				'message'   => '`%1$s` does not escape output by default, please echo and escape with the `get_*()` variant function instead (i.e. `get_field()`).',
-				'functions' => array(
+				'functions' => [
 					'the_sub_field',
 					'the_field',
-				),
-			),
+				],
+			],
 			// @link WordPress.com: https://lobby.vip.wordpress.com/wordpress-com-documentation/code-review-what-we-look-for/#remote-calls
 			// @link VIP Go: https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/#remote-calls
-			'wp_remote_get' => array(
+			'wp_remote_get' => [
 				'type'      => 'warning',
 				'message'   => '%s() is highly discouraged, please use vip_safe_wp_remote_get() instead.',
-				'functions' => array(
+				'functions' => [
 					'wp_remote_get',
-				),
-			),
+				],
+			],
 			// @link WordPress.com: https://lobby.vip.wordpress.com/wordpress-com-documentation/code-review-what-we-look-for/#custom-roles
 			// @link VIP Go: https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/#cache-constraints
-			'cookies' => array(
+			'cookies' => [
 				'type'      => 'warning',
 				'message'   => 'Due to using Batcache, server side based client related logic will not work, use JS instead.',
-				'functions' => array(
+				'functions' => [
 					'setcookie',
-				),
-			),
+				],
+			],
 			// @todo Introduce a sniff specific to get_posts() that checks for suppress_filters=>false being supplied.
-			'get_posts' => array(
+			'get_posts' => [
 				'type'      => 'warning',
 				'message'   => '%s() is uncached unless the "suppress_filters" parameter is set to false. If the suppress_filter parameter is set to false this can be safely ignored. More Info: https://vip.wordpress.com/documentation/vip-go/uncached-functions/',
-				'functions' => array(
+				'functions' => [
 					'get_posts',
 					'wp_get_recent_posts',
 					'get_children',
-				),
-			),
-		);
+				],
+			],
+		];
 
-		$deprecated_vip_helpers = array(
+		$deprecated_vip_helpers = [
 			'get_term_link'        => 'wpcom_vip_get_term_link',
 			'get_term_by'          => 'wpcom_vip_get_term_by',
 			'get_category_by_slug' => 'wpcom_vip_get_category_by_slug',
-		);
+		];
 		foreach ( $deprecated_vip_helpers as $restricted => $helper ) {
-			$groups[ $helper ] = array(
+			$groups[ $helper ] = [
 				'type'      => 'warning',
 				'message'   => "`%s()` is deprecated, please use `{$restricted}()` instead.",
-				'functions' => array(
+				'functions' => [
 					$helper,
-				),
-			);
+				],
+			];
 		}
 
 		return $groups;

--- a/WordPressVIPMinimum/Sniffs/VIP/RobotstxtSniff.php
+++ b/WordPressVIPMinimum/Sniffs/VIP/RobotstxtSniff.php
@@ -49,7 +49,7 @@ class RobotstxtSniff implements Sniff {
 		}
 
 		$actionNamePtr = $phpcsFile->findNext(
-			array_merge( Tokens::$emptyTokens, array( T_OPEN_PARENTHESIS ) ), // types.
+			array_merge( Tokens::$emptyTokens, [ T_OPEN_PARENTHESIS ] ), // types.
 			$stackPtr + 1, // start.
 			null, // end.
 			true, // exclude.

--- a/WordPressVIPMinimum/Sniffs/VIP/StaticStrreplaceSniff.php
+++ b/WordPressVIPMinimum/Sniffs/VIP/StaticStrreplaceSniff.php
@@ -52,7 +52,7 @@ class StaticStrreplaceSniff implements Sniff {
 
 		$next_start_ptr = $openBracket + 1;
 		for ( $i = 0; $i < 3; $i++ ) {
-			$param_ptr = $phpcsFile->findNext( array_merge( Tokens::$emptyTokens, array( T_COMMA ) ), $next_start_ptr, null, true );
+			$param_ptr = $phpcsFile->findNext( array_merge( Tokens::$emptyTokens, [ T_COMMA ] ), $next_start_ptr, null, true );
 
 			if ( T_ARRAY === $tokens[ $param_ptr ]['code'] ) {
 				$openBracket = $phpcsFile->findNext( Tokens::$emptyTokens, ( $param_ptr + 1 ), null, true );
@@ -63,13 +63,13 @@ class StaticStrreplaceSniff implements Sniff {
 				// Find the closing bracket.
 				$closeBracket = $tokens[ $openBracket ]['parenthesis_closer'];
 
-				$array_item_ptr = $phpcsFile->findNext( array_merge( Tokens::$emptyTokens, array( T_COMMA ) ), ( $openBracket + 1 ), $closeBracket, true );
+				$array_item_ptr = $phpcsFile->findNext( array_merge( Tokens::$emptyTokens, [ T_COMMA ] ), ( $openBracket + 1 ), $closeBracket, true );
 				while ( false !== $array_item_ptr ) {
 
 					if ( T_CONSTANT_ENCAPSED_STRING !== $tokens[ $array_item_ptr ]['code'] ) {
 						return;
 					}
-					$array_item_ptr = $phpcsFile->findNext( array_merge( Tokens::$emptyTokens, array( T_COMMA ) ), ( $array_item_ptr + 1 ), $closeBracket, true );
+					$array_item_ptr = $phpcsFile->findNext( array_merge( Tokens::$emptyTokens, [ T_COMMA ] ), ( $array_item_ptr + 1 ), $closeBracket, true );
 				}
 
 				$next_start_ptr = $closeBracket + 1;

--- a/WordPressVIPMinimum/Sniffs/VIP/TaxonomyMetaInOptionsSniff.php
+++ b/WordPressVIPMinimum/Sniffs/VIP/TaxonomyMetaInOptionsSniff.php
@@ -24,19 +24,19 @@ class TaxonomyMetaInOptionsSniff implements Sniff {
 	 *
 	 * @var array
 	 */
-	public $option_functions = array(
+	public $option_functions = [
 		'get_option',
 		'add_option',
 		'update_option',
 		'delete_option',
-	);
+	];
 
 	/**
 	 * List of possible variable names holding term ID.
 	 *
 	 * @var array
 	 */
-	public $taxonomy_term_patterns = array(
+	public $taxonomy_term_patterns = [
 		'category_id',
 		'cat_id',
 		'cat',
@@ -44,7 +44,7 @@ class TaxonomyMetaInOptionsSniff implements Sniff {
 		'term',
 		'tag_id',
 		'tag',
-	);
+	];
 
 	/**
 	 * Returns an array of tokens this test wants to listen for.

--- a/WordPressVIPMinimum/Sniffs/VIP/WPQueryParamsSniff.php
+++ b/WordPressVIPMinimum/Sniffs/VIP/WPQueryParamsSniff.php
@@ -25,9 +25,9 @@ class WPQueryParamsSniff implements Sniff {
 	 * @return array
 	 */
 	public function register() {
-		return array(
+		return [
 			T_CONSTANT_ENCAPSED_STRING,
-		);
+		];
 	}
 
 	/**
@@ -44,7 +44,7 @@ class WPQueryParamsSniff implements Sniff {
 
 		if ( 'suppress_filters' === trim( $tokens[ $stackPtr ]['content'], '\'' ) ) {
 
-			$next_token = $phpcsFile->findNext( array_merge( Tokens::$emptyTokens, array( T_EQUAL, T_CLOSE_SQUARE_BRACKET, T_DOUBLE_ARROW ) ), ( $stackPtr + 1 ), null, true );
+			$next_token = $phpcsFile->findNext( array_merge( Tokens::$emptyTokens, [ T_EQUAL, T_CLOSE_SQUARE_BRACKET, T_DOUBLE_ARROW ] ), ( $stackPtr + 1 ), null, true );
 
 			if ( T_TRUE === $tokens[ $next_token ]['code'] ) {
 				// WordPress.com: https://lobby.vip.wordpress.com/wordpress-com-documentation/uncached-functions/.

--- a/WordPressVIPMinimum/Sniffs/Variables/ServerVariablesSniff.php
+++ b/WordPressVIPMinimum/Sniffs/Variables/ServerVariablesSniff.php
@@ -23,17 +23,17 @@ class ServerVariablesSniff implements Sniff {
 	 *
 	 * @var array
 	 */
-	public $restrictedVariables = array(
-		'authVariables'           => array(
+	public $restrictedVariables = [
+		'authVariables'           => [
 			'PHP_AUTH_USER' => true,
 			'PHP_AUTH_PW'   => true,
-		),
-		'userControlledVariables' => array(
+		],
+		'userControlledVariables' => [
 			'HTTP_X_IP_TRAIL'      => true,
 			'HTTP_X_FORWARDED_FOR' => true,
 			'REMOTE_ADDR'          => true,
-		),
-	);
+		],
+	];
 
 	/**
 	 * Returns an array of tokens this test wants to listen for.
@@ -41,9 +41,9 @@ class ServerVariablesSniff implements Sniff {
 	 * @return array
 	 */
 	public function register() {
-		return array(
+		return [
 			T_VARIABLE,
-		);
+		];
 	}
 
 	/**
@@ -63,8 +63,8 @@ class ServerVariablesSniff implements Sniff {
 			return;
 		}
 
-		$variableNamePtr = $phpcsFile->findNext( array( T_CONSTANT_ENCAPSED_STRING ), ( $stackPtr + 1 ), null, false, null, true );
-		$variableName    = str_replace( array( "'", '"' ), '', $tokens[ $variableNamePtr ]['content'] );
+		$variableNamePtr = $phpcsFile->findNext( [ T_CONSTANT_ENCAPSED_STRING ], ( $stackPtr + 1 ), null, false, null, true );
+		$variableName    = str_replace( [ "'", '"' ], '', $tokens[ $variableNamePtr ]['content'] );
 
 		if ( isset( $this->restrictedVariables['authVariables'][ $variableName ] ) ) {
 			$phpcsFile->addError( 'Basic authentication should not be handled via PHP code.', $stackPtr, 'BasicAuthentication' );

--- a/WordPressVIPMinimum/Tests/Actions/PreGetPostsUnitTest.php
+++ b/WordPressVIPMinimum/Tests/Actions/PreGetPostsUnitTest.php
@@ -22,7 +22,7 @@ class PreGetPostsUnitTest extends AbstractSniffUnitTest {
 	 * @return array <int line number> => <int number of errors>
 	 */
 	public function getErrorList() {
-		return array();
+		return [];
 	}
 
 	/**
@@ -31,7 +31,7 @@ class PreGetPostsUnitTest extends AbstractSniffUnitTest {
 	 * @return array <int line number> => <int number of warnings>
 	 */
 	public function getWarningList() {
-		return array(
+		return [
 			8  => 1,
 			11 => 1,
 			29 => 1,
@@ -39,7 +39,7 @@ class PreGetPostsUnitTest extends AbstractSniffUnitTest {
 			52 => 1,
 			57 => 1,
 			87 => 1,
-		);
+		];
 	}
 
 }

--- a/WordPressVIPMinimum/Tests/Cache/BatcacheWhitelistedParamsUnitTest.php
+++ b/WordPressVIPMinimum/Tests/Cache/BatcacheWhitelistedParamsUnitTest.php
@@ -22,7 +22,7 @@ class BatcacheWhitelistedParamsUnitTest extends AbstractSniffUnitTest {
 	 * @return array <int line number> => <int number of errors>
 	 */
 	public function getErrorList() {
-		return array();
+		return [];
 	}
 
 	/**
@@ -31,10 +31,10 @@ class BatcacheWhitelistedParamsUnitTest extends AbstractSniffUnitTest {
 	 * @return array <int line number> => <int number of warnings>
 	 */
 	public function getWarningList() {
-		return array(
+		return [
 			3 => 2,
 			7 => 1,
-		);
+		];
 	}
 
 }

--- a/WordPressVIPMinimum/Tests/Cache/CacheValueOverrideUnitTest.php
+++ b/WordPressVIPMinimum/Tests/Cache/CacheValueOverrideUnitTest.php
@@ -22,9 +22,9 @@ class CacheValueOverrideUnitTest extends AbstractSniffUnitTest {
 	 * @return array <int line number> => <int number of errors>
 	 */
 	public function getErrorList() {
-		return array(
+		return [
 			5 => 1,
-		);
+		];
 	}
 
 	/**
@@ -33,7 +33,7 @@ class CacheValueOverrideUnitTest extends AbstractSniffUnitTest {
 	 * @return array <int line number> => <int number of warnings>
 	 */
 	public function getWarningList() {
-		return array();
+		return [];
 	}
 
 }

--- a/WordPressVIPMinimum/Tests/Classes/DeclarationCompatibilityUnitTest.php
+++ b/WordPressVIPMinimum/Tests/Classes/DeclarationCompatibilityUnitTest.php
@@ -22,7 +22,7 @@ class DeclarationCompatibilityUnitTest extends AbstractSniffUnitTest {
 	 * @return array <int line number> => <int number of errors>
 	 */
 	public function getErrorList() {
-		return array(
+		return [
 			4   => 1,
 			7   => 1,
 			10  => 1,
@@ -46,7 +46,7 @@ class DeclarationCompatibilityUnitTest extends AbstractSniffUnitTest {
 			112 => 1,
 			119 => 1,
 			128 => 1,
-		);
+		];
 	}
 
 	/**
@@ -55,7 +55,7 @@ class DeclarationCompatibilityUnitTest extends AbstractSniffUnitTest {
 	 * @return array <int line number> => <int number of warnings>
 	 */
 	public function getWarningList() {
-		return array();
+		return [];
 	}
 
 }

--- a/WordPressVIPMinimum/Tests/Constants/ConstantRestrictionsUnitTest.php
+++ b/WordPressVIPMinimum/Tests/Constants/ConstantRestrictionsUnitTest.php
@@ -22,11 +22,11 @@ class ConstantRestrictionsUnitTest extends AbstractSniffUnitTest {
 	 * @return array <int line number> => <int number of errors>
 	 */
 	public function getErrorList() {
-		return array(
+		return [
 			11 => 1,
 			13 => 1,
 			15 => 1,
-		);
+		];
 	}
 
 	/**
@@ -35,10 +35,10 @@ class ConstantRestrictionsUnitTest extends AbstractSniffUnitTest {
 	 * @return array <int line number> => <int number of warnings>
 	 */
 	public function getWarningList() {
-		return array(
+		return [
 			3 => 1,
 			7 => 2,
-		);
+		];
 	}
 
 }

--- a/WordPressVIPMinimum/Tests/Constants/ConstantStringUnitTest.php
+++ b/WordPressVIPMinimum/Tests/Constants/ConstantStringUnitTest.php
@@ -22,10 +22,10 @@ class ConstantStringUnitTest extends AbstractSniffUnitTest {
 	 * @return array <int line number> => <int number of errors>
 	 */
 	public function getErrorList() {
-		return array(
+		return [
 			7 => 1,
 			8 => 1,
-		);
+		];
 	}
 
 	/**
@@ -34,7 +34,7 @@ class ConstantStringUnitTest extends AbstractSniffUnitTest {
 	 * @return array <int line number> => <int number of warnings>
 	 */
 	public function getWarningList() {
-		return array();
+		return [];
 	}
 
 }

--- a/WordPressVIPMinimum/Tests/Files/IncludingNonPHPFileUnitTest.php
+++ b/WordPressVIPMinimum/Tests/Files/IncludingNonPHPFileUnitTest.php
@@ -21,7 +21,7 @@ class IncludingNonPHPFileUnitTest extends AbstractSniffUnitTest {
 	 * @return array <int line number> => <int number of errors>
 	 */
 	public function getErrorList() {
-		return array(
+		return [
 			15 => 1,
 			17 => 1,
 			19 => 1,
@@ -39,7 +39,7 @@ class IncludingNonPHPFileUnitTest extends AbstractSniffUnitTest {
 			45 => 1,
 			47 => 1,
 			49 => 1,
-		);
+		];
 	}
 
 	/**
@@ -48,7 +48,7 @@ class IncludingNonPHPFileUnitTest extends AbstractSniffUnitTest {
 	 * @return array <int line number> => <int number of warnings>
 	 */
 	public function getWarningList() {
-		return array();
+		return [];
 	}
 
 }

--- a/WordPressVIPMinimum/Tests/Filters/RestrictedHookUnitTest.php
+++ b/WordPressVIPMinimum/Tests/Filters/RestrictedHookUnitTest.php
@@ -23,7 +23,7 @@ class RestrictedHookUnitTest extends AbstractSniffUnitTest {
 	 * @return array <int line number> => <int number of errors>
 	 */
 	public function getErrorList() {
-		return array();
+		return [];
 	}
 
 	/**
@@ -32,7 +32,7 @@ class RestrictedHookUnitTest extends AbstractSniffUnitTest {
 	 * @return array <int line number> => <int number of warnings>
 	 */
 	public function getWarningList() {
-		return array(
+		return [
 			7  => 1,
 			8  => 1,
 			9  => 1,
@@ -46,7 +46,7 @@ class RestrictedHookUnitTest extends AbstractSniffUnitTest {
 			19 => 1,
 			20 => 1,
 			21 => 1,
-		);
+		];
 	}
 
 }

--- a/WordPressVIPMinimum/Tests/Functions/CheckReturnValueUnitTest.php
+++ b/WordPressVIPMinimum/Tests/Functions/CheckReturnValueUnitTest.php
@@ -22,13 +22,13 @@ class CheckReturnValueUnitTest extends AbstractSniffUnitTest {
 	 * @return array <int line number> => <int number of errors>
 	 */
 	public function getErrorList() {
-		return array(
+		return [
 			5  => 1,
 			9  => 1,
 			16 => 1,
 			19 => 1,
 			23 => 1,
-		);
+		];
 	}
 
 	/**
@@ -37,7 +37,7 @@ class CheckReturnValueUnitTest extends AbstractSniffUnitTest {
 	 * @return array <int line number> => <int number of warnings>
 	 */
 	public function getWarningList() {
-		return array();
+		return [];
 	}
 
 }

--- a/WordPressVIPMinimum/Tests/Functions/CreateFunctionSniff.php
+++ b/WordPressVIPMinimum/Tests/Functions/CreateFunctionSniff.php
@@ -22,9 +22,9 @@ class CreateFunctionUnitTest extends AbstractSniffUnitTest {
 	 * @return array <int line number> => <int number of errors>
 	 */
 	public function getErrorList() {
-		return array(
+		return [
 			9 => 1,
-		);
+		];
 	}
 
 	/**
@@ -33,7 +33,7 @@ class CreateFunctionUnitTest extends AbstractSniffUnitTest {
 	 * @return array <int line number> => <int number of warnings>
 	 */
 	public function getWarningList() {
-		return array();
+		return [];
 	}
 
 }

--- a/WordPressVIPMinimum/Tests/Functions/DynamicCallsUnitTest.php
+++ b/WordPressVIPMinimum/Tests/Functions/DynamicCallsUnitTest.php
@@ -22,9 +22,9 @@ class DynamicCallsUnitTest extends AbstractSniffUnitTest {
 	 * @return array <int line number> => <int number of errors>
 	 */
 	public function getErrorList() {
-		return array(
+		return [
 			9 => 1,
-		);
+		];
 	}
 
 	/**
@@ -33,7 +33,7 @@ class DynamicCallsUnitTest extends AbstractSniffUnitTest {
 	 * @return array <int line number> => <int number of warnings>
 	 */
 	public function getWarningList() {
-		return array();
+		return [];
 	}
 
 }

--- a/WordPressVIPMinimum/Tests/JS/HTMLExecutingFunctionsUnitTest.php
+++ b/WordPressVIPMinimum/Tests/JS/HTMLExecutingFunctionsUnitTest.php
@@ -22,7 +22,7 @@ class HTMLExecutingFunctionsUnitTest extends AbstractSniffUnitTest {
 	 * @return array <int line number> => <int number of errors>
 	 */
 	public function getErrorList() {
-		return array();
+		return [];
 	}
 
 	/**
@@ -31,14 +31,14 @@ class HTMLExecutingFunctionsUnitTest extends AbstractSniffUnitTest {
 	 * @return array <int line number> => <int number of warnings>
 	 */
 	public function getWarningList() {
-		return array(
+		return [
 			5  => 1,
 			6  => 1,
 			7  => 1,
 			9  => 1,
 			11 => 1,
 			12 => 1,
-		);
+		];
 	}
 
 }

--- a/WordPressVIPMinimum/Tests/JS/InnerHTMLUnitTest.php
+++ b/WordPressVIPMinimum/Tests/JS/InnerHTMLUnitTest.php
@@ -22,7 +22,7 @@ class InnerHTMLUnitTest extends AbstractSniffUnitTest {
 	 * @return array <int line number> => <int number of errors>
 	 */
 	public function getErrorList() {
-		return array();
+		return [];
 	}
 
 	/**
@@ -31,9 +31,9 @@ class InnerHTMLUnitTest extends AbstractSniffUnitTest {
 	 * @return array <int line number> => <int number of warnings>
 	 */
 	public function getWarningList() {
-		return array(
+		return [
 			5 => 1,
-		);
+		];
 	}
 
 }

--- a/WordPressVIPMinimum/Tests/JS/StringConcatUnitTest.php
+++ b/WordPressVIPMinimum/Tests/JS/StringConcatUnitTest.php
@@ -22,9 +22,9 @@ class StringConcatUnitTest extends AbstractSniffUnitTest {
 	 * @return array <int line number> => <int number of errors>
 	 */
 	public function getErrorList() {
-		return array(
+		return [
 			4 => 2,
-		);
+		];
 	}
 
 	/**
@@ -33,7 +33,7 @@ class StringConcatUnitTest extends AbstractSniffUnitTest {
 	 * @return array <int line number> => <int number of warnings>
 	 */
 	public function getWarningList() {
-		return array();
+		return [];
 	}
 
 }

--- a/WordPressVIPMinimum/Tests/JS/StrippingTagsUnitTest.php
+++ b/WordPressVIPMinimum/Tests/JS/StrippingTagsUnitTest.php
@@ -22,9 +22,9 @@ class StrippingTagsUnitTest extends AbstractSniffUnitTest {
 	 * @return array <int line number> => <int number of errors>
 	 */
 	public function getErrorList() {
-		return array(
+		return [
 			2 => 1,
-		);
+		];
 	}
 
 	/**
@@ -33,7 +33,7 @@ class StrippingTagsUnitTest extends AbstractSniffUnitTest {
 	 * @return array <int line number> => <int number of warnings>
 	 */
 	public function getWarningList() {
-		return array();
+		return [];
 	}
 
 }

--- a/WordPressVIPMinimum/Tests/Plugins/ZoninatorUnitTest.php
+++ b/WordPressVIPMinimum/Tests/Plugins/ZoninatorUnitTest.php
@@ -22,7 +22,7 @@ class ZoninatorUnitTest extends AbstractSniffUnitTest {
 	 * @return array <int line number> => <int number of errors>
 	 */
 	public function getErrorList() {
-		return array();
+		return [];
 	}
 
 	/**
@@ -31,12 +31,12 @@ class ZoninatorUnitTest extends AbstractSniffUnitTest {
 	 * @return array <int line number> => <int number of warnings>
 	 */
 	public function getWarningList() {
-		return array(
+		return [
 			3 => 1,
 			4 => 1,
 			5 => 1,
 			6 => 1,
-		);
+		];
 	}
 
 }

--- a/WordPressVIPMinimum/Tests/TemplatingEngines/UnescapedOutputMustacheUnitTest.php
+++ b/WordPressVIPMinimum/Tests/TemplatingEngines/UnescapedOutputMustacheUnitTest.php
@@ -22,7 +22,7 @@ class UnescapedOutputMustacheUnitTest extends AbstractSniffUnitTest {
 	 * @return array <int line number> => <int number of errors>
 	 */
 	public function getErrorList() {
-		return array();
+		return [];
 	}
 
 	/**
@@ -31,14 +31,14 @@ class UnescapedOutputMustacheUnitTest extends AbstractSniffUnitTest {
 	 * @return array <int line number> => <int number of warnings>
 	 */
 	public function getWarningList() {
-		return array(
+		return [
 			2  => 1,
 			3  => 1,
 			6  => 1,
 			7  => 1,
 			8  => 1,
 			18 => 1,
-		);
+		];
 	}
 
 }

--- a/WordPressVIPMinimum/Tests/TemplatingEngines/UnescapedOutputTwigUnitTest.php
+++ b/WordPressVIPMinimum/Tests/TemplatingEngines/UnescapedOutputTwigUnitTest.php
@@ -22,7 +22,7 @@ class UnescapedOutputTwigUnitTest extends AbstractSniffUnitTest {
 	 * @return array <int line number> => <int number of errors>
 	 */
 	public function getErrorList() {
-		return array();
+		return [];
 	}
 
 	/**
@@ -31,10 +31,10 @@ class UnescapedOutputTwigUnitTest extends AbstractSniffUnitTest {
 	 * @return array <int line number> => <int number of warnings>
 	 */
 	public function getWarningList() {
-		return array(
+		return [
 			5  => 1,
 			10 => 1,
-		);
+		];
 	}
 
 }

--- a/WordPressVIPMinimum/Tests/TemplatingEngines/UnescapedOutputUnderscorejsUnitTest.php
+++ b/WordPressVIPMinimum/Tests/TemplatingEngines/UnescapedOutputUnderscorejsUnitTest.php
@@ -22,7 +22,7 @@ class UnescapedOutputUnderscorejsUnitTest extends AbstractSniffUnitTest {
 	 * @return array <int line number> => <int number of errors>
 	 */
 	public function getErrorList() {
-		return array();
+		return [];
 	}
 
 	/**
@@ -31,10 +31,10 @@ class UnescapedOutputUnderscorejsUnitTest extends AbstractSniffUnitTest {
 	 * @return array <int line number> => <int number of warnings>
 	 */
 	public function getWarningList() {
-		return array(
+		return [
 			6  => 1,
 			14 => 1,
-		);
+		];
 	}
 
 }

--- a/WordPressVIPMinimum/Tests/TemplatingEngines/UnescapedOutputVuejsUnitTest.php
+++ b/WordPressVIPMinimum/Tests/TemplatingEngines/UnescapedOutputVuejsUnitTest.php
@@ -22,7 +22,7 @@ class UnescapedOutputVuejsUnitTest extends AbstractSniffUnitTest {
 	 * @return array <int line number> => <int number of errors>
 	 */
 	public function getErrorList() {
-		return array();
+		return [];
 	}
 
 	/**
@@ -31,9 +31,9 @@ class UnescapedOutputVuejsUnitTest extends AbstractSniffUnitTest {
 	 * @return array <int line number> => <int number of warnings>
 	 */
 	public function getWarningList() {
-		return array(
+		return [
 			5 => 1,
-		);
+		];
 	}
 
 }

--- a/WordPressVIPMinimum/Tests/VIP/ErrorControlUnitTest.php
+++ b/WordPressVIPMinimum/Tests/VIP/ErrorControlUnitTest.php
@@ -22,9 +22,9 @@ class ErrorControlUnitTest extends AbstractSniffUnitTest {
 	 * @return array <int line number> => <int number of errors>
 	 */
 	public function getErrorList() {
-		return array(
+		return [
 			3 => 1,
-		);
+		];
 	}
 
 	/**
@@ -33,7 +33,7 @@ class ErrorControlUnitTest extends AbstractSniffUnitTest {
 	 * @return array <int line number> => <int number of warnings>
 	 */
 	public function getWarningList() {
-		return array();
+		return [];
 	}
 
 }

--- a/WordPressVIPMinimum/Tests/VIP/EscapingVoidReturnFunctionsUnitTest.php
+++ b/WordPressVIPMinimum/Tests/VIP/EscapingVoidReturnFunctionsUnitTest.php
@@ -22,9 +22,9 @@ class EscapingVoidReturnFunctionsUnitTest extends AbstractSniffUnitTest {
 	 * @return array <int line number> => <int number of errors>
 	 */
 	public function getErrorList() {
-		return array(
+		return [
 			3 => 1,
-		);
+		];
 	}
 
 	/**
@@ -33,7 +33,7 @@ class EscapingVoidReturnFunctionsUnitTest extends AbstractSniffUnitTest {
 	 * @return array <int line number> => <int number of warnings>
 	 */
 	public function getWarningList() {
-		return array();
+		return [];
 	}
 
 }

--- a/WordPressVIPMinimum/Tests/VIP/ExitAfterRedirectUnitTest.php
+++ b/WordPressVIPMinimum/Tests/VIP/ExitAfterRedirectUnitTest.php
@@ -22,10 +22,10 @@ class ExitAfterRedirectUnitTest extends AbstractSniffUnitTest {
 	 * @return array <int line number> => <int number of errors>
 	 */
 	public function getErrorList() {
-		return array(
+		return [
 			7 => 1,
 			9 => 1,
-		);
+		];
 	}
 
 	/**
@@ -34,7 +34,7 @@ class ExitAfterRedirectUnitTest extends AbstractSniffUnitTest {
 	 * @return array <int line number> => <int number of warnings>
 	 */
 	public function getWarningList() {
-		return array();
+		return [];
 	}
 
 }

--- a/WordPressVIPMinimum/Tests/VIP/FetchingRemoteDataUnitTest.php
+++ b/WordPressVIPMinimum/Tests/VIP/FetchingRemoteDataUnitTest.php
@@ -22,7 +22,7 @@ class FetchingRemoteDataUnitTest extends AbstractSniffUnitTest {
 	 * @return array <int line number> => <int number of errors>
 	 */
 	public function getErrorList() {
-		return array();
+		return [];
 	}
 
 	/**
@@ -31,9 +31,9 @@ class FetchingRemoteDataUnitTest extends AbstractSniffUnitTest {
 	 * @return array <int line number> => <int number of warnings>
 	 */
 	public function getWarningList() {
-		return array(
+		return [
 			7 => 1,
-		);
+		];
 	}
 
 }

--- a/WordPressVIPMinimum/Tests/VIP/FlushRewriteRulesUnitTest.php
+++ b/WordPressVIPMinimum/Tests/VIP/FlushRewriteRulesUnitTest.php
@@ -22,10 +22,10 @@ class FlushRewriteRulesUnitTest extends AbstractSniffUnitTest {
 	 * @return array <int line number> => <int number of errors>
 	 */
 	public function getErrorList() {
-		return array(
+		return [
 			4 => 1,
 			6 => 1,
-		);
+		];
 	}
 
 	/**
@@ -34,7 +34,7 @@ class FlushRewriteRulesUnitTest extends AbstractSniffUnitTest {
 	 * @return array <int line number> => <int number of warnings>
 	 */
 	public function getWarningList() {
-		return array();
+		return [];
 	}
 
 }

--- a/WordPressVIPMinimum/Tests/VIP/MergeConflictUnitTest.php
+++ b/WordPressVIPMinimum/Tests/VIP/MergeConflictUnitTest.php
@@ -22,11 +22,11 @@ class MergeConflictUnitTest extends AbstractSniffUnitTest {
 	 * @return array <int line number> => <int number of errors>
 	 */
 	public function getErrorList() {
-		return array(
+		return [
 			4  => 1,
 			8  => 1,
 			12 => 1,
-		);
+		];
 	}
 
 	/**
@@ -35,7 +35,7 @@ class MergeConflictUnitTest extends AbstractSniffUnitTest {
 	 * @return array <int line number> => <int number of warnings>
 	 */
 	public function getWarningList() {
-		return array();
+		return [];
 	}
 
 }

--- a/WordPressVIPMinimum/Tests/VIP/PHPFilterFunctionsUnitTest.php
+++ b/WordPressVIPMinimum/Tests/VIP/PHPFilterFunctionsUnitTest.php
@@ -31,7 +31,7 @@ class PHPFilterFunctionsUnitTest extends AbstractSniffUnitTest {
 	 * @return array <int line number> => <int number of warnings>
 	 */
 	public function getWarningList() {
-		return array(
+		return [
 			18 => 1,
 			19 => 1,
 			20 => 1,
@@ -44,7 +44,7 @@ class PHPFilterFunctionsUnitTest extends AbstractSniffUnitTest {
 			27 => 1,
 			28 => 1,
 			29 => 1,
-		);
+		];
 	}
 
 }

--- a/WordPressVIPMinimum/Tests/VIP/ProperEscapingFunctionUnitTest.php
+++ b/WordPressVIPMinimum/Tests/VIP/ProperEscapingFunctionUnitTest.php
@@ -22,7 +22,7 @@ class ProperEscapingFunctionUnitTest extends AbstractSniffUnitTest {
 	 * @return array <int line number> => <int number of errors>
 	 */
 	public function getErrorList() {
-		return array(
+		return [
 			3  => 1,
 			5  => 1,
 			15 => 1,
@@ -31,7 +31,7 @@ class ProperEscapingFunctionUnitTest extends AbstractSniffUnitTest {
 			23 => 1,
 			33 => 1,
 			37 => 1,
-		);
+		];
 	}
 
 	/**
@@ -40,7 +40,7 @@ class ProperEscapingFunctionUnitTest extends AbstractSniffUnitTest {
 	 * @return array <int line number> => <int number of warnings>
 	 */
 	public function getWarningList() {
-		return array();
+		return [];
 	}
 
 }

--- a/WordPressVIPMinimum/Tests/VIP/RegexpCompareUnitTest.php
+++ b/WordPressVIPMinimum/Tests/VIP/RegexpCompareUnitTest.php
@@ -22,12 +22,12 @@ class RegexpCompareUnitTest extends AbstractSniffUnitTest {
 	 * @return array <int line number> => <int number of errors>
 	 */
 	public function getErrorList() {
-		return array(
+		return [
 			10 => 1,
 			15 => 1,
 			30 => 1,
 			34 => 1,
-		);
+		];
 	}
 
 	/**
@@ -36,7 +36,7 @@ class RegexpCompareUnitTest extends AbstractSniffUnitTest {
 	 * @return array <int line number> => <int number of warnings>
 	 */
 	public function getWarningList() {
-		return array();
+		return [];
 	}
 
 }

--- a/WordPressVIPMinimum/Tests/VIP/RemoteRequestTimeoutUnitTest.php
+++ b/WordPressVIPMinimum/Tests/VIP/RemoteRequestTimeoutUnitTest.php
@@ -22,9 +22,9 @@ class RemoteRequestTimeoutUnitTest extends AbstractSniffUnitTest {
 	 * @return array <int line number> => <int number of errors>
 	 */
 	public function getErrorList() {
-		return array(
+		return [
 			5 => 1,
-		);
+		];
 	}
 
 	/**
@@ -33,7 +33,7 @@ class RemoteRequestTimeoutUnitTest extends AbstractSniffUnitTest {
 	 * @return array <int line number> => <int number of warnings>
 	 */
 	public function getWarningList() {
-		return array();
+		return [];
 	}
 
 }

--- a/WordPressVIPMinimum/Tests/VIP/RobotstxtSniff.php
+++ b/WordPressVIPMinimum/Tests/VIP/RobotstxtSniff.php
@@ -22,7 +22,7 @@ class RobotstxtSniffUnitTest extends AbstractSniffUnitTest {
 	 * @return array <int line number> => <int number of errors>
 	 */
 	public function getErrorList() {
-		return array();
+		return [];
 	}
 
 	/**
@@ -31,9 +31,9 @@ class RobotstxtSniffUnitTest extends AbstractSniffUnitTest {
 	 * @return array <int line number> => <int number of warnings>
 	 */
 	public function getWarningList() {
-		return array(
+		return [
 			9 => 1,
 			7 => 1,
-		);
+		];
 	}
 }

--- a/WordPressVIPMinimum/Tests/VIP/StaticStrreplaceUnitTest.php
+++ b/WordPressVIPMinimum/Tests/VIP/StaticStrreplaceUnitTest.php
@@ -22,10 +22,10 @@ class StaticStrreplaceUnitTest extends AbstractSniffUnitTest {
 	 * @return array <int line number> => <int number of errors>
 	 */
 	public function getErrorList() {
-		return array(
+		return [
 			3 => 1,
 			7 => 1,
-		);
+		];
 	}
 
 	/**
@@ -34,7 +34,7 @@ class StaticStrreplaceUnitTest extends AbstractSniffUnitTest {
 	 * @return array <int line number> => <int number of warnings>
 	 */
 	public function getWarningList() {
-		return array();
+		return [];
 	}
 
 }

--- a/WordPressVIPMinimum/Tests/VIP/TaxonomyMetaInOptionsUnitTest.php
+++ b/WordPressVIPMinimum/Tests/VIP/TaxonomyMetaInOptionsUnitTest.php
@@ -22,7 +22,7 @@ class TaxonomyMetaInOptionsUnitTest extends AbstractSniffUnitTest {
 	 * @return array <int line number> => <int number of errors>
 	 */
 	public function getErrorList() {
-		return array();
+		return [];
 	}
 
 	/**
@@ -31,14 +31,14 @@ class TaxonomyMetaInOptionsUnitTest extends AbstractSniffUnitTest {
 	 * @return array <int line number> => <int number of warnings>
 	 */
 	public function getWarningList() {
-		return array(
+		return [
 			3 => 1,
 			4 => 1,
 			5 => 1,
 			6 => 1,
 			7 => 1,
 			8 => 1,
-		);
+		];
 	}
 
 }

--- a/WordPressVIPMinimum/Tests/VIP/WPQueryParamsUnitTest.php
+++ b/WordPressVIPMinimum/Tests/VIP/WPQueryParamsUnitTest.php
@@ -22,10 +22,10 @@ class WPQueryParamsUnitTest extends AbstractSniffUnitTest {
 	 * @return array <int line number> => <int number of errors>
 	 */
 	public function getErrorList() {
-		return array(
+		return [
 			5  => 1,
 			17 => 1,
-		);
+		];
 	}
 
 	/**
@@ -34,10 +34,10 @@ class WPQueryParamsUnitTest extends AbstractSniffUnitTest {
 	 * @return array <int line number> => <int number of warnings>
 	 */
 	public function getWarningList() {
-		return array(
+		return [
 			4  => 1,
 			11 => 1,
-		);
+		];
 	}
 
 }

--- a/WordPressVIPMinimum/Tests/Variables/ServerVariablesUnitTest.php
+++ b/WordPressVIPMinimum/Tests/Variables/ServerVariablesUnitTest.php
@@ -22,12 +22,12 @@ class ServerVariablesUnitTest extends AbstractSniffUnitTest {
 	 * @return array <int line number> => <int number of errors>
 	 */
 	public function getErrorList() {
-		return array(
+		return [
 			4 => 1,
 			5 => 1,
 			6 => 1,
 			7 => 1,
-		);
+		];
 	}
 
 	/**
@@ -36,7 +36,7 @@ class ServerVariablesUnitTest extends AbstractSniffUnitTest {
 	 * @return array <int line number> => <int number of warnings>
 	 */
 	public function getWarningList() {
-		return array();
+		return [];
 	}
 
 }

--- a/WordPressVIPMinimum/Tests/Variables/VariableAnalysisUnitTest.php
+++ b/WordPressVIPMinimum/Tests/Variables/VariableAnalysisUnitTest.php
@@ -22,7 +22,7 @@ class VariableAnalysisUnitTest extends AbstractSniffUnitTest {
 	 * @return array <int line number> => <int number of errors>
 	 */
 	public function getErrorList() {
-		return array();
+		return [];
 	}
 
 	/**

--- a/ruleset_test.php
+++ b/ruleset_test.php
@@ -18,8 +18,8 @@
 namespace WordPressVIPMinimum;
 
 // Expected values.
-$expected = array(
-	'errors'   => array(
+$expected = [
+	'errors'   => [
 		4   => 1,
 		9   => 1,
 		16  => 1,
@@ -51,8 +51,8 @@ $expected = array(
 		170 => 1,
 		174 => 1,
 		178 => 1,
-	),
-	'warnings' => array(
+	],
+	'warnings' => [
 		9   => 1,
 		19  => 1,
 		23  => 1,
@@ -77,13 +77,13 @@ $expected = array(
 		164 => 1,
 		168 => 1,
 		172 => 1,
-	),
-	'messages' => array(
-		129 => array(
+	],
+	'messages' => [
+		129 => [
 			'`get_children()` performs a no-LIMIT query by default, make sure to set a reasonable `posts_per_page`. `get_children()` will do a -1 query by default, a maximum of 100 should be used.',
-		),
-	),
-);
+		],
+	],
+];
 
 /**
  * Class PHPCS_Ruleset_Test
@@ -95,21 +95,21 @@ class PHPCS_Ruleset_Test {
 	 *
 	 * @var array
 	 */
-	private $errors = array();
+	private $errors = [];
 
 	/**
 	 * Numbers of Warnings for each line.
 	 *
 	 * @var array
 	 */
-	private $warnings = array();
+	private $warnings = [];
 
 	/**
 	 * Messages reported by PHPCS.
 	 *
 	 * @var array
 	 */
-	private $messages = array();
+	private $messages = [];
 
 	/**
 	 * Number of found issues.
@@ -123,14 +123,14 @@ class PHPCS_Ruleset_Test {
 	 *
 	 * @var array
 	 */
-	public $expected = array();
+	public $expected = [];
 
 	/**
 	 * Init the object by processing the test file.
 	 *
 	 * @param array $expected The array of expected errors, warnings and messages.
 	 */
-	public function __construct( $expected = array() ) {
+	public function __construct( $expected = [] ) {
 		$this->expected = $expected;
 
 		// Travis support.
@@ -157,7 +157,7 @@ class PHPCS_Ruleset_Test {
 				} else {
 					$this->warnings[ $issue['line'] ] = ( isset( $this->warnings[ $issue['line'] ] ) ) ? $this->warnings[ $issue['line'] ]++ : 1;
 				}
-				$this->messages[ $issue['line'] ] = ( false === isset( $this->messages[ $issue['line'] ] ) || false === is_array( $this->messages[ $issue['line'] ] ) ) ? array( $issue['message'] ) : array_merge( $this->messages[ $issue['line'] ], array( $issue['message'] ) );
+				$this->messages[ $issue['line'] ] = ( false === isset( $this->messages[ $issue['line'] ] ) || false === is_array( $this->messages[ $issue['line'] ] ) ) ? [ $issue['message'] ] : array_merge( $this->messages[ $issue['line'] ], [ $issue['message'] ] );
 			}
 		}
 	}
@@ -203,7 +203,7 @@ class PHPCS_Ruleset_Test {
 	 * Check whether there are no unexpected numbers of errors and warnings.
 	 */
 	private function check_unexpected_values() {
-		foreach ( array( 'errors', 'warnings' ) as $type ) {
+		foreach ( [ 'errors', 'warnings' ] as $type ) {
 			foreach ( $this->$type as $line => $number ) {
 				if ( false === isset( $expected[ $type ][ $line ] ) ) {
 					$this->error_warning_message( 0, $type, $number, $line );


### PR DESCRIPTION
Since VIPCS requires PHP 5.6+, we can shift over to using the short array syntax `[]` instead of `array()`.

Fixed with `phpcbf`. Lint and tests all still pass.

Fixes #319