### PR TITLE
Copy deprecated has_html_open_tag() method

### DIFF
--- a/WordPressVIPMinimum/Sniffs/UserExperience/AdminBarRemovalSniff.php
+++ b/WordPressVIPMinimum/Sniffs/UserExperience/AdminBarRemovalSniff.php
@@ -411,4 +411,32 @@ class AdminBarRemovalSniff extends AbstractFunctionParameterSniff {
 		}
 	}
 
+	/**
+	 * Check if a content string contains a specific HTML open tag.
+	 *
+	 * @param string $tag_name The name of the HTML tag without brackets. So if
+	 *                         searching for '<span...', this would be 'span'.
+	 * @param int    $stackPtr Optional. The position of the current token in the
+	 *                         token stack.
+	 *                         This parameter needs to be passed if no $content is
+	 *                         passed.
+	 * @param string $content  Optionally, the current content string, might be a
+	 *                         substring of the original string.
+	 *                         Defaults to `false` to distinguish between a passed
+	 *                         empty string and not passing the $content string.
+	 *
+	 * @return bool True if the string contains an <tag_name> open tag, false otherwise.
+	 */
+	public function has_html_open_tag( $tag_name, $stackPtr = null, $content = null ) {
+		if ( null === $content && isset( $stackPtr ) ) {
+			$content = $this->tokens[ $stackPtr ]['content'];
+		}
+
+		if ( ! empty( $content ) && false !== strpos( $content, '<' . $tag_name ) ) {
+			return true;
+		}
+
+		return false;
+	}
+
 }


### PR DESCRIPTION
WPCS 2.0 [removes](https://github.com/WordPress-Coding-Standards/WordPress-Coding-Standards/commit/969a8054f6c699652e57c4e681018c772f2499f0#diff-35cb3caff18d91218603d585bccb1f82) the deprecated `has_html_open_tag()` method, so this PR copies it into VIPCS so it can continue to be used.

The only change is to amend the default value of the the `$content` argument to be `null` instead of `false`, and adjust the logic in the first line.

See #349.