### PR TITLE
Improve addError() and addWarning() calls

### DIFF
--- a/WordPressVIPMinimum/Sniffs/Actions/PreGetPostsSniff.php
+++ b/WordPressVIPMinimum/Sniffs/Actions/PreGetPostsSniff.php
@@ -243,10 +243,10 @@ class PreGetPostsSniff implements Sniff {
 				}
 			} elseif ( $this->isInsideIfConditonal( $wpQueryVarUsed ) ) {
 				if ( ! $this->isParentConditionalCheckingMainQuery( $wpQueryVarUsed ) ) {
-					$this->_phpcsFile->addWarning( 'Main WP_Query is being modified without `$query->is_main_query()` check. Needs manual inspection.', $wpQueryVarUsed, 'PreGetPosts' );
+					$this->addPreGetPostsWarning( $wpQueryVarUsed );
 				}
 			} elseif ( $this->isWPQueryMethodCall( $wpQueryVarUsed, 'set' ) ) {
-				$this->_phpcsFile->addWarning( 'Main WP_Query is being modified without `$query->is_main_query()` check. Needs manual inspection.', $wpQueryVarUsed, 'PreGetPosts' );
+				$this->addPreGetPostsWarning( $wpQueryVarUsed );
 			}
 			$wpQueryVarUsed = $this->_phpcsFile->findNext(
 				[ T_VARIABLE ], // types.
@@ -257,6 +257,16 @@ class PreGetPostsSniff implements Sniff {
 				false // local.
 			);
 		}
+	}
+
+	/**
+	 * Consolidated violation.
+	 *
+	 * @param int $stackPtr The position in the stack where the token was found.
+	 */
+	private function addPreGetPostsWarning( $stackPtr ) {
+		$message = 'Main WP_Query is being modified without `$query->is_main_query()` check. Needs manual inspection.';
+		$this->_phpcsFile->addWarning( $message, $stackPtr, 'PreGetPosts' );
 	}
 
 	/**

--- a/WordPressVIPMinimum/Sniffs/Cache/BatcacheWhitelistedParamsSniff.php
+++ b/WordPressVIPMinimum/Sniffs/Cache/BatcacheWhitelistedParamsSniff.php
@@ -107,7 +107,10 @@ class BatcacheWhitelistedParamsSniff implements Sniff {
 		$variable_name = substr( $variable_name, 1, -1 );
 
 		if ( true === in_array( $variable_name, $this->whitelistes_batcache_params, true ) ) {
-			$phpcsFile->addWarning( sprintf( 'Batcache whitelisted GET param, `%s`, found. Batcache whitelisted parameters get stripped and are not available in PHP.', $variable_name ), $stackPtr, 'StrippedGetParam' );
+			$message = 'Batcache whitelisted GET param, `%s`, found. Batcache whitelisted parameters get stripped and are not available in PHP.';
+			$data    = [ $variable_name ];
+			$phpcsFile->addWarning( $message, $stackPtr, 'StrippedGetParam', $data );
+
 			return;
 		}
 	}

--- a/WordPressVIPMinimum/Sniffs/Cache/CacheValueOverrideSniff.php
+++ b/WordPressVIPMinimum/Sniffs/Cache/CacheValueOverrideSniff.php
@@ -96,7 +96,9 @@ class CacheValueOverrideSniff implements Sniff {
 		$valueAfterEqualSign = $phpcsFile->findNext( Tokens::$emptyTokens, ( $rightAfterNextVariableOccurence + 1 ), null, true, null, true );
 
 		if ( T_FALSE === $tokens[ $valueAfterEqualSign ]['code'] ) {
-			$phpcsFile->addError( sprintf( 'Obtained cached value in `%s` is being overriden. Disabling caching?', $variableName ), $nextVariableOccurrence, 'CacheValueOverride' );
+			$message = 'Obtained cached value in `%s` is being overridden. Disabling caching?';
+			$data    = [ $variableName ];
+			$phpcsFile->addError( $message, $nextVariableOccurrence, 'CacheValueOverride', $data );
 		}
 	}
 

--- a/WordPressVIPMinimum/Sniffs/Cache/LowExpiryCacheTimeSniff.php
+++ b/WordPressVIPMinimum/Sniffs/Cache/LowExpiryCacheTimeSniff.php
@@ -81,11 +81,9 @@ class LowExpiryCacheTimeSniff extends AbstractFunctionParameterSniff {
 		}
 
 		if ( $time < 300 ) {
-			$this->phpcsFile->addWarning(
-				sprintf( 'Low cache expiry time of "%s", it is recommended to have 300 seconds or more.', $parameters[4]['raw'] ),
-				$stackPtr,
-				'LowCacheTime'
-			);
+			$message = 'Low cache expiry time of "%s", it is recommended to have 300 seconds or more.';
+			$data    = [ $parameters[4]['raw'] ];
+			$this->phpcsFile->addWarning( $message, $stackPtr, 'LowCacheTime', $data );
 		}
 	}
 }

--- a/WordPressVIPMinimum/Sniffs/Classes/DeclarationCompatibilitySniff.php
+++ b/WordPressVIPMinimum/Sniffs/Classes/DeclarationCompatibilitySniff.php
@@ -299,7 +299,9 @@ class DeclarationCompatibilitySniff extends AbstractScopeSniff {
 
 		$parentSignature = sprintf( '%s::%s(%s)', $parentClassName, $methodName, implode( ', ', $this->generateParamList( $parentMethodSignature ) ) );
 
-		$phpcsFile->addError( sprintf( 'Declaration of `%s` should be compatible with `%s`', $currentSignature, $parentSignature ), $stackPtr, 'DeclarationCompatibility' );
+		$message = 'Declaration of `%s` should be compatible with `%s`.';
+		$data    = [ $currentSignature, $parentSignature ];
+		$phpcsFile->addError( $message, $stackPtr, 'DeclarationCompatibility', $data );
 	}
 
 	/**

--- a/WordPressVIPMinimum/Sniffs/Constants/ConstantRestrictionsSniff.php
+++ b/WordPressVIPMinimum/Sniffs/Constants/ConstantRestrictionsSniff.php
@@ -74,7 +74,9 @@ class ConstantRestrictionsSniff implements Sniff {
 		}
 
 		if ( T_STRING === $tokens[ $stackPtr ]['code'] && true === in_array( $constantName, $this->restrictedConstantNames, true ) ) {
-			$phpcsFile->addWarning( sprintf( 'Code is touching the `%s` constant. Make sure it\'s used appropriately.', $constantName ), $stackPtr, 'UsingRestrictedConstant' );
+			$message = 'Code is touching the `%s` constant. Make sure it\'s used appropriately.';
+			$data    = [ $constantName ];
+			$phpcsFile->addWarning( $message, $stackPtr, 'UsingRestrictedConstant', $data );
 			return;
 		}
 
@@ -101,10 +103,13 @@ class ConstantRestrictionsSniff implements Sniff {
 		}
 
 		if ( true === in_array( $tokens[ $previous ]['code'], Tokens::$functionNameTokens, true ) ) {
+			$data = [ $constantName ];
 			if ( 'define' === $tokens[ $previous ]['content'] ) {
-				$phpcsFile->addError( sprintf( 'The definition of `%s` constant is prohibited. Please use a different name.', $constantName ), $previous, 'DefiningRestrictedConstant' );
+				$message = 'The definition of `%s` constant is prohibited. Please use a different name.';
+				$phpcsFile->addError( $message, $previous, 'DefiningRestrictedConstant', $data );
 			} elseif ( true === in_array( $constantName, $this->restrictedConstantNames, true ) ) {
-				$phpcsFile->addWarning( sprintf( 'Code is touching the `%s` constant. Make sure it\'s used appropriately.', $constantName ), $previous, 'UsingRestrictedConstant' );
+				$message = 'Code is touching the `%s` constant. Make sure it\'s used appropriately.';
+				$phpcsFile->addWarning( $message, $previous, 'UsingRestrictedConstant', $data );
 			}
 		}
 	}

--- a/WordPressVIPMinimum/Sniffs/Constants/ConstantStringSniff.php
+++ b/WordPressVIPMinimum/Sniffs/Constants/ConstantStringSniff.php
@@ -62,7 +62,9 @@ class ConstantStringSniff implements Sniff {
 		$nextToken = $phpcsFile->findNext( Tokens::$emptyTokens, ( $nextToken + 1 ), null, true, null, true );
 
 		if ( T_CONSTANT_ENCAPSED_STRING !== $tokens[ $nextToken ]['code'] ) {
-			$phpcsFile->addError( sprintf( 'Constant name, as a string, should be used along with `%s()`.', $tokens[ $stackPtr ]['content'] ), $nextToken, 'NotCheckingConstantName' );
+			$message = 'Constant name, as a string, should be used along with `%s()`.';
+			$data    = [ $tokens[ $stackPtr ]['content'] ];
+			$phpcsFile->addError( $message, $nextToken, 'NotCheckingConstantName', $data );
 			return;
 		}
 	}

--- a/WordPressVIPMinimum/Sniffs/Files/IncludingFileSniff.php
+++ b/WordPressVIPMinimum/Sniffs/Files/IncludingFileSniff.php
@@ -106,7 +106,9 @@ class IncludingFileSniff extends AbstractFunctionRestrictionsSniff {
 		}
 
 		if ( T_VARIABLE === $tokens[ $nextToken ]['code'] ) {
-			$this->phpcsFile->addWarning( sprintf( 'File inclusion using variable (`%s`). Probably needs manual inspection.', $tokens[ $nextToken ]['content'] ), $nextToken, 'UsingVariable' );
+			$message = 'File inclusion using variable (`%s`). Probably needs manual inspection.';
+			$data    = [ $tokens[ $nextToken ]['content'] ];
+			$this->phpcsFile->addWarning( $message, $nextToken, 'UsingVariable', $data );
 			return;
 		}
 
@@ -123,19 +125,25 @@ class IncludingFileSniff extends AbstractFunctionRestrictionsSniff {
 
 			if ( true === in_array( $tokens[ $nextToken ]['content'], array_keys( $this->restrictedConstants ), true ) ) {
 				// The construct is using one of the restricted constants.
-				$this->phpcsFile->addError( sprintf( '`%s` constant might not be defined or available. Use `%s()` instead.', $tokens[ $nextToken ]['content'], $this->restrictedConstants[ $tokens[ $nextToken ]['content'] ] ), $nextToken, 'RestrictedConstant' );
+				$message = '`%s` constant might not be defined or available. Use `%s()` instead.';
+				$data    = [ $tokens[ $nextToken ]['content'], $this->restrictedConstants[ $tokens[ $nextToken ]['content'] ] ];
+				$this->phpcsFile->addError( $message, $nextToken, 'RestrictedConstant', $data );
 				return;
 			}
 
 			$nextNextToken = $this->phpcsFile->findNext( array_merge( Tokens::$emptyTokens, [ T_COMMENT ] ), ( $nextToken + 1 ), null, true, null, true );
 			if ( 1 === preg_match( '/^[a-zA-Z_\x7f-\xff][a-zA-Z0-9_\x7f-\xff]*$/', $tokens[ $nextToken ]['content'] ) && T_OPEN_PARENTHESIS !== $tokens[ $nextNextToken ]['code'] ) {
 				// The construct is using custom constant, which needs manual inspection.
-				$this->phpcsFile->addWarning( sprintf( 'File inclusion using custom constant (`%s`). Probably needs manual inspection.', $tokens[ $nextToken ]['content'] ), $nextToken, 'UsingCustomConstant' );
+				$message = 'File inclusion using custom constant (`%s`). Probably needs manual inspection.';
+				$data    = [ $tokens[ $nextToken ]['content'] ];
+				$this->phpcsFile->addWarning( $message, $nextToken, 'UsingCustomConstant', $data );
 				return;
 			}
 
 			if ( 0 === strpos( $tokens[ $nextToken ]['content'], '$' ) ) {
-				$this->phpcsFile->addWarning( sprintf( 'File inclusion using variable (`%s`). Probably needs manual inspection.', $tokens[ $nextToken ]['content'] ), $nextToken, 'UsingVariable' );
+				$message = 'File inclusion using variable (`%s`). Probably needs manual inspection.';
+				$data    = [ $tokens[ $nextToken ]['content'] ];
+				$this->phpcsFile->addWarning( $message, $nextToken, 'UsingVariable', $data );
 				return;
 			}
 
@@ -145,19 +153,24 @@ class IncludingFileSniff extends AbstractFunctionRestrictionsSniff {
 			}
 
 			if ( $this->is_targetted_token( $nextToken ) ) {
-				$this->phpcsFile->addWarning( sprintf( 'File inclusion using custom function ( `%s()` ). Must return local file source, as external URLs are prohibited on WordPress VIP. Probably needs manual inspection.', $tokens[ $nextToken ]['content'] ), $nextToken, 'UsingCustomFunction' );
+				$message = 'File inclusion using custom function ( `%s()` ). Must return local file source, as external URLs are prohibited on WordPress VIP. Probably needs manual inspection.';
+				$data    = [ $tokens[ $nextToken ]['content'] ];
+				$this->phpcsFile->addWarning( $message, $nextToken, 'UsingCustomFunction', $data );
 				return;
 			}
 
-			$this->phpcsFile->addError( 'Absolute include path must be used. Use `get_template_directory()`, `get_stylesheet_directory()` or `plugin_dir_path()`.', $nextToken, 'NotAbsolutePath' );
+			$message = 'Absolute include path must be used. Use `get_template_directory()`, `get_stylesheet_directory()` or `plugin_dir_path()`.';
+			$this->phpcsFile->addError( $message, $nextToken, 'NotAbsolutePath' );
 			return;
 		} else {
 			if ( T_CONSTANT_ENCAPSED_STRING === $tokens[ $nextToken ]['code'] && filter_var( str_replace( [ '"', "'" ], '', $tokens[ $nextToken ]['content'] ), FILTER_VALIDATE_URL ) ) {
-				$this->phpcsFile->addError( 'Include path must be local file source, external URLs are prohibited on WordPress VIP.', $nextToken, 'ExternalURL' );
+				$message = 'Include path must be local file source, external URLs are prohibited on WordPress VIP.';
+				$this->phpcsFile->addError( $message, $nextToken, 'ExternalURL' );
 				return;
 			}
 
-			$this->phpcsFile->addError( 'Absolute include path must be used. Use `get_template_directory()`, `get_stylesheet_directory()` or `plugin_dir_path()`.', $nextToken, 'NotAbsolutePath' );
+			$message = 'Absolute include path must be used. Use `get_template_directory()`, `get_stylesheet_directory()` or `plugin_dir_path()`.';
+			$this->phpcsFile->addError( $message, $nextToken, 'NotAbsolutePath' );
 			return;
 		}
 	}

--- a/WordPressVIPMinimum/Sniffs/Files/IncludingNonPHPFileSniff.php
+++ b/WordPressVIPMinimum/Sniffs/Files/IncludingNonPHPFileSniff.php
@@ -63,11 +63,17 @@ class IncludingNonPHPFileSniff implements Sniff {
 				return;
 			}
 
+			$message = 'Local non-PHP file should be loaded via `file_get_contents` rather than via `%s`.';
+			$data    = [ $tokens[ $stackPtr ]['content'] ];
+			$code    = 'IncludingNonPHPFile';
+
 			if ( true === in_array( $extension, [ '.svg', '.css' ], true ) ) {
-				$phpcsFile->addError( sprintf( 'Local SVG and CSS files should be loaded via `file_get_contents` rather than via `%s`.', $tokens[ $stackPtr ]['content'] ), $curStackPtr, 'IncludingSVGCSSFile' );
-			} else {
-				$phpcsFile->addError( sprintf( 'Local non-PHP file should be loaded via `file_get_contents` rather than via `%s`', $tokens[ $stackPtr ]['content'] ), $curStackPtr, 'IncludingNonPHPFile' );
+				// Be more specific for SVG and CSS files.
+				$message = 'Local SVG and CSS files should be loaded via `file_get_contents` rather than via `%s`.';
+				$code    = 'IncludingSVGCSSFile';
 			}
+
+			$phpcsFile->addError( $message, $curStackPtr, $code, $data );
 		}
 	}
 

--- a/WordPressVIPMinimum/Sniffs/Filters/AlwaysReturnSniff.php
+++ b/WordPressVIPMinimum/Sniffs/Filters/AlwaysReturnSniff.php
@@ -231,12 +231,9 @@ class AlwaysReturnSniff implements Sniff {
 				$outsideConditionalReturn++;
 			}
 			if ( $this->isReturningVoid( $returnTokenPtr ) ) {
-				$this->phpcsFile->addError(
-					'Please, make sure that a callback to `%s` filter is returning void intentionally.',
-					$functionBodyScopeStart,
-					'VoidReturn',
-					[ $filterName ]
-				);
+				$message = 'Please, make sure that a callback to `%s` filter is returning void intentionally.';
+				$data    = [ $filterName ];
+				$this->phpcsFile->addError( $message, $functionBodyScopeStart, 'VoidReturn', $data );
 			}
 			$returnTokenPtr = $this->phpcsFile->findNext(
 				[ T_RETURN ], // types.
@@ -249,12 +246,10 @@ class AlwaysReturnSniff implements Sniff {
 		}
 
 		if ( 0 <= $insideIfConditionalReturn && 0 === $outsideConditionalReturn ) {
-			$this->phpcsFile->addError(
-				'Please, make sure that a callback to `%s` filter is always returning some value.',
-				$functionBodyScopeStart,
-				'MissingReturnStatement',
-				[ $filterName ]
-			);
+			$message = 'Please, make sure that a callback to `%s` filter is always returning some value.';
+			$data    = [ $filterName ];
+			$this->phpcsFile->addError( $message, $functionBodyScopeStart, 'MissingReturnStatement', $data );
+
 		}
 	}
 

--- a/WordPressVIPMinimum/Sniffs/Functions/CreateFunctionSniff.php
+++ b/WordPressVIPMinimum/Sniffs/Functions/CreateFunctionSniff.php
@@ -45,9 +45,7 @@ class CreateFunctionSniff implements Sniff {
 	 * @return void
 	 */
 	public function process( File $phpcsFile, $stackPtr ) {
-		$tokens    = $phpcsFile->getTokens();
-		$phpcsFile = $phpcsFile;
-		$stackPtr  = $stackPtr;
+		$tokens = $phpcsFile->getTokens();
 
 		$functionName = $phpcsFile->findNext(
 			T_STRING,
@@ -79,10 +77,7 @@ class CreateFunctionSniff implements Sniff {
 			return;
 		}
 
-		$phpcsFile->addError(
-			'create_function() is deprecated as of PHP 7.2.0.',
-			$functionName,
-			'CreateFunction'
-		);
+		$message = 'create_function() is deprecated as of PHP 7.2.0.';
+		$phpcsFile->addError( $message, $functionName, 'CreateFunction' );
 	}
 }

--- a/WordPressVIPMinimum/Sniffs/Functions/DynamicCallsSniff.php
+++ b/WordPressVIPMinimum/Sniffs/Functions/DynamicCallsSniff.php
@@ -250,11 +250,8 @@ class DynamicCallsSniff implements Sniff {
 		}
 
 		// We do, so report.
-		$this->_phpcsFile->addError(
-			'Dynamic calling is not recommended in the case of %s',
-			$t_item_key,
-			'DynamicCalls',
-			[ $this->_variables_arr[ $this->_tokens[ $this->_stackPtr ]['content'] ] ]
-		);
+		$message = 'Dynamic calling is not recommended in the case of %s.';
+		$data    = [ $this->_variables_arr[ $this->_tokens[ $this->_stackPtr ]['content'] ] ];
+		$this->_phpcsFile->addError( $message, $t_item_key, 'DynamicCalls', $data );
 	}
 }

--- a/WordPressVIPMinimum/Sniffs/Functions/StripTagsSniff.php
+++ b/WordPressVIPMinimum/Sniffs/Functions/StripTagsSniff.php
@@ -49,17 +49,11 @@ class StripTagsSniff extends AbstractFunctionParameterSniff {
 	 */
 	public function process_parameters( $stackPtr, $group_name, $matched_content, $parameters ) {
 		if ( 1 === count( $parameters ) ) {
-			$this->phpcsFile->addWarning(
-				sprintf( '`strip_tags()` does not strip CSS and JS in between the script and style tags. Use `wp_strip_all_tags()` to strip all tags.', $matched_content ),
-				$stackPtr,
-				'StripTagsOneParameter'
-			);
+			$message = '`strip_tags()` does not strip CSS and JS in between the script and style tags. Use `wp_strip_all_tags()` to strip all tags.';
+			$this->phpcsFile->addWarning( $message, $stackPtr, 'StripTagsOneParameter' );
 		} elseif ( isset( $parameters[2] ) ) {
-			$this->phpcsFile->addWarning(
-				sprintf( '`strip_tags()` does not strip CSS and JS in between the script and style tags. Use `wp_kses()` instead to allow only the HTML you need.', $matched_content ),
-				$stackPtr,
-				'StripTagsTwoParameters'
-			);
+			$message = '`strip_tags()` does not strip CSS and JS in between the script and style tags. Use `wp_kses()` instead to allow only the HTML you need.';
+			$this->phpcsFile->addWarning( $message, $stackPtr, 'StripTagsTwoParameters' );
 		}
 	}
 }

--- a/WordPressVIPMinimum/Sniffs/JS/DangerouslySetInnerHTMLSniff.php
+++ b/WordPressVIPMinimum/Sniffs/JS/DangerouslySetInnerHTMLSniff.php
@@ -71,7 +71,9 @@ class DangerouslySetInnerHTMLSniff implements Sniff {
 			return;
 		}
 
-		$phpcsFile->addError( sprintf( "Any HTML passed to `%s` gets executed. Please make sure it's properly escaped.", $tokens[ $stackPtr ]['content'] ), $stackPtr, 'Found' );
+		$message = "Any HTML passed to `%s` gets executed. Please make sure it's properly escaped.";
+		$data    = [ $tokens[ $stackPtr ]['content'] ];
+		$phpcsFile->addError( $message, $stackPtr, 'Found', $data );
 	}
 
 }

--- a/WordPressVIPMinimum/Sniffs/JS/HTMLExecutingFunctionsSniff.php
+++ b/WordPressVIPMinimum/Sniffs/JS/HTMLExecutingFunctionsSniff.php
@@ -81,7 +81,10 @@ class HTMLExecutingFunctionsSniff implements Sniff {
 		while ( $nextToken < $parenthesis_closer ) {
 			$nextToken = $phpcsFile->findNext( Tokens::$emptyTokens, ( $nextToken + 1 ), null, true, null, true );
 			if ( T_STRING === $tokens[ $nextToken ]['code'] ) {
-				$phpcsFile->addWarning( sprintf( 'Any HTML passed to `%s` gets executed. Make sure it\'s properly escaped.', $tokens[ $stackPtr ]['content'] ), $stackPtr, $tokens[ $stackPtr ]['content'] );
+				$message = 'Any HTML passed to `%s` gets executed. Make sure it\'s properly escaped.';
+				$data    = [ $tokens[ $stackPtr ]['content'] ];
+				$phpcsFile->addWarning( $message, $stackPtr, $tokens[ $stackPtr ]['content'], $data );
+
 				return;
 			}
 		}

--- a/WordPressVIPMinimum/Sniffs/JS/InnerHTMLSniff.php
+++ b/WordPressVIPMinimum/Sniffs/JS/InnerHTMLSniff.php
@@ -84,7 +84,9 @@ class InnerHTMLSniff implements Sniff {
 		}
 
 		if ( true === $foundVariable ) {
-			$phpcsFile->addWarning( sprintf( 'Any HTML passed to `%s` gets executed. Consider using `.textContent` or make sure that used variables are properly escaped.', $tokens[ $stackPtr ]['content'] ), $stackPtr, 'Found' );
+			$message = 'Any HTML passed to `%s` gets executed. Consider using `.textContent` or make sure that used variables are properly escaped.';
+			$data    = [ $tokens[ $stackPtr ]['content'] ];
+			$phpcsFile->addWarning( $message, $stackPtr, 'Found', $data );
 		}
 	}
 

--- a/WordPressVIPMinimum/Sniffs/JS/StringConcatSniff.php
+++ b/WordPressVIPMinimum/Sniffs/JS/StringConcatSniff.php
@@ -44,9 +44,8 @@ class StringConcatSniff implements Sniff {
 	/**
 	 * Processes this test, when one of its tokens is encountered.
 	 *
-	 * @param \PHP_CodeSniffer\Files\File $phpcsFile The file being scanned.
-	 * @param int                         $stackPtr  The position of the current token in the
-	 *                                               stack passed in $tokens.
+	 * @param File $phpcsFile The file being scanned.
+	 * @param int  $stackPtr  The position of the current token in the stack passed in $tokens.
 	 *
 	 * @return void
 	 */
@@ -57,7 +56,8 @@ class StringConcatSniff implements Sniff {
 
 		if ( T_CONSTANT_ENCAPSED_STRING === $tokens[ $nextToken ]['code'] ) {
 			if ( false !== strpos( $tokens[ $nextToken ]['content'], '<' ) && 1 === preg_match( '/\<\/[a-zA-Z]+/', $tokens[ $nextToken ]['content'] ) ) {
-				$phpcsFile->addError( sprintf( 'HTML string concatenation detected, this is a security risk, use DOM node construction or a templating language instead: %s', '+' . $tokens[ $nextToken ]['content'] ), $stackPtr, 'Found' );
+				$data = [ '+' . $tokens[ $nextToken ]['content'] ];
+				$this->addFoundError( $phpcsFile, $stackPtr, $data );
 			}
 		}
 
@@ -65,9 +65,22 @@ class StringConcatSniff implements Sniff {
 
 		if ( T_CONSTANT_ENCAPSED_STRING === $tokens[ $prevToken ]['code'] ) {
 			if ( false !== strpos( $tokens[ $prevToken ]['content'], '<' ) && 1 === preg_match( '/\<[a-zA-Z]+/', $tokens[ $prevToken ]['content'] ) ) {
-				$phpcsFile->addError( sprintf( 'HTML string concatenation detected, this is a security risk, use DOM node construction or a templating language instead: %s', $tokens[ $prevToken ]['content'] . '+' ), $stackPtr, 'Found' );
+				$data = [ $tokens[ $nextToken ]['content'] . '+' ];
+				$this->addFoundError( $phpcsFile, $stackPtr, $data );
 			}
 		}
+	}
+
+	/**
+	 * Consolidated violation.
+	 *
+	 * @param File  $phpcsFile The file being scanned.
+	 * @param int   $stackPtr  The position of the current token in the stack passed in $tokens.
+	 * @param array $data     Replacements for the error message.
+	 */
+	private function addFoundError( File $phpcsFile, $stackPtr, array $data ) {
+		$message = 'HTML string concatenation detected, this is a security risk, use DOM node construction or a templating language instead: %s.';
+		$phpcsFile->addError( $message, $stackPtr, 'Found', $data );
 	}
 
 }

--- a/WordPressVIPMinimum/Sniffs/JS/StrippingTagsSniff.php
+++ b/WordPressVIPMinimum/Sniffs/JS/StrippingTagsSniff.php
@@ -74,7 +74,8 @@ class StrippingTagsSniff implements Sniff {
 		$nextToken = $phpcsFile->findNext( Tokens::$emptyTokens, ( $afterFunctionCall + 1 ), null, true, null, true );
 
 		if ( T_STRING === $tokens[ $nextToken ]['code'] && 'text' === $tokens[ $nextToken ]['content'] ) {
-			$phpcsFile->addError( 'Vulnerable tag stripping approach detected', $stackPtr, 'VulnerableTagStripping' );
+			$message = 'Vulnerable tag stripping approach detected.';
+			$phpcsFile->addError( $message, $stackPtr, 'VulnerableTagStripping' );
 		}
 	}
 

--- a/WordPressVIPMinimum/Sniffs/JS/WindowSniff.php
+++ b/WordPressVIPMinimum/Sniffs/JS/WindowSniff.php
@@ -128,25 +128,20 @@ class WindowSniff implements Sniff {
 
 		$windowProperty  = 'window.';
 		$windowProperty .= $nextNextNextNextToken ? $nextNextToken . '.' . $nextNextNextNextToken : $nextNextToken;
+		$data            = [ $windowProperty ];
 
 		$prevTokenPtr = $phpcsFile->findPrevious( Tokens::$emptyTokens, ( $stackPtr - 1 ), null, true, null, true );
+
 		if ( T_EQUAL === $tokens[ $prevTokenPtr ]['code'] ) {
 			// Variable assignment.
-			$phpcsFile->addWarning(
-				'Data from JS global "%s" may contain user-supplied values and should be checked.',
-				$stackPtr,
-				'VarAssignment',
-				[ $windowProperty ]
-			);
+			$message = 'Data from JS global "%s" may contain user-supplied values and should be checked.';
+			$phpcsFile->addWarning( $message, $stackPtr, 'VarAssignment', $data );
+
 			return;
 		}
 
-		$phpcsFile->addError(
-			'Data from JS global "%s" may contain user-supplied values and should be sanitized before output to prevent XSS.',
-			$stackPtr,
-			$nextNextToken,
-			[ $windowProperty ]
-		);
+		$message = 'Data from JS global "%s" may contain user-supplied values and should be sanitized before output to prevent XSS.';
+		$phpcsFile->addError( $message, $stackPtr, $nextNextToken, $data );
 	}
 
 }

--- a/WordPressVIPMinimum/Sniffs/Plugins/ZoninatorSniff.php
+++ b/WordPressVIPMinimum/Sniffs/Plugins/ZoninatorSniff.php
@@ -78,7 +78,8 @@ class ZoninatorSniff implements Sniff {
 		$version = $this->remove_wrapping_quotation_marks( $tokens[ $version ]['content'] );
 
 		if ( true === version_compare( $version, '0.8', '>=' ) ) {
-			$phpcsFile->addWarning( 'Zoninator of version >= v0.8 requires WordPress core REST API. Please, make sure the `wpcom_vip_load_wp_rest_api()` is being called on all sites loading this file.', $stackPtr, 'RequiresRESTAPI' );
+			$message = 'Zoninator of version >= v0.8 requires WordPress core REST API. Please, make sure the `wpcom_vip_load_wp_rest_api()` is being called on all sites loading this file.';
+			$phpcsFile->addWarning( $message, $stackPtr, 'RequiresRESTAPI' );
 		}
 	}
 

--- a/WordPressVIPMinimum/Sniffs/TemplatingEngines/UnescapedOutputMustacheSniff.php
+++ b/WordPressVIPMinimum/Sniffs/TemplatingEngines/UnescapedOutputMustacheSniff.php
@@ -57,23 +57,28 @@ class UnescapedOutputMustacheSniff implements Sniff {
 
 		if ( false !== strpos( $tokens[ $stackPtr ]['content'], '{{{' ) || false !== strpos( $tokens[ $stackPtr ]['content'], '}}}' ) ) {
 			// Mustache unescaped output notation.
-			$phpcsFile->addWarning( 'Found Mustache unescaped output notation: "{{{}}}".', $stackPtr, 'OutputNotation' );
+			$message = 'Found Mustache unescaped output notation: "{{{}}}".';
+			$phpcsFile->addWarning( $message, $stackPtr, 'OutputNotation' );
 		}
 
 		if ( false !== strpos( $tokens[ $stackPtr ]['content'], '{{&' ) ) {
 			// Mustache unescaped variable notation.
-			$phpcsFile->addWarning( 'Found Mustache unescape variable notation: "{{&".', $stackPtr, 'VariableNotation' );
+			$message = 'Found Mustache unescape variable notation: "{{&".';
+			$phpcsFile->addWarning( $message, $stackPtr, 'VariableNotation' );
 		}
 
 		if ( false !== strpos( $tokens[ $stackPtr ]['content'], '{{=' ) ) {
 			// Mustache delimiter change.
-			$new_delimiter = trim( str_replace( [ '{{=', '=}}' ], '', substr( $tokens[ $stackPtr ]['content'], 0, ( strpos( $tokens[ $stackPtr ]['content'], '=}}' ) + 3 ) ) ) );
-			$phpcsFile->addWarning( sprintf( 'Found Mustache delimiter change notation. New delimiter is: %s', $new_delimiter ), $stackPtr, 'DelimiterChange' );
+			$new_delimiter = trim( str_replace( [ '{{=', '=}}' ], '', substr( $tokens[ $stackPtr ]['content'], 0, strpos( $tokens[ $stackPtr ]['content'], '=}}' ) + 3 ) ) );
+			$message       = 'Found Mustache delimiter change notation. New delimiter is: %s.';
+			$data          = [ $new_delimiter ];
+			$phpcsFile->addWarning( $message, $stackPtr, 'DelimiterChange', $data );
 		}
 
 		if ( false !== strpos( $tokens[ $stackPtr ]['content'], 'SafeString' ) ) {
 			// Handlebars.js Handlebars.SafeString does not get escaped.
-			$phpcsFile->addWarning( 'Found Handlebars.SafeString call which does not get escaped.', $stackPtr, 'SafeString' );
+			$message = 'Found Handlebars.SafeString call which does not get escaped.';
+			$phpcsFile->addWarning( $message, $stackPtr, 'SafeString' );
 		}
 	}
 

--- a/WordPressVIPMinimum/Sniffs/TemplatingEngines/UnescapedOutputTwigSniff.php
+++ b/WordPressVIPMinimum/Sniffs/TemplatingEngines/UnescapedOutputTwigSniff.php
@@ -56,12 +56,14 @@ class UnescapedOutputTwigSniff implements Sniff {
 
 		if ( 1 === preg_match( '/autoescape\s+false/', $tokens[ $stackPtr ]['content'] ) ) {
 			// Twig autoescape disabled.
-			$phpcsFile->addWarning( 'Found Twig autoescape disabling notation.', $stackPtr, 'AutoescapeFalse' );
+			$message = 'Found Twig autoescape disabling notation.';
+			$phpcsFile->addWarning( $message, $stackPtr, 'AutoescapeFalse' );
 		}
 
 		if ( 1 === preg_match( '/\|\s*raw/', $tokens[ $stackPtr ]['content'] ) ) {
 			// Twig default unescape filter.
-			$phpcsFile->addWarning( 'Found Twig default unescape filter: "|raw".', $stackPtr, 'RawFound' );
+			$message = 'Found Twig default unescape filter: "|raw".';
+			$phpcsFile->addWarning( $message, $stackPtr, 'RawFound' );
 		}
 	}
 

--- a/WordPressVIPMinimum/Sniffs/TemplatingEngines/UnescapedOutputUnderscorejsSniff.php
+++ b/WordPressVIPMinimum/Sniffs/TemplatingEngines/UnescapedOutputUnderscorejsSniff.php
@@ -57,12 +57,14 @@ class UnescapedOutputUnderscorejsSniff implements Sniff {
 
 		if ( false !== strpos( $tokens[ $stackPtr ]['content'], '<%=' ) ) {
 			// Underscore.js unescaped output.
-			$phpcsFile->addWarning( 'Found Underscore.js unescaped output notation: "<%=".', $stackPtr, 'OutputNotation' );
+			$message = 'Found Underscore.js unescaped output notation: "<%=".';
+			$phpcsFile->addWarning( $message, $stackPtr, 'OutputNotation' );
 		}
 
 		if ( false !== strpos( $tokens[ $stackPtr ]['content'], 'interpolate' ) ) {
 			// Underscore.js unescaped output.
-			$phpcsFile->addWarning( 'Found Underscore.js delimiter change notation.', $stackPtr, 'InterpolateFound' );
+			$message = 'Found Underscore.js delimiter change notation.';
+			$phpcsFile->addWarning( $message, $stackPtr, 'InterpolateFound' );
 		}
 	}
 

--- a/WordPressVIPMinimum/Sniffs/TemplatingEngines/UnescapedOutputVuejsSniff.php
+++ b/WordPressVIPMinimum/Sniffs/TemplatingEngines/UnescapedOutputVuejsSniff.php
@@ -54,8 +54,9 @@ class UnescapedOutputVuejsSniff implements Sniff {
 		$tokens = $phpcsFile->getTokens();
 
 		if ( false !== strpos( $tokens[ $stackPtr ]['content'], 'v-html' ) ) {
-			// Twig autoescape disabled.
-			$phpcsFile->addWarning( 'Found Vue.js non-escaped (raw) HTML directive.', $stackPtr, 'RawHTMLDirectiveFound' );
+			// Vue autoescape disabled.
+			$message = 'Found Vue.js non-escaped (raw) HTML directive.';
+			$phpcsFile->addWarning( $message, $stackPtr, 'RawHTMLDirectiveFound' );
 		}
 	}
 

--- a/WordPressVIPMinimum/Sniffs/VIP/AdminBarRemovalSniff.php
+++ b/WordPressVIPMinimum/Sniffs/VIP/AdminBarRemovalSniff.php
@@ -225,7 +225,8 @@ class AdminBarRemovalSniff extends AbstractFunctionParameterSniff {
 		}
 
 		if ( true === $error ) {
-			$this->phpcsFile->addError( 'Removal of admin bar is prohibited.', $stackPtr, 'RemovalDetected' );
+			$message = 'Removal of admin bar is prohibited.';
+			$this->phpcsFile->addError( $message, $stackPtr, 'RemovalDetected' );
 		}
 	}
 
@@ -315,7 +316,7 @@ class AdminBarRemovalSniff extends AbstractFunctionParameterSniff {
 					}
 
 					if ( true === $error ) {
-						$this->phpcsFile->addError( 'Hiding of the admin bar is not allowed.', $stackPtr, 'HidingDetected' );
+						$this->addHidingDetectedError( $stackPtr );
 					}
 				}
 			}
@@ -366,11 +367,21 @@ class AdminBarRemovalSniff extends AbstractFunctionParameterSniff {
 					}
 
 					if ( true === $error ) {
-						$this->phpcsFile->addError( 'Hiding of the admin bar is not allowed.', $stackPtr, 'HidingDetected' );
+						$this->addHidingDetectedError( $stackPtr );
 					}
 				}
 			}
 		}
+	}
+
+	/**
+	 * Consolidated violation.
+	 *
+	 * @param int $stackPtr  The position of the current token in the stack passed in $tokens.
+	 */
+	private function addHidingDetectedError( $stackPtr ) {
+		$message = 'Hiding of the admin bar is not allowed.';
+		$this->phpcsFile->addError( $message, $stackPtr, 'HidingDetected' );
 	}
 
 	/**

--- a/WordPressVIPMinimum/Sniffs/VIP/EscapingVoidReturnFunctionsSniff.php
+++ b/WordPressVIPMinimum/Sniffs/VIP/EscapingVoidReturnFunctionsSniff.php
@@ -62,7 +62,9 @@ class EscapingVoidReturnFunctionsSniff implements Sniff {
 		}
 
 		if ( 0 === strpos( $tokens[ $next_token ]['content'], '_e' ) ) {
-			$phpcsFile->addError( sprintf( 'Attempting to escape `%s()` which is printing its output.', $tokens[ $next_token ]['content'] ), $stackPtr, 'Found' );
+			$message = 'Attempting to escape `%s()` which is printing its output.';
+			$data    = [ $tokens[ $next_token ]['content'] ];
+			$phpcsFile->addError( $message, $stackPtr, 'Found', $data );
 			return;
 		}
 	}

--- a/WordPressVIPMinimum/Sniffs/VIP/ExitAfterRedirectSniff.php
+++ b/WordPressVIPMinimum/Sniffs/VIP/ExitAfterRedirectSniff.php
@@ -52,6 +52,9 @@ class ExitAfterRedirectSniff implements Sniff {
 
 		$next_token = $phpcsFile->findNext( array_merge( Tokens::$emptyTokens, [ T_SEMICOLON, T_CLOSE_PARENTHESIS ] ), ( $tokens[ $openBracket ]['parenthesis_closer'] + 1 ), null, true );
 
+		$message = '`%s()` should almost always be followed by a call to `exit;`.';
+		$data    = [ $tokens[ $stackPtr ]['content'] ];
+
 		if ( T_OPEN_CURLY_BRACKET === $tokens[ $next_token ]['code'] ) {
 			$is_exit_in_scope = false;
 			for ( $i = $tokens[ $next_token ]['scope_opener']; $i <= $tokens[ $next_token ]['scope_closer']; $i++ ) {
@@ -60,10 +63,10 @@ class ExitAfterRedirectSniff implements Sniff {
 				}
 			}
 			if ( false === $is_exit_in_scope ) {
-				$phpcsFile->addError( sprintf( '`%s()` should almost always be followed by a call to `exit;`', $tokens[ $stackPtr ]['content'] ), $stackPtr, 'NoExitInConditional' );
+				$phpcsFile->addError( $message, $stackPtr, 'NoExitInConditional', $data );
 			}
 		} elseif ( T_EXIT !== $tokens[ $next_token ]['code'] ) {
-			$phpcsFile->addError( sprintf( '`%s()` should almost always be followed by a call to `exit;`', $tokens[ $stackPtr ]['content'] ), $stackPtr, 'NoExit' );
+			$phpcsFile->addError( $message, $stackPtr, 'NoExit', $data );
 		}
 	}
 }

--- a/WordPressVIPMinimum/Sniffs/VIP/FetchingRemoteDataSniff.php
+++ b/WordPressVIPMinimum/Sniffs/VIP/FetchingRemoteDataSniff.php
@@ -45,26 +45,20 @@ class FetchingRemoteDataSniff implements Sniff {
 			return;
 		}
 
+		$data = [ $tokens[ $stackPtr ]['content'] ];
+
 		$fileNameStackPtr = $phpcsFile->findNext( Tokens::$stringTokens, ( $stackPtr + 1 ), null, false, null, true );
 		if ( false === $fileNameStackPtr ) {
-			$phpcsFile->addWarning(
-				'`%s()` is highly discouraged for remote requests, please use `wpcom_vip_file_get_contents()` or `vip_safe_wp_remote_get()` instead. If it\'s for a local file please use WP_Filesystem instead.',
-				$stackPtr,
-				'FileGetContentsUnknown',
-				[ $tokens[ $stackPtr ]['content'] ]
-			);
+			$message = '`%s()` is highly discouraged for remote requests, please use `wpcom_vip_file_get_contents()` or `vip_safe_wp_remote_get()` instead. If it\'s for a local file please use WP_Filesystem instead.';
+			$phpcsFile->addWarning( $message, $stackPtr, 'FileGetContentsUnknown', $data );
 		}
 
 		$fileName = $tokens[ $fileNameStackPtr ]['content'];
 
 		$isRemoteFile = ( false !== strpos( $fileName, '://' ) );
 		if ( true === $isRemoteFile ) {
-			$phpcsFile->addWarning(
-				'`%s()` is highly discouraged for remote requests, please use `wpcom_vip_file_get_contents()` or `vip_safe_wp_remote_get()` instead.',
-				$stackPtr,
-				'FileGetContentsRemoteFile',
-				[ $tokens[ $stackPtr ]['content'] ]
-			);
+			$message = '`%s()` is highly discouraged for remote requests, please use `wpcom_vip_file_get_contents()` or `vip_safe_wp_remote_get()` instead.';
+			$phpcsFile->addWarning( $message, $stackPtr, 'FileGetContentsRemoteFile', $data );
 		}
 	}
 

--- a/WordPressVIPMinimum/Sniffs/VIP/MergeConflictSniff.php
+++ b/WordPressVIPMinimum/Sniffs/VIP/MergeConflictSniff.php
@@ -47,9 +47,8 @@ class MergeConflictSniff implements Sniff {
 	/**
 	 * Processes this test, when one of its tokens is encountered.
 	 *
-	 * @param \PHP_CodeSniffer\Files\File $phpcsFile The file being scanned.
-	 * @param int                         $stackPtr  The position of the current token in the
-	 *                                               stack passed in $tokens.
+	 * @param File $phpcsFile The file being scanned.
+	 * @param int  $stackPtr  The position of the current token in the stack passed in $tokens.
 	 *
 	 * @return void
 	 */
@@ -65,20 +64,39 @@ class MergeConflictSniff implements Sniff {
 			if ( T_STRING !== $tokens[ $nextToken ]['code'] || '<<< HEAD' !== substr( $tokens[ $nextToken ]['content'], 0, 8 ) ) {
 				return;
 			}
-			$phpcsFile->addError( 'Merge conflict detected. Found "<<<<<<< HEAD" string.', $stackPtr, 'Start' );
+
+			$message = 'Merge conflict detected. Found "<<<<<<< HEAD" string.';
+			$phpcsFile->addError( $message, $stackPtr, 'Start' );
+
 			return;
 		} elseif ( T_ENCAPSED_AND_WHITESPACE === $tokens[ $stackPtr ]['code'] ) {
 			if ( '=======' === substr( $tokens[ $stackPtr ]['content'], 0, 7 ) ) {
-				$phpcsFile->addError( 'Merge conflict detected. Found "=======" string.', $stackPtr, 'Separator' );
+				$this->addSeparatorError( $phpcsFile, $stackPtr );
+
 				return;
 			} elseif ( '>>>>>>>' === substr( $tokens[ $stackPtr ]['content'], 0, 7 ) ) {
-				$phpcsFile->addError( sprintf( 'Merge conflict detected. Found "%s" string.', trim( $tokens[ $stackPtr ]['content'] ) ), $stackPtr, 'End' );
+				$message = 'Merge conflict detected. Found "%s" string.';
+				$data    = [ trim( $tokens[ $stackPtr ]['content'] ) ];
+				$phpcsFile->addError( $message, $stackPtr, 'End', $data );
+
 				return;
 			}
 		} elseif ( T_IS_IDENTICAL === $tokens[ $stackPtr ]['code'] && T_IS_IDENTICAL === $tokens[ ( $stackPtr + 1 ) ]['code'] ) {
-			$phpcsFile->addError( 'Merge conflict detected. Found "=======" string.', $stackPtr, 'Separator' );
+			$this->addSeparatorError( $phpcsFile, $stackPtr );
+
 			return;
 		}
+	}
+
+	/**
+	 * Consolidated violation.
+	 *
+	 * @param File $phpcsFile The file being scanned.
+	 * @param int  $stackPtr  The position of the current token in the stack passed in $tokens.
+	 */
+	private function addSeparatorError( File $phpcsFile, $stackPtr ) {
+		$message = 'Merge conflict detected. Found "=======" string.';
+		$phpcsFile->addError( $message, $stackPtr, 'Separator' );
 	}
 
 }

--- a/WordPressVIPMinimum/Sniffs/VIP/PHPFilterFunctionsSniff.php
+++ b/WordPressVIPMinimum/Sniffs/VIP/PHPFilterFunctionsSniff.php
@@ -63,35 +63,27 @@ class PHPFilterFunctionsSniff extends AbstractFunctionParameterSniff {
 	public function process_parameters( $stackPtr, $group_name, $matched_content, $parameters ) {
 		if ( 'filter_input' === $matched_content ) {
 			if ( 2 === count( $parameters ) ) {
-				$this->phpcsFile->addWarning(
-					sprintf( 'Missing third parameter for "%s".', $matched_content ),
-					$stackPtr,
-					'MissingThirdParameter'
-				);
+				$message = 'Missing third parameter for "%s".';
+				$data    = [ $matched_content ];
+				$this->phpcsFile->addWarning( $message, $stackPtr, 'MissingThirdParameter', $data );
 			}
 
 			if ( isset( $parameters[3] ) && isset( $this->restricted_filters[ $parameters[3]['raw'] ] ) ) {
-				$this->phpcsFile->addWarning(
-					sprintf( 'Please use an appropriate filter to sanitize, as "%s" does no filtering, see: http://php.net/manual/en/filter.filters.sanitize.php.', strtoupper( $parameters[3]['raw'] ) ),
-					$stackPtr,
-					'RestrictedFilter'
-				);
+				$message = 'Please use an appropriate filter to sanitize, as "%s" does no filtering, see: http://php.net/manual/en/filter.filters.sanitize.php.';
+				$data    = [ strtoupper( $parameters[3]['raw'] ) ];
+				$this->phpcsFile->addWarning( $message, $stackPtr, 'RestrictedFilter', $data );
 			}
 		} else {
 			if ( 1 === count( $parameters ) ) {
-				$this->phpcsFile->addWarning(
-					sprintf( 'Missing second parameter for "%s".', $matched_content ),
-					$stackPtr,
-					'MissingSecondParameter'
-				);
+				$message = 'Missing second parameter for "%s".';
+				$data    = [ $matched_content ];
+				$this->phpcsFile->addWarning( $message, $stackPtr, 'MissingSecondParameter', $data );
 			}
 
 			if ( isset( $parameters[2] ) && isset( $this->restricted_filters[ $parameters[2]['raw'] ] ) ) {
-				$this->phpcsFile->addWarning(
-					sprintf( 'Please use an appropriate filter to sanitize, as "%s" does no filtering, see http://php.net/manual/en/filter.filters.sanitize.php.', strtoupper( $parameters[2]['raw'] ) ),
-					$stackPtr,
-					'RestrictedFilter'
-				);
+				$message = 'Please use an appropriate filter to sanitize, as "%s" does no filtering, see http://php.net/manual/en/filter.filters.sanitize.php.';
+				$data    = [ strtoupper( $parameters[2]['raw'] ) ];
+				$this->phpcsFile->addWarning( $message, $stackPtr, 'RestrictedFilter', $data );
 			}
 		}
 	}

--- a/WordPressVIPMinimum/Sniffs/VIP/ProperEscapingFunctionSniff.php
+++ b/WordPressVIPMinimum/Sniffs/VIP/ProperEscapingFunctionSniff.php
@@ -84,12 +84,16 @@ class ProperEscapingFunctionSniff implements Sniff {
 			return;
 		}
 
+		$data = [ $function_name ];
+
 		if ( 'esc_url' !== $function_name && $this->is_href_or_src( $tokens[ $html ]['content'] ) ) {
-			$phpcsFile->addError( sprintf( 'Wrong escaping function. href and src attributes should be escaped by `esc_url()`, not by `%s()`', $function_name ), $stackPtr, 'hrefSrcEscUrl' );
+			$message = 'Wrong escaping function. href and src attributes should be escaped by `esc_url()`, not by `%s()`.';
+			$phpcsFile->addError( $message, $stackPtr, 'hrefSrcEscUrl', $data );
 			return;
 		}
 		if ( 'esc_html' === $function_name && $this->is_html_attr( $tokens[ $html ]['content'] ) ) {
-			$phpcsFile->addError( sprintf( 'Wrong escaping function. HTML attributes should be escaped by `esc_attr()`, not by `%s()`', $function_name ), $stackPtr, 'htmlAttrNotByEscHTML' );
+			$message = 'Wrong escaping function. HTML attributes should be escaped by `esc_attr()`, not by `%s()`.';
+			$phpcsFile->addError( $message, $stackPtr, 'htmlAttrNotByEscHTML', $data );
 			return;
 		}
 	}

--- a/WordPressVIPMinimum/Sniffs/VIP/RemoteRequestTimeoutSniff.php
+++ b/WordPressVIPMinimum/Sniffs/VIP/RemoteRequestTimeoutSniff.php
@@ -53,7 +53,7 @@ class RemoteRequestTimeoutSniff extends \WordPress\AbstractArrayAssignmentRestri
 	 *                       with custom error message passed to ->process().
 	 */
 	public function callback( $key, $val, $line, $group ) {
-		if ( intval( $val ) > 3 ) {
+		if ( (int) $val > 3 ) {
 			return 'Detected high remote request timeout. `%s` is set to `%d`.';
 		}
 	}

--- a/WordPressVIPMinimum/Sniffs/VIP/RestrictedFunctionsSniff.php
+++ b/WordPressVIPMinimum/Sniffs/VIP/RestrictedFunctionsSniff.php
@@ -53,7 +53,7 @@ class RestrictedFunctionsSniff extends AbstractFunctionRestrictionsSniff {
 			],
 			'get_super_admins' => [
 				'type'      => 'error',
-				'message'   => '`%s` is prohibited on the WordPress.com VIP platform',
+				'message'   => '`%s` is prohibited on the WordPress.com VIP platform.',
 				'functions' => [
 					'get_super_admins',
 				],
@@ -125,7 +125,7 @@ class RestrictedFunctionsSniff extends AbstractFunctionRestrictionsSniff {
 			// @link VIP Go: https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/#custom-roles
 			'custom_role' => [
 				'type'      => 'error',
-				'message'   => 'Use wpcom_vip_add_role() instead of %s()',
+				'message'   => 'Use wpcom_vip_add_role() instead of %s().',
 				'functions' => [
 					'add_role',
 				],
@@ -265,7 +265,7 @@ class RestrictedFunctionsSniff extends AbstractFunctionRestrictionsSniff {
 			// @todo Introduce a sniff specific to get_posts() that checks for suppress_filters=>false being supplied.
 			'get_posts' => [
 				'type'      => 'warning',
-				'message'   => '%s() is uncached unless the "suppress_filters" parameter is set to false. If the suppress_filter parameter is set to false this can be safely ignored. More Info: https://vip.wordpress.com/documentation/vip-go/uncached-functions/',
+				'message'   => '%s() is uncached unless the "suppress_filters" parameter is set to false. If the suppress_filter parameter is set to false this can be safely ignored. More Info: https://vip.wordpress.com/documentation/vip-go/uncached-functions/.',
 				'functions' => [
 					'get_posts',
 					'wp_get_recent_posts',

--- a/WordPressVIPMinimum/Sniffs/VIP/RobotstxtSniff.php
+++ b/WordPressVIPMinimum/Sniffs/VIP/RobotstxtSniff.php
@@ -63,7 +63,8 @@ class RobotstxtSniff implements Sniff {
 		}
 
 		if ( 'do_robotstxt' === substr( $tokens[ $actionNamePtr ]['content'], 1, -1 ) ) {
-			$phpcsFile->addWarning( 'Internal note: remember to flush robots.txt nginx cache after deploying this revision', $stackPtr, 'DoRobotsTxtFound' );
+			$message = 'Internal note: remember to flush robots.txt NGINX cache after deploying this revision.';
+			$phpcsFile->addWarning( $message, $stackPtr, 'DoRobotsTxtFound' );
 		}
 	}
 }

--- a/WordPressVIPMinimum/Sniffs/VIP/StaticStrreplaceSniff.php
+++ b/WordPressVIPMinimum/Sniffs/VIP/StaticStrreplaceSniff.php
@@ -83,6 +83,7 @@ class StaticStrreplaceSniff implements Sniff {
 
 		}
 
-		$phpcsFile->addError( sprintf( 'This code pattern is often used to run a very dangerous shell programs on your server. The code in these files needs to be reviewed, and possibly cleaned.', $tokens[ $stackPtr ]['content'] ), $stackPtr, 'StaticStrreplace' );
+		$message = 'This code pattern is often used to run a very dangerous shell programs on your server. The code in these files needs to be reviewed, and possibly cleaned.';
+		$phpcsFile->addError( $message, $stackPtr, 'StaticStrreplace' );
 	}
 }

--- a/WordPressVIPMinimum/Sniffs/VIP/TaxonomyMetaInOptionsSniff.php
+++ b/WordPressVIPMinimum/Sniffs/VIP/TaxonomyMetaInOptionsSniff.php
@@ -82,7 +82,7 @@ class TaxonomyMetaInOptionsSniff implements Sniff {
 		if ( T_DOUBLE_QUOTED_STRING === $tokens[ $param_ptr ]['code'] ) {
 			foreach ( $this->taxonomy_term_patterns as $taxonomy_term_pattern ) {
 				if ( false !== strpos( $tokens[ $param_ptr ]['content'], $taxonomy_term_pattern ) ) {
-					$this->addWarning( $phpcsFile, $stackPtr );
+					$this->addPossibleTermMetaInOptionsWarning( $phpcsFile, $stackPtr );
 					return;
 				}
 			}
@@ -100,7 +100,7 @@ class TaxonomyMetaInOptionsSniff implements Sniff {
 
 			foreach ( $this->taxonomy_term_patterns as $taxonomy_term_pattern ) {
 				if ( false !== strpos( $tokens[ $variable_name ]['content'], $taxonomy_term_pattern ) ) {
-					$this->addWarning( $phpcsFile, $stackPtr );
+					$this->addPossibleTermMetaInOptionsWarning( $phpcsFile, $stackPtr );
 					return;
 				}
 			}
@@ -117,7 +117,7 @@ class TaxonomyMetaInOptionsSniff implements Sniff {
 
 			foreach ( $this->taxonomy_term_patterns as $taxonomy_term_pattern ) {
 				if ( false !== strpos( $tokens[ $object_property ]['content'], $taxonomy_term_pattern ) ) {
-					$this->addWarning( $phpcsFile, $stackPtr );
+					$this->addPossibleTermMetaInOptionsWarning( $phpcsFile, $stackPtr );
 					return;
 				}
 			}
@@ -127,13 +127,13 @@ class TaxonomyMetaInOptionsSniff implements Sniff {
 	/**
 	 * Helper method for composing the Warnign for all possible cases.
 	 *
-	 * @param \PHP_CodeSniffer\Files\File $phpcsFile The file being scanned.
-	 * @param int                         $stackPtr The position of the current token in the stack passed in $tokens.
-	 * @param string                      $type The warning type.
+	 * @param File $phpcsFile The file being scanned.
+	 * @param int  $stackPtr  The position of the current token in the stack passed in $tokens.
 	 *
-	 * @return void.
+	 * @return void
 	 */
-	public function addWarning( $phpcsFile, $stackPtr, $type = 'PossibleTermMetaInOptions' ) {
-		$phpcsFile->addWarning( sprintf( 'Possible detection of storing taxonomy term meta in options table. Needs manual inspection. All such data should be stored in term_meta.' ), $stackPtr, $type );
+	public function addPossibleTermMetaInOptionsWarning( File $phpcsFile, $stackPtr ) {
+		$message = 'Possible detection of storing taxonomy term meta in options table. Needs manual inspection. All such data should be stored in term_meta.';
+		$phpcsFile->addWarning( $message, $stackPtr, 'PossibleTermMetaInOptions' );
 	}
 }

--- a/WordPressVIPMinimum/Sniffs/VIP/WPQueryParamsSniff.php
+++ b/WordPressVIPMinimum/Sniffs/VIP/WPQueryParamsSniff.php
@@ -49,12 +49,14 @@ class WPQueryParamsSniff implements Sniff {
 			if ( T_TRUE === $tokens[ $next_token ]['code'] ) {
 				// WordPress.com: https://lobby.vip.wordpress.com/wordpress-com-documentation/uncached-functions/.
 				// VIP Go: https://vip.wordpress.com/documentation/vip-go/uncached-functions/.
-				$phpcsFile->addError( 'Setting `suppress_filters` to `true` is prohibited.', $stackPtr, 'SuppressFiltersTrue' );
+				$message = 'Setting `suppress_filters` to `true` is prohibited.';
+				$phpcsFile->addError( $message, $stackPtr, 'SuppressFiltersTrue' );
 			}
 		}
 
 		if ( 'post__not_in' === trim( $tokens[ $stackPtr ]['content'], '\'' ) ) {
-			$phpcsFile->addWarning( 'Using `post__not_in` should be done with caution, see https://vip.wordpress.com/documentation/performance-improvements-by-removing-usage-of-post__not_in/ for more information.', $stackPtr, 'PostNotIn' );
+			$message = 'Using `post__not_in` should be done with caution, see https://vip.wordpress.com/documentation/performance-improvements-by-removing-usage-of-post__not_in/ for more information.';
+			$phpcsFile->addWarning( $message, $stackPtr, 'PostNotIn' );
 		}
 	}
 

--- a/WordPressVIPMinimum/Sniffs/Variables/ServerVariablesSniff.php
+++ b/WordPressVIPMinimum/Sniffs/Variables/ServerVariablesSniff.php
@@ -67,13 +67,12 @@ class ServerVariablesSniff implements Sniff {
 		$variableName    = str_replace( [ "'", '"' ], '', $tokens[ $variableNamePtr ]['content'] );
 
 		if ( isset( $this->restrictedVariables['authVariables'][ $variableName ] ) ) {
-			$phpcsFile->addError( 'Basic authentication should not be handled via PHP code.', $stackPtr, 'BasicAuthentication' );
+			$message = 'Basic authentication should not be handled via PHP code.';
+			$phpcsFile->addError( $message, $stackPtr, 'BasicAuthentication' );
 		} elseif ( isset( $this->restrictedVariables['userControlledVariables'][ $variableName ] ) ) {
-			$phpcsFile->addError(
-				sprintf( 'Header "%s" is user-controlled and should be properly validated before use.', $variableName ),
-				$stackPtr,
-				'UserControlledHeaders'
-			);
+			$message = 'Header "%s" is user-controlled and should be properly validated before use.';
+			$data    = [ $variableName ];
+			$phpcsFile->addError( $message, $stackPtr, 'UserControlledHeaders', $data );
 		}
 	}
 

--- a/WordPressVIPMinimum/Sniffs/Variables/VariableAnalysisSniff.php
+++ b/WordPressVIPMinimum/Sniffs/Variables/VariableAnalysisSniff.php
@@ -430,16 +430,13 @@ class VariableAnalysisSniff implements Sniff {
 				//  Note: we check off scopeType not firstDeclared, this is so that
 				//    we catch declarations that come after implicit declarations like
 				//    use of a variable as a local.
-				$this->currentFile->addWarning(
-					"Redeclaration of %s %s as %s.",
-					$stackPtr,
-					'VariableRedeclaration',
-					array(
-						VariableInfo::$scopeTypeDescriptions[$varInfo->scopeType],
-						"\${$varName}",
-						VariableInfo::$scopeTypeDescriptions[$scopeType],
-					)
-				);
+				$message = 'Redeclaration of %s %s as %s.';
+				$data    = [
+					VariableInfo::$scopeTypeDescriptions[$varInfo->scopeType],
+					"\${$varName}",
+					VariableInfo::$scopeTypeDescriptions[$scopeType],
+				];
+				$this->currentFile->addWarning( $message, $stackPtr, 'VariableRedeclaration', $data );
 			}
 		}
 		$varInfo->scopeType = $scopeType;
@@ -484,18 +481,15 @@ class VariableAnalysisSniff implements Sniff {
 		return true;
 	}
 
-	function markVariableReadAndWarnIfUndefined( $phpcsFile, $varName, $stackPtr, $currScope ) {
+	function markVariableReadAndWarnIfUndefined( File $phpcsFile, $varName, $stackPtr, $currScope ) {
 
 		$this->markVariableRead( $varName, $stackPtr, $currScope );
 
 		if ( $this->isVariableUndefined( $varName, $stackPtr, $currScope ) === true ) {
 			// We haven't been defined by this point.
-			$phpcsFile->addWarning(
-				"Variable %s is undefined.",
-				$stackPtr,
-				'UndefinedVariable',
-				array( "\${$varName}" )
-			);
+			$message = 'Variable %s is undefined.';
+			$data    = [ "\${$varName}" ];
+			$phpcsFile->addWarning( $message, $stackPtr, 'UndefinedVariable', $data );
 		}
 		return true;
 	}
@@ -726,10 +720,9 @@ class VariableAnalysisSniff implements Sniff {
 			$this->markVariableRead( $varName, $stackPtr, $currScope );
 			if ( $this->isVariableUndefined( $varName, $stackPtr, $currScope ) === true ) {
 				// We haven't been defined by this point.
-				$phpcsFile->addWarning( "Variable `%s` is undefined.", $stackPtr,
-					'UndefinedVariable',
-					array( "\${$varName}" )
-				);
+				$message = 'Variable `%s` is undefined.';
+				$data    = [ "\${$varName}" ];
+				$phpcsFile->addWarning( $message, $stackPtr, 'UndefinedVariable', $data );
 				return true;
 			}
 			// $functionPtr is at the use, we need the function keyword for start of scope.
@@ -872,10 +865,9 @@ class VariableAnalysisSniff implements Sniff {
 					//  self within a closure is invalid
 					//  Note: have to fetch code from $tokens, T_CLOSURE isn't set for conditions codes.
 					if ( $tokens[$scopePtr]['code'] === T_CLOSURE ) {
-						$phpcsFile->addError( "Use of `{$err_desc}%s` inside closure.", $stackPtr,
-							$err_prefix . 'InsideClosure',
-							array( "\${$varName}" )
-						);
+						$message = "Use of `{$err_desc}%s` inside closure.";
+						$data    = [ "\${$varName}" ];
+						$phpcsFile->addError( $message, $stackPtr,$err_prefix . 'InsideClosure', $data );
 						return true;
 					}
 					if ( $scopeCode === T_CLASS ) {
@@ -883,10 +875,10 @@ class VariableAnalysisSniff implements Sniff {
 					}
 				}
 			}
-			$phpcsFile->addError( "Use of `{$err_desc}%s` outside class definition.", $stackPtr,
-				$err_prefix . 'OutsideClass',
-				array( "\${$varName}" )
-			);
+
+			$message = "Use of `{$err_desc}%s` outside class definition.";
+			$data    = [ "\${$varName}" ];
+			$phpcsFile->addError( $message, $stackPtr,$err_prefix . 'OutsideClass', $data );
 			return true;
 		}
 
@@ -1413,27 +1405,18 @@ class VariableAnalysisSniff implements Sniff {
 				// of "unused variable" warnings.
 				continue;
 			}
+
+			$message = 'Unused %s `%s`.';
+			$data    = [
+				VariableInfo::$scopeTypeDescriptions[$varInfo->scopeType],
+				"\${$varInfo->name}",
+			];
+
 			if ( isset( $varInfo->firstDeclared ) ) {
-				$phpcsFile->addWarning(
-					"Unused %s `%s`.",
-					$varInfo->firstDeclared,
-					'UnusedVariable',
-					array(
-						VariableInfo::$scopeTypeDescriptions[$varInfo->scopeType],
-						"\${$varInfo->name}",
-					)
-				);
+				$phpcsFile->addWarning( $message, $varInfo->firstDeclared, 'UnusedVariable', $data );
 			}
 			if ( isset( $varInfo->firstInitialized ) ) {
-				$phpcsFile->addWarning(
-					"Unused %s `%s`.",
-					$varInfo->firstInitialized,
-					'UnusedVariable',
-					array(
-						VariableInfo::$scopeTypeDescriptions[$varInfo->scopeType],
-						"\${$varInfo->name}",
-					)
-				);
+				$phpcsFile->addWarning( $message, $varInfo->firstInitialized, 'UnusedVariable', $data );
 			}
 		}
 	}


### PR DESCRIPTION
 - Consolidate some `add*()` calls into private methods to remove most multiple instances of violation codes, keeping code DRY.
 - Remove all uses of `sprintf()` around messages, and use the `$data` parameter of the `add*()` call instead. Some were redundant since the message didn’t contain any placeholder.
 - Extract messages out into a `$message` variable for all `add*()` calls. This reduces long line lengths, especially when considering the planned additions to message content, and allows duplicate messages to be used with multiple `add*()` calls that use different violation codes.
- Add all missing full stops to messages.
- Fixed an unnecessary dynamic violation code.

Fixes #272