### PR TITLE
Docs: Tidy reference to PHP_CodeSniffer/Files/File, and other docs items

### DIFF
--- a/WordPressVIPMinimum/Sniffs/Actions/PreGetPostsSniff.php
+++ b/WordPressVIPMinimum/Sniffs/Actions/PreGetPostsSniff.php
@@ -12,7 +12,7 @@ use PHP_CodeSniffer\Sniffs\Sniff;
 use PHP_CodeSniffer\Util\Tokens;
 
 /**
- * This sniff validates a propper usage of pre_get_posts action callback
+ * This sniff validates a proper usage of pre_get_posts action callback.
  *
  * It looks for cases when the WP_Query object is being modified without checking for WP_Query::is_main_query().
  *
@@ -28,9 +28,9 @@ class PreGetPostsSniff implements Sniff {
 	private $_tokens;
 
 	/**
-	 * The phpcsFile.
+	 * The PHP_CodeSniffer file where the token was found.
 	 *
-	 * @var phpcsFile
+	 * @var File
 	 */
 	private $_phpcsFile;
 
@@ -47,9 +47,8 @@ class PreGetPostsSniff implements Sniff {
 	/**
 	 * Processes the tokens that this sniff is interested in.
 	 *
-	 * @param \PHP_CodeSniffer\Files\File $phpcsFile The file where the token was found.
-	 * @param int                         $stackPtr  The position in the stack where
-	 *                                               the token was found.
+	 * @param File $phpcsFile The PHP_CodeSniffer file where the token was found.
+	 * @param int  $stackPtr  The position in the stack where the token was found.
 	 *
 	 * @return void
 	 */
@@ -81,7 +80,7 @@ class PreGetPostsSniff implements Sniff {
 		}
 
 		if ( 'pre_get_posts' !== substr( $this->_tokens[ $actionNamePtr ]['content'], 1, -1 ) ) {
-			// This is not setting a callback for pre_gest_posts action.
+			// This is not setting a callback for pre_get_posts action.
 			return;
 		}
 
@@ -180,7 +179,7 @@ class PreGetPostsSniff implements Sniff {
 			[ T_FUNCTION ], // types.
 			$wpQueryObjectNamePtr - 1, // start.
 			null, // end.
-			false, // exlcude.
+			false, // exclude.
 			null, // value.
 			false // local.
 		);

--- a/WordPressVIPMinimum/Sniffs/Cache/BatcacheWhitelistedParamsSniff.php
+++ b/WordPressVIPMinimum/Sniffs/Cache/BatcacheWhitelistedParamsSniff.php
@@ -20,7 +20,7 @@ use PHP_CodeSniffer\Util\Tokens;
 class BatcacheWhitelistedParamsSniff implements Sniff {
 
 	/**
-	 * List of whitelisted batcache params.
+	 * List of whitelisted Batcache params.
 	 *
 	 * @var array
 	 */
@@ -83,8 +83,8 @@ class BatcacheWhitelistedParamsSniff implements Sniff {
 	/**
 	 * Process this test when one of its tokens is encountered
 	 *
-	 * @param \PHP_CodeSniffer\Files\File $phpcsFile The file being scanned.
-	 * @param int                         $stackPtr  The position of the current token in the stack passed in $tokens.
+	 * @param File $phpcsFile The PHP_CodeSniffer file where the token was found.
+	 * @param int  $stackPtr  The position of the current token in the stack passed in $tokens.
 	 *
 	 * @return void
 	 */

--- a/WordPressVIPMinimum/Sniffs/Cache/CacheValueOverrideSniff.php
+++ b/WordPressVIPMinimum/Sniffs/Cache/CacheValueOverrideSniff.php
@@ -12,7 +12,7 @@ use PHP_CodeSniffer\Sniffs\Sniff;
 use PHP_CodeSniffer\Util\Tokens;
 
 /**
- * This sniff enforces checking the return value of a function before passing it to anoher one.
+ * This sniff enforces checking the return value of a function before passing it to another one.
  *
  * An example of a not checking return value is:
  *
@@ -44,9 +44,8 @@ class CacheValueOverrideSniff implements Sniff {
 	/**
 	 * Processes the tokens that this sniff is interested in.
 	 *
-	 * @param \PHP_CodeSniffer\Files\File $phpcsFile The file where the token was found.
-	 * @param int                         $stackPtr  The position in the stack where
-	 *                                               the token was found.
+	 * @param File $phpcsFile The PHP_CodeSniffer file where the token was found.
+	 * @param int  $stackPtr  The position in the stack where the token was found.
 	 *
 	 * @return void
 	 */

--- a/WordPressVIPMinimum/Sniffs/Classes/DeclarationCompatibilitySniff.php
+++ b/WordPressVIPMinimum/Sniffs/Classes/DeclarationCompatibilitySniff.php
@@ -194,10 +194,9 @@ class DeclarationCompatibilitySniff extends AbstractScopeSniff {
 	/**
 	 * Processes this test when one of its tokens is encountered.
 	 *
-	 * @param \PHP_CodeSniffer\Files\File $phpcsFile The current file being scanned.
-	 * @param int                         $stackPtr  The position of the current token
-	 *                                               in the stack passed in $tokens.
-	 * @param int                         $currScope A pointer to the start of the scope.
+	 * @param File $phpcsFile The PHP_CodeSniffer file where the token was found.
+	 * @param int  $stackPtr  The position of the current token in the stack passed in $tokens.
+	 * @param int  $currScope A pointer to the start of the scope.
 	 *
 	 * @return void
 	 */
@@ -284,12 +283,12 @@ class DeclarationCompatibilitySniff extends AbstractScopeSniff {
 	/**
 	 * Generates an error with nice current and parent class method notations
 	 *
-	 * @param string                      $parentClassName        The name of the extended (parent) class.
-	 * @param string                      $methodName             The name of the method currently being examined.
-	 * @param array                       $currentMethodSignature The list of params and their options of the method which is being examined.
-	 * @param array                       $parentMethodSignature  The list of params and their options of the parent class method.
-	 * @param \PHP_CodeSniffer\Files\File $phpcsFile              The file being scanned.
-	 * @param int                         $stackPtr               The position of the current token in the stack.
+	 * @param string $parentClassName        The name of the extended (parent) class.
+	 * @param string $methodName             The name of the method currently being examined.
+	 * @param array  $currentMethodSignature The list of params and their options of the method which is being examined.
+	 * @param array  $parentMethodSignature  The list of params and their options of the parent class method.
+	 * @param File   $phpcsFile              The PHP_CodeSniffer file where the token was found.
+	 * @param int    $stackPtr               The position of the current token in the stack.
 	 *
 	 * @return void
 	 */

--- a/WordPressVIPMinimum/Sniffs/Constants/ConstantRestrictionsSniff.php
+++ b/WordPressVIPMinimum/Sniffs/Constants/ConstantRestrictionsSniff.php
@@ -51,10 +51,10 @@ class ConstantRestrictionsSniff implements Sniff {
 	}
 
 	/**
-	 * Process this test when one of its tokens is encoutnered
+	 * Process this test when one of its tokens is encountered
 	 *
-	 * @param \PHP_CodeSniffer\Files\File $phpcsFile The file being scanned.
-	 * @param int                         $stackPtr  The position of the current token in the stack passed in $tokens.
+	 * @param File $phpcsFile The PHP_CodeSniffer file where the token was found.
+	 * @param int  $stackPtr  The position of the current token in the stack passed in $tokens.
 	 *
 	 * @return void
 	 */

--- a/WordPressVIPMinimum/Sniffs/Constants/ConstantStringSniff.php
+++ b/WordPressVIPMinimum/Sniffs/Constants/ConstantStringSniff.php
@@ -33,8 +33,8 @@ class ConstantStringSniff implements Sniff {
 	/**
 	 * Process this test when one of its tokens is encountered.
 	 *
-	 * @param \PHP_CodeSniffer\Files\File $phpcsFile The file being scanned.
-	 * @param int                         $stackPtr  The position of the current token in the stack passed in $tokens.
+	 * @param File $phpcsFile The PHP_CodeSniffer file where the token was found.
+	 * @param int  $stackPtr  The position of the current token in the stack passed in $tokens.
 	 *
 	 * @return void
 	 */

--- a/WordPressVIPMinimum/Sniffs/Files/IncludingNonPHPFileSniff.php
+++ b/WordPressVIPMinimum/Sniffs/Files/IncludingNonPHPFileSniff.php
@@ -34,9 +34,8 @@ class IncludingNonPHPFileSniff implements Sniff {
 	/**
 	 * Processes this test, when one of its tokens is encountered.
 	 *
-	 * @param \PHP_CodeSniffer\Files\File $phpcsFile The file being scanned.
-	 * @param int                         $stackPtr  The position of the current token in the
-	 *                                               stack passed in $tokens.
+	 * @param File $phpcsFile The PHP_CodeSniffer file where the token was found.
+	 * @param int  $stackPtr  The position of the current token in the stack passed in $tokens.
 	 *
 	 * @return void
 	 */

--- a/WordPressVIPMinimum/Sniffs/Filters/AlwaysReturnSniff.php
+++ b/WordPressVIPMinimum/Sniffs/Filters/AlwaysReturnSniff.php
@@ -26,9 +26,9 @@ class AlwaysReturnSniff implements Sniff {
 	private $tokens;
 
 	/**
-	 * The phpcsFile.
+	 * The PHP_CodeSniffer file where the token was found.
 	 *
-	 * @var phpcsFile
+	 * @var File
 	 */
 	private $phpcsFile;
 
@@ -51,9 +51,8 @@ class AlwaysReturnSniff implements Sniff {
 	/**
 	 * Processes the tokens that this sniff is interested in.
 	 *
-	 * @param \PHP_CodeSniffer\Files\File $phpcsFile The file where the token was found.
-	 * @param int                         $stackPtr  The position in the stack where
-	 *                                               the token was found.
+	 * @param File $phpcsFile The PHP_CodeSniffer file where the token was found.
+	 * @param int  $stackPtr  The position in the stack where the token was found.
 	 *
 	 * @return void
 	 */

--- a/WordPressVIPMinimum/Sniffs/Functions/CheckReturnValueSniff.php
+++ b/WordPressVIPMinimum/Sniffs/Functions/CheckReturnValueSniff.php
@@ -63,7 +63,7 @@ class CheckReturnValueSniff implements Sniff {
 	];
 
 	/**
-	 * The file where the token was found.
+	 * The PHP_CodeSniffer file where the token was found.
 	 *
 	 * @var File
 	 */
@@ -81,7 +81,7 @@ class CheckReturnValueSniff implements Sniff {
 	/**
 	 * Processes the tokens that this sniff is interested in.
 	 *
-	 * @param File $phpcsFile The file where the token was found.
+	 * @param File $phpcsFile The PHP_CodeSniffer file where the token was found.
 	 * @param int  $stackPtr  The position in the stack where
 	 *                        the token was found.
 	 *
@@ -292,7 +292,7 @@ class CheckReturnValueSniff implements Sniff {
 		// Find previous non-empty token, which is not an open parenthesis, comma nor variable.
 		$search   = Tokens::$emptyTokens;
 		$search[] = T_OPEN_PARENTHESIS;
-		// This allows us to check for variables which are passed as second paramt of a function. Eg.: array_key_exists.
+		// This allows us to check for variables which are passed as second parameter of a function e.g.: array_key_exists.
 		$search[] = T_COMMA;
 		$search[] = T_VARIABLE;
 		$search[] = T_CONSTANT_ENCAPSED_STRING;

--- a/WordPressVIPMinimum/Sniffs/Functions/CreateFunctionSniff.php
+++ b/WordPressVIPMinimum/Sniffs/Functions/CreateFunctionSniff.php
@@ -38,9 +38,8 @@ class CreateFunctionSniff implements Sniff {
 	/**
 	 * Processes the tokens that this sniff is interested in.
 	 *
-	 * @param \PHP_CodeSniffer\Files\File $phpcsFile The file where the token was found.
-	 * @param int                         $stackPtr  The position in the stack where
-	 *                                               the token was found.
+	 * @param File $phpcsFile The PHP_CodeSniffer file where the token was found.
+	 * @param int  $stackPtr  The position in the stack where the token was found.
 	 *
 	 * @return void
 	 */

--- a/WordPressVIPMinimum/Sniffs/Functions/DynamicCallsSniff.php
+++ b/WordPressVIPMinimum/Sniffs/Functions/DynamicCallsSniff.php
@@ -66,9 +66,8 @@ class DynamicCallsSniff implements Sniff {
 	/**
 	 * Processes the tokens that this sniff is interested in.
 	 *
-	 * @param \PHP_CodeSniffer\Files\File $phpcsFile The file where the token was found.
-	 * @param int                         $stackPtr  The position in the stack where
-	 *                                               the token was found.
+	 * @param File $phpcsFile The PHP_CodeSniffer file where the token was found.
+	 * @param int  $stackPtr  The position in the stack where the token was found.
 	 *
 	 * @return void
 	 */
@@ -136,7 +135,7 @@ class DynamicCallsSniff implements Sniff {
 		}
 
 		/*
-		 * Find encapsed string ( "" )
+		 * Find encapsulated string ( "" )
 		 */
 		$t_item_key = $this->_phpcsFile->findNext(
 			[ T_CONSTANT_ENCAPSED_STRING ],

--- a/WordPressVIPMinimum/Sniffs/JS/DangerouslySetInnerHTMLSniff.php
+++ b/WordPressVIPMinimum/Sniffs/JS/DangerouslySetInnerHTMLSniff.php
@@ -43,9 +43,8 @@ class DangerouslySetInnerHTMLSniff implements Sniff {
 	/**
 	 * Processes this test, when one of its tokens is encountered.
 	 *
-	 * @param \PHP_CodeSniffer\Files\File $phpcsFile The file being scanned.
-	 * @param int                         $stackPtr  The position of the current token in the
-	 *                                               stack passed in $tokens.
+	 * @param File $phpcsFile The PHP_CodeSniffer file where the token was found.
+	 * @param int  $stackPtr  The position of the current token in the stack passed in $tokens.
 	 *
 	 * @return void
 	 */

--- a/WordPressVIPMinimum/Sniffs/JS/HTMLExecutingFunctionsSniff.php
+++ b/WordPressVIPMinimum/Sniffs/JS/HTMLExecutingFunctionsSniff.php
@@ -55,9 +55,8 @@ class HTMLExecutingFunctionsSniff implements Sniff {
 	/**
 	 * Processes this test, when one of its tokens is encountered.
 	 *
-	 * @param \PHP_CodeSniffer\Files\File $phpcsFile The file being scanned.
-	 * @param int                         $stackPtr  The position of the current token in the
-	 *                                               stack passed in $tokens.
+	 * @param File $phpcsFile The PHP_CodeSniffer file where the token was found.
+	 * @param int  $stackPtr  The position of the current token in the stack passed in $tokens.
 	 *
 	 * @return void
 	 */

--- a/WordPressVIPMinimum/Sniffs/JS/InnerHTMLSniff.php
+++ b/WordPressVIPMinimum/Sniffs/JS/InnerHTMLSniff.php
@@ -43,9 +43,8 @@ class InnerHTMLSniff implements Sniff {
 	/**
 	 * Processes this test, when one of its tokens is encountered.
 	 *
-	 * @param \PHP_CodeSniffer\Files\File $phpcsFile The file being scanned.
-	 * @param int                         $stackPtr  The position of the current token in the
-	 *                                               stack passed in $tokens.
+	 * @param File $phpcsFile The PHP_CodeSniffer file where the token was found.
+	 * @param int  $stackPtr  The position of the current token in the stack passed in $tokens.
 	 *
 	 * @return void
 	 */

--- a/WordPressVIPMinimum/Sniffs/JS/StringConcatSniff.php
+++ b/WordPressVIPMinimum/Sniffs/JS/StringConcatSniff.php
@@ -44,7 +44,7 @@ class StringConcatSniff implements Sniff {
 	/**
 	 * Processes this test, when one of its tokens is encountered.
 	 *
-	 * @param File $phpcsFile The file being scanned.
+	 * @param File $phpcsFile The PHP_CodeSniffer file where the token was found.
 	 * @param int  $stackPtr  The position of the current token in the stack passed in $tokens.
 	 *
 	 * @return void
@@ -74,9 +74,9 @@ class StringConcatSniff implements Sniff {
 	/**
 	 * Consolidated violation.
 	 *
-	 * @param File  $phpcsFile The file being scanned.
+	 * @param File  $phpcsFile The PHP_CodeSniffer file where the token was found.
 	 * @param int   $stackPtr  The position of the current token in the stack passed in $tokens.
-	 * @param array $data     Replacements for the error message.
+	 * @param array $data      Replacements for the error message.
 	 */
 	private function addFoundError( File $phpcsFile, $stackPtr, array $data ) {
 		$message = 'HTML string concatenation detected, this is a security risk, use DOM node construction or a templating language instead: %s.';

--- a/WordPressVIPMinimum/Sniffs/JS/StrippingTagsSniff.php
+++ b/WordPressVIPMinimum/Sniffs/JS/StrippingTagsSniff.php
@@ -44,9 +44,8 @@ class StrippingTagsSniff implements Sniff {
 	/**
 	 * Processes this test, when one of its tokens is encountered.
 	 *
-	 * @param \PHP_CodeSniffer\Files\File $phpcsFile The file being scanned.
-	 * @param int                         $stackPtr  The position of the current token in the
-	 *                                               stack passed in $tokens.
+	 * @param File $phpcsFile The PHP_CodeSniffer file where the token was found.
+	 * @param int  $stackPtr  The position of the current token in the stack passed in $tokens.
 	 *
 	 * @return void
 	 */

--- a/WordPressVIPMinimum/Sniffs/JS/WindowSniff.php
+++ b/WordPressVIPMinimum/Sniffs/JS/WindowSniff.php
@@ -75,9 +75,8 @@ class WindowSniff implements Sniff {
 	/**
 	 * Processes this test, when one of its tokens is encountered.
 	 *
-	 * @param \PHP_CodeSniffer\Files\File $phpcsFile The file being scanned.
-	 * @param int                         $stackPtr  The position of the current token in the
-	 *                                               stack passed in $tokens.
+	 * @param File $phpcsFile The PHP_CodeSniffer file where the token was found.
+	 * @param int  $stackPtr  The position of the current token in the stack passed in $tokens.
 	 *
 	 * @return void
 	 */

--- a/WordPressVIPMinimum/Sniffs/Plugins/ZoninatorSniff.php
+++ b/WordPressVIPMinimum/Sniffs/Plugins/ZoninatorSniff.php
@@ -30,9 +30,8 @@ class ZoninatorSniff implements Sniff {
 	/**
 	 * Processes the tokens that this sniff is interested in.
 	 *
-	 * @param \PHP_CodeSniffer\Files\File $phpcsFile The file where the token was found.
-	 * @param int                         $stackPtr  The position in the stack where
-	 *                                               the token was found.
+	 * @param File $phpcsFile The PHP_CodeSniffer file where the token was found.
+	 * @param int  $stackPtr  The position in the stack where the token was found.
 	 *
 	 * @return void
 	 */

--- a/WordPressVIPMinimum/Sniffs/TemplatingEngines/UnescapedOutputMustacheSniff.php
+++ b/WordPressVIPMinimum/Sniffs/TemplatingEngines/UnescapedOutputMustacheSniff.php
@@ -46,9 +46,8 @@ class UnescapedOutputMustacheSniff implements Sniff {
 	/**
 	 * Processes this test, when one of its tokens is encountered.
 	 *
-	 * @param \PHP_CodeSniffer\Files\File $phpcsFile The file being scanned.
-	 * @param int                         $stackPtr  The position of the current token in the
-	 *                                               stack passed in $tokens.
+	 * @param File $phpcsFile The PHP_CodeSniffer file where the token was found.
+	 * @param int  $stackPtr  The position of the current token in the stack passed in $tokens.
 	 *
 	 * @return void
 	 */

--- a/WordPressVIPMinimum/Sniffs/TemplatingEngines/UnescapedOutputTwigSniff.php
+++ b/WordPressVIPMinimum/Sniffs/TemplatingEngines/UnescapedOutputTwigSniff.php
@@ -45,9 +45,8 @@ class UnescapedOutputTwigSniff implements Sniff {
 	/**
 	 * Processes this test, when one of its tokens is encountered.
 	 *
-	 * @param \PHP_CodeSniffer\Files\File $phpcsFile The file being scanned.
-	 * @param int                         $stackPtr  The position of the current token in the
-	 *                                               stack passed in $tokens.
+	 * @param File $phpcsFile The PHP_CodeSniffer file where the token was found.
+	 * @param int  $stackPtr  The position of the current token in the stack passed in $tokens.
 	 *
 	 * @return void
 	 */

--- a/WordPressVIPMinimum/Sniffs/TemplatingEngines/UnescapedOutputUnderscorejsSniff.php
+++ b/WordPressVIPMinimum/Sniffs/TemplatingEngines/UnescapedOutputUnderscorejsSniff.php
@@ -46,9 +46,8 @@ class UnescapedOutputUnderscorejsSniff implements Sniff {
 	/**
 	 * Processes this test, when one of its tokens is encountered.
 	 *
-	 * @param \PHP_CodeSniffer\Files\File $phpcsFile The file being scanned.
-	 * @param int                         $stackPtr  The position of the current token in the
-	 *                                               stack passed in $tokens.
+	 * @param File $phpcsFile The PHP_CodeSniffer file where the token was found.
+	 * @param int  $stackPtr  The position of the current token in the stack passed in $tokens.
 	 *
 	 * @return void
 	 */

--- a/WordPressVIPMinimum/Sniffs/TemplatingEngines/UnescapedOutputVuejsSniff.php
+++ b/WordPressVIPMinimum/Sniffs/TemplatingEngines/UnescapedOutputVuejsSniff.php
@@ -44,9 +44,8 @@ class UnescapedOutputVuejsSniff implements Sniff {
 	/**
 	 * Processes this test, when one of its tokens is encountered.
 	 *
-	 * @param \PHP_CodeSniffer\Files\File $phpcsFile The file being scanned.
-	 * @param int                         $stackPtr  The position of the current token in the
-	 *                                               stack passed in $tokens.
+	 * @param File $phpcsFile The PHP_CodeSniffer file where the token was found.
+	 * @param int  $stackPtr  The position of the current token in the stack passed in $tokens.
 	 *
 	 * @return void
 	 */

--- a/WordPressVIPMinimum/Sniffs/VIP/EscapingVoidReturnFunctionsSniff.php
+++ b/WordPressVIPMinimum/Sniffs/VIP/EscapingVoidReturnFunctionsSniff.php
@@ -33,8 +33,8 @@ class EscapingVoidReturnFunctionsSniff implements Sniff {
 	/**
 	 * Process this test when one of its tokens is encountered
 	 *
-	 * @param \PHP_CodeSniffer\Files\File $phpcsFile The file being scanned.
-	 * @param int                         $stackPtr  The position of the current token in the stack passed in $tokens.
+	 * @param File $phpcsFile The PHP_CodeSniffer file where the token was found.
+	 * @param int  $stackPtr  The position of the current token in the stack passed in $tokens.
 	 *
 	 * @return void
 	 */

--- a/WordPressVIPMinimum/Sniffs/VIP/ExitAfterRedirectSniff.php
+++ b/WordPressVIPMinimum/Sniffs/VIP/ExitAfterRedirectSniff.php
@@ -31,8 +31,8 @@ class ExitAfterRedirectSniff implements Sniff {
 	/**
 	 * Process this test when one of its tokens is encountered
 	 *
-	 * @param \PHP_CodeSniffer\Files\File $phpcsFile The file being scanned.
-	 * @param int                         $stackPtr  The position of the current token in the stack passed in $tokens.
+	 * @param File $phpcsFile The PHP_CodeSniffer file where the token was found.
+	 * @param int  $stackPtr  The position of the current token in the stack passed in $tokens.
 	 *
 	 * @return void
 	 */

--- a/WordPressVIPMinimum/Sniffs/VIP/FetchingRemoteDataSniff.php
+++ b/WordPressVIPMinimum/Sniffs/VIP/FetchingRemoteDataSniff.php
@@ -31,8 +31,8 @@ class FetchingRemoteDataSniff implements Sniff {
 	/**
 	 * Process this test when one of its tokens is encountered.
 	 *
-	 * @param \PHP_CodeSniffer\Files\File $phpcsFile  The file being scanned.
-	 * @param int                         $stackPtr   The position of the current token in the stack passed in $tokens.
+	 * @param File $phpcsFile The PHP_CodeSniffer file where the token was found.
+	 * @param int  $stackPtr  The position of the current token in the stack passed in $tokens.
 	 *
 	 * @return void
 	 */

--- a/WordPressVIPMinimum/Sniffs/VIP/MergeConflictSniff.php
+++ b/WordPressVIPMinimum/Sniffs/VIP/MergeConflictSniff.php
@@ -47,7 +47,7 @@ class MergeConflictSniff implements Sniff {
 	/**
 	 * Processes this test, when one of its tokens is encountered.
 	 *
-	 * @param File $phpcsFile The file being scanned.
+	 * @param File $phpcsFile The PHP_CodeSniffer file where the token was found.
 	 * @param int  $stackPtr  The position of the current token in the stack passed in $tokens.
 	 *
 	 * @return void
@@ -91,7 +91,7 @@ class MergeConflictSniff implements Sniff {
 	/**
 	 * Consolidated violation.
 	 *
-	 * @param File $phpcsFile The file being scanned.
+	 * @param File $phpcsFile The PHP_CodeSniffer file where the token was found.
 	 * @param int  $stackPtr  The position of the current token in the stack passed in $tokens.
 	 */
 	private function addSeparatorError( File $phpcsFile, $stackPtr ) {

--- a/WordPressVIPMinimum/Sniffs/VIP/ProperEscapingFunctionSniff.php
+++ b/WordPressVIPMinimum/Sniffs/VIP/ProperEscapingFunctionSniff.php
@@ -42,8 +42,8 @@ class ProperEscapingFunctionSniff implements Sniff {
 	/**
 	 * Process this test when one of its tokens is encountered
 	 *
-	 * @param \PHP_CodeSniffer\Files\File $phpcsFile The file being scanned.
-	 * @param int                         $stackPtr  The position of the current token in the stack passed in $tokens.
+	 * @param File $phpcsFile The PHP_CodeSniffer file where the token was found.
+	 * @param int  $stackPtr  The position of the current token in the stack passed in $tokens.
 	 *
 	 * @return void
 	 */

--- a/WordPressVIPMinimum/Sniffs/VIP/RobotstxtSniff.php
+++ b/WordPressVIPMinimum/Sniffs/VIP/RobotstxtSniff.php
@@ -15,7 +15,7 @@ use PHP_CodeSniffer\Util\Tokens;
 
 /**
  * This sniff searches for `do_robotstxt` action hooked callback and thows an internal reminder
- * for VIP devs to flush related caches in order to make the change actually happen in production
+ * for VIP engineers to flush related caches in order to make the change actually happen in production
  */
 class RobotstxtSniff implements Sniff {
 
@@ -31,10 +31,8 @@ class RobotstxtSniff implements Sniff {
 	/**
 	 * Processes the tokens that this sniff is interested in.
 	 *
-	 * @param PHP_CodeSniffer_File $phpcsFile The file where the token
-	 *                                        was found.
-	 * @param int                  $stackPtr  The position in the stack
-	 *                                        where the token was found.
+	 * @param File $phpcsFile The PHP_CodeSniffer file where the token was found.
+	 * @param int  $stackPtr  The position in the stack where the token was found.
 	 *
 	 * @return void
 	 */

--- a/WordPressVIPMinimum/Sniffs/VIP/StaticStrreplaceSniff.php
+++ b/WordPressVIPMinimum/Sniffs/VIP/StaticStrreplaceSniff.php
@@ -31,8 +31,8 @@ class StaticStrreplaceSniff implements Sniff {
 	/**
 	 * Process this test when one of its tokens is encountered
 	 *
-	 * @param \PHP_CodeSniffer\Files\File $phpcsFile The file being scanned.
-	 * @param int                         $stackPtr  The position of the current token in the stack passed in $tokens.
+	 * @param File $phpcsFile The PHP_CodeSniffer file where the token was found.
+	 * @param int  $stackPtr  The position of the current token in the stack passed in $tokens.
 	 *
 	 * @return void
 	 */

--- a/WordPressVIPMinimum/Sniffs/VIP/TaxonomyMetaInOptionsSniff.php
+++ b/WordPressVIPMinimum/Sniffs/VIP/TaxonomyMetaInOptionsSniff.php
@@ -58,8 +58,8 @@ class TaxonomyMetaInOptionsSniff implements Sniff {
 	/**
 	 * Process this test when one of its tokens is encountered
 	 *
-	 * @param \PHP_CodeSniffer\Files\File $phpcsFile The file being scanned.
-	 * @param int                         $stackPtr  The position of the current token in the stack passed in $tokens.
+	 * @param File $phpcsFile The PHP_CodeSniffer file where the token was found.
+	 * @param int  $stackPtr  The position of the current token in the stack passed in $tokens.
 	 *
 	 * @return void
 	 */
@@ -125,9 +125,9 @@ class TaxonomyMetaInOptionsSniff implements Sniff {
 	}
 
 	/**
-	 * Helper method for composing the Warnign for all possible cases.
+	 * Helper method for composing the Warning for all possible cases.
 	 *
-	 * @param File $phpcsFile The file being scanned.
+	 * @param File $phpcsFile The PHP_CodeSniffer file where the token was found.
 	 * @param int  $stackPtr  The position of the current token in the stack passed in $tokens.
 	 *
 	 * @return void

--- a/WordPressVIPMinimum/Sniffs/VIP/WPQueryParamsSniff.php
+++ b/WordPressVIPMinimum/Sniffs/VIP/WPQueryParamsSniff.php
@@ -33,8 +33,8 @@ class WPQueryParamsSniff implements Sniff {
 	/**
 	 * Process this test when one of its tokens is encountered
 	 *
-	 * @param \PHP_CodeSniffer\Files\File $phpcsFile The file being scanned.
-	 * @param int                         $stackPtr  The position of the current token in the stack passed in $tokens.
+	 * @param File $phpcsFile The PHP_CodeSniffer file where the token was found.
+	 * @param int  $stackPtr  The position of the current token in the stack passed in $tokens.
 	 *
 	 * @return void
 	 */

--- a/WordPressVIPMinimum/Sniffs/Variables/ServerVariablesSniff.php
+++ b/WordPressVIPMinimum/Sniffs/Variables/ServerVariablesSniff.php
@@ -47,10 +47,10 @@ class ServerVariablesSniff implements Sniff {
 	}
 
 	/**
-	 * Process this test when one of its tokens is encoutnered
+	 * Process this test when one of its tokens is encountered
 	 *
-	 * @param \PHP_CodeSniffer\Files\File $phpcsFile The file being scanned.
-	 * @param int                         $stackPtr  The position of the current token in the stack passed in $tokens.
+	 * @param File $phpcsFile The PHP_CodeSniffer file where the token was found.
+	 * @param int  $stackPtr  The position of the current token in the stack passed in $tokens.
 	 *
 	 * @return void
 	 */

--- a/WordPressVIPMinimum/Sniffs/Variables/VariableAnalysisHelper.php
+++ b/WordPressVIPMinimum/Sniffs/Variables/VariableAnalysisHelper.php
@@ -1,7 +1,7 @@
 <?php
 // @codingStandardsIgnoreStart
 /**
- * This file is part of the VariableAnalysis addon for PHP_CodeSniffer.
+ * This file is part of the VariableAnalysis add-on for PHP_CodeSniffer.
  *
  * PHP version 5
  *

--- a/WordPressVIPMinimum/Sniffs/Variables/VariableAnalysisSniff.php
+++ b/WordPressVIPMinimum/Sniffs/Variables/VariableAnalysisSniff.php
@@ -1,7 +1,7 @@
 <?php
 // @codingStandardsIgnoreStart
 /**
- * This file is part of the VariableAnalysis addon for PHP_CodeSniffer.
+ * This file is part of the VariableAnalysis add-on for PHP_CodeSniffer.
  *
  * PHP version 5
  *
@@ -32,9 +32,9 @@ use PHP_CodeSniffer\Sniffs\Sniff;
  */
 class VariableAnalysisSniff implements Sniff {
 	/**
-	 * The current phpcsFile being checked.
+	 * The PHP_CodeSniffer file where the token was found.
 	 *
-	 * @var phpcsFile
+	 * @var File
 	 */
 	protected $currentFile = null;
 
@@ -50,7 +50,7 @@ class VariableAnalysisSniff implements Sniff {
 
 	/**
 	 *  Array of known pass-by-reference functions and the argument(s) which are passed
-	 *  by reference, the arguments are numbered starting from 1 and an elipsis '...'
+	 *  by reference, the arguments are numbered starting from 1 and an ellipsis '...'
 	 *  means all argument numbers after the previous should be considered pass-by-reference.
 	 */
 	private $_passByRefFunctions = array(
@@ -311,7 +311,7 @@ class VariableAnalysisSniff implements Sniff {
 	 * @return array
 	 */
 	public function register() {
-		//  Magic to modfy $_passByRefFunctions with any site-specific settings.
+		//  Magic to modify $_passByRefFunctions with any site-specific settings.
 		if ( !empty( $this->sitePassByRefFunctions) ) {
 			foreach (preg_split( '/\s+/', trim( $this->sitePassByRefFunctions) ) as $line ) {
 				list ( $function, $args) = explode( ':', $line );
@@ -334,9 +334,8 @@ class VariableAnalysisSniff implements Sniff {
 	/**
 	 * Processes this test, when one of its tokens is encountered.
 	 *
-	 * @param \PHP_CodeSniffer\Files\File $phpcsFile The file being scanned.
-	 * @param int                         $stackPtr  The position of the current token
-	 *                                               in the stack passed in $tokens.
+	 * @param File $phpcsFile The PHP_CodeSniffer file where the token was found.
+	 * @param int  $stackPtr  The position of the current token in the stack passed in $tokens.
 	 *
 	 * @return void
 	 */
@@ -898,7 +897,7 @@ class VariableAnalysisSniff implements Sniff {
 			return false;
 		}
 
-		// Plain ol' assignment. Simpl(ish).
+		// Plain ol' assignment. Simple-ish.
 		if ( ( $writtenPtr = $this->findWhereAssignExecuted( $phpcsFile, $assignPtr ) ) === false ) {
 			$writtenPtr = $stackPtr;  // I dunno
 		}
@@ -1029,7 +1028,7 @@ class VariableAnalysisSniff implements Sniff {
 	) {
 		$tokens = $phpcsFile->getTokens();
 
-		// Are we a foreach loopvar?
+		// Are we a foreach loop var?
 		if ( ( $openPtr = $this->findContainingBrackets( $phpcsFile, $stackPtr ) ) === false ) {
 			return false;
 		}
@@ -1080,7 +1079,7 @@ class VariableAnalysisSniff implements Sniff {
 			return false;
 		}
 		if ( !in_array( $argPos, $refArgs) ) {
-			// Our arg wasn't mentioned explicitly, are we after an elipsis catch-all?
+			// Our arg wasn't mentioned explicitly, are we after an ellipsis catch-all?
 			if ( ( $elipsis = array_search( '...', $refArgs) ) === false ) {
 				return false;
 			}
@@ -1116,7 +1115,7 @@ class VariableAnalysisSniff implements Sniff {
 		$tokens = $phpcsFile->getTokens();
 		$token  = $tokens[$stackPtr];
 
-		// Are we a symbolic object property/function derefeference?
+		// Are we a symbolic object property/function dereference?
 		// Search backwards for first token that isn't whitespace, is it a "->" operator?
 		$objectOperatorPtr = $phpcsFile->findPrevious(
 			T_WHITESPACE,
@@ -1132,9 +1131,8 @@ class VariableAnalysisSniff implements Sniff {
 	/**
 	 * Called to process class member vars.
 	 *
-	 * @param \PHP_CodeSniffer\Files\File $phpcsFile The PHP_CodeSniffer file where this
-	 *                                               token was found.
-	 * @param int                         $stackPtr  The position where the token was found.
+	 * @param File $phpcsFile The PHP_CodeSniffer file where the token was found.
+	 * @param int  $stackPtr  The position where the token was found.
 	 *
 	 * @return void
 	 */
@@ -1148,9 +1146,8 @@ class VariableAnalysisSniff implements Sniff {
 	/**
 	 * Called to process normal member vars.
 	 *
-	 * @param \PHP_CodeSniffer\Files\File $phpcsFile The PHP_CodeSniffer file where this
-	 *                                               token was found.
-	 * @param int                         $stackPtr  The position where the token was found.
+	 * @param File $phpcsFile The PHP_CodeSniffer file where the token was found.
+	 * @param int  $stackPtr  The position where the token was found.
 	 *
 	 * @return void
 	 */
@@ -1245,7 +1242,7 @@ class VariableAnalysisSniff implements Sniff {
 			return;
 		}
 
-		// Are we a foreach loopvar?
+		// Are we a foreach loop var?
 		if ( $this->checkForForeachLoopVar( $phpcsFile, $stackPtr, $varName, $currScope ) ) {
 			return;
 		}
@@ -1265,10 +1262,8 @@ class VariableAnalysisSniff implements Sniff {
 	 * Note that there may be more than one variable in the string, which will
 	 * result only in one call for the string.
 	 *
-	 * @param \PHP_CodeSniffer\Files\File $phpcsFile The PHP_CodeSniffer file where this
-	 *                                               token was found.
-	 * @param int                          $stackPtr  The position where the double quoted
-	 *                                                string was found.
+	 * @param File $phpcsFile The PHP_CodeSniffer file where the token was found.
+	 * @param int  $stackPtr  The position where the double quoted string was found.
 	 *
 	 * @return void
 	 */
@@ -1351,10 +1346,8 @@ class VariableAnalysisSniff implements Sniff {
 	/**
 	 * Called to process variables named in a call to compact().
 	 *
-	 * @param \PHP_CodeSniffer\Files\File $phpcsFile The PHP_CodeSniffer file where this
-	 *                                               token was found.
-	 * @param int                         $stackPtr  The position where the call to compact()
-	 *                                               was found.
+	 * @param File $phpcsFile The PHP_CodeSniffer file where the token was found.
+	 * @param int  $stackPtr  The position where the call to compact() was found.
 	 *
 	 * @return void
 	 */
@@ -1377,9 +1370,8 @@ class VariableAnalysisSniff implements Sniff {
 	 * Note that although triggered by the closing curly brace of the scope, $stackPtr is
 	 * the scope conditional, not the closing curly brace.
 	 *
-	 * @param \PHP_CodeSniffer\Files\File $phpcsFile The PHP_CodeSniffer file where this
-	 *                                        token was found.
-	 * @param int                         $stackPtr  The position of the scope conditional.
+	 * @param File $phpcsFile The PHP_CodeSniffer file where the token was found..
+	 * @param int  $stackPtr  The position of the scope conditional.
 	 *
 	 * @return void
 	 */


### PR DESCRIPTION
Since all the sniffs that have a `process()` or similar method that has a `File` type declaration for `$phpcsFile`, also have an import statement, then the corresponding Docs can simply reference `File` instead of `PHP_CodeSniffer/Files/File`.

`vendor/bin/phpcbf --standard=WordPress-Docs WordPressVIPMinimum/Sniffs/` used to auto-realign everything correctly.

Also, the descriptions for `$phpcsFile` have been updated to be consistent with the parent interface `@param` description: "The PHP_CodeSniffer file where the token was found.".

Also fixed up some comment / DocBlock typos.