### PR TITLE
Remove non-existing function: url_to_post_id

### DIFF
--- a/WordPressVIPMinimum/Sniffs/VIP/RestrictedFunctionsSniff.php
+++ b/WordPressVIPMinimum/Sniffs/VIP/RestrictedFunctionsSniff.php
@@ -118,7 +118,6 @@ class RestrictedFunctionsSniff extends AbstractFunctionRestrictionsSniff {
 				'message'   => '%s() is prohibited, please use wpcom_vip_url_to_postid() instead.',
 				'functions' => [
 					'url_to_postid',
-					'url_to_post_id',
 				],
 			],
 			// @link WordPress.com: https://lobby.vip.wordpress.com/wordpress-com-documentation/code-review-what-we-look-for/#custom-roles


### PR DESCRIPTION
Closes https://github.com/Automattic/VIP-Coding-Standards/issues/334

The rule name seems a bit convoluted, but I'm not sure if changing that is a good idea: https://github.com/Automattic/VIP-Coding-Standards/blob/b46ec66b8899d6ca8f83e9b0e70062ed6409c184/WordPress-VIP-Go/ruleset.xml#L128