### PR TITLE
Inspections: Multiple fixes

### DIFF
--- a/WordPressVIPMinimum/Sniffs/AbstractVariableRestrictionsSniff.php
+++ b/WordPressVIPMinimum/Sniffs/AbstractVariableRestrictionsSniff.php
@@ -127,7 +127,7 @@ abstract class AbstractVariableRestrictionsSniff extends Sniff {
 
 		$token = $this->tokens[ $stackPtr ];
 
-		$this->excluded_groups = $this->merge_custom_array( $this->exclude );
+		$this->excluded_groups = static::merge_custom_array( $this->exclude );
 		if ( array_diff_key( $this->groups_cache, $this->excluded_groups ) === [] ) {
 			// All groups have been excluded.
 			// Don't remove the listener as the exclude property can be changed inline.
@@ -136,8 +136,8 @@ abstract class AbstractVariableRestrictionsSniff extends Sniff {
 
 		// Check if it is a function not a variable.
 		if ( \in_array( $token['code'], [ \T_OBJECT_OPERATOR, \T_DOUBLE_COLON ], true ) ) { // This only works for object vars and array members.
-			$method               = $this->phpcsFile->findNext( \T_WHITESPACE, ( $stackPtr + 1 ), null, true );
-			$possible_parenthesis = $this->phpcsFile->findNext( \T_WHITESPACE, ( $method + 1 ), null, true );
+			$method               = $this->phpcsFile->findNext( \T_WHITESPACE, $stackPtr + 1, null, true );
+			$possible_parenthesis = $this->phpcsFile->findNext( \T_WHITESPACE, $method + 1, null, true );
 			if ( \T_OPEN_PARENTHESIS === $this->tokens[ $possible_parenthesis ]['code'] ) {
 				return; // So .. it is a function after all !
 			}
@@ -174,7 +174,7 @@ abstract class AbstractVariableRestrictionsSniff extends Sniff {
 
 				if ( isset( $token['bracket_closer'] ) ) {
 					$owner  = $this->phpcsFile->findPrevious( \T_VARIABLE, $stackPtr );
-					$inside = $this->phpcsFile->getTokensAsString( $stackPtr, ( $token['bracket_closer'] - $stackPtr + 1 ) );
+					$inside = $this->phpcsFile->getTokensAsString( $stackPtr, $token['bracket_closer'] - $stackPtr + 1 );
 					$var    = implode( '', [ $this->tokens[ $owner ]['content'], $inside ] );
 				}
 			}
@@ -198,7 +198,7 @@ abstract class AbstractVariableRestrictionsSniff extends Sniff {
 			$this->addMessage(
 				$group['message'],
 				$stackPtr,
-				( 'error' === $group['type'] ),
+				'error' === $group['type'],
 				$this->string_to_errorcode( $groupName . '_' . $match[1] ),
 				[ $var ]
 			);

--- a/WordPressVIPMinimum/Sniffs/Classes/DeclarationCompatibilitySniff.php
+++ b/WordPressVIPMinimum/Sniffs/Classes/DeclarationCompatibilitySniff.php
@@ -34,7 +34,7 @@ class DeclarationCompatibilitySniff extends AbstractScopeSniff {
 	/**
 	 * A list of classes and methods to check.
 	 *
-	 * @var array
+	 * @var string[]
 	 */
 	public $checkClasses = [
 		'WP_Widget' => [
@@ -170,7 +170,7 @@ class DeclarationCompatibilitySniff extends AbstractScopeSniff {
 	/**
 	 * List of grouped classes with same methods (as they extend the same parent class)
 	 *
-	 * @var array
+	 * @var string[]
 	 */
 	public $checkClassesGroups = [
 		'Walker' => [
@@ -249,7 +249,7 @@ class DeclarationCompatibilitySniff extends AbstractScopeSniff {
 		$parentSignature = $this->checkClasses[ $parentClassName ][ $methodName ];
 
 		if ( count( $signatureParams ) > count( $parentSignature ) ) {
-			$extra_params                  = array_slice( $signatureParams, ( count( $parentSignature ) - count( $signatureParams ) ) );
+			$extra_params                  = array_slice( $signatureParams, count( $parentSignature ) - count( $signatureParams ) );
 			$all_extra_params_have_default = true;
 			foreach ( $extra_params as $extra_param ) {
 				if ( false === array_key_exists( 'default', $extra_param ) || 'true' !== $extra_param['default'] ) {
@@ -269,8 +269,14 @@ class DeclarationCompatibilitySniff extends AbstractScopeSniff {
 		$i = 0;
 		foreach ( $parentSignature as $key => $param ) {
 			if ( true === is_array( $param ) ) {
-				if ( true === array_key_exists( 'default', $param ) && false === array_key_exists( 'default', $signatureParams[ $i ] )
-					|| true === array_key_exists( 'pass_by_reference', $param ) && $param['pass_by_reference'] !== $signatureParams[ $i ]['pass_by_reference']
+				if (
+					(
+						true === array_key_exists( 'default', $param ) &&
+						false === array_key_exists( 'default', $signatureParams[ $i ] )
+					) || (
+						true === array_key_exists( 'pass_by_reference', $param ) &&
+						$param['pass_by_reference'] !== $signatureParams[ $i ]['pass_by_reference']
+					)
 				) {
 					$this->addError( $originalParentClassName, $methodName, $signatureParams, $parentSignature, $phpcsFile, $stackPtr );
 					return;

--- a/WordPressVIPMinimum/Sniffs/Compatibility/ZoninatorSniff.php
+++ b/WordPressVIPMinimum/Sniffs/Compatibility/ZoninatorSniff.php
@@ -43,36 +43,36 @@ class ZoninatorSniff implements Sniff {
 			return;
 		}
 
-		$openBracket = $phpcsFile->findNext( Tokens::$emptyTokens, ( $stackPtr + 1 ), null, true );
+		$openBracket = $phpcsFile->findNext( Tokens::$emptyTokens, $stackPtr + 1, null, true );
 
 		if ( T_OPEN_PARENTHESIS !== $tokens[ $openBracket ]['code'] ) {
 			// Not a function call.
 			return;
 		}
 
-		$plugin_name = $phpcsFile->findNext( Tokens::$emptyTokens, ( $openBracket + 1 ), null, true );
+		$plugin_name = $phpcsFile->findNext( Tokens::$emptyTokens, $openBracket + 1, null, true );
 
 		if ( 'zoninator' !== $this->remove_wrapping_quotation_marks( $tokens[ $plugin_name ]['content'] ) ) {
 			return;
 		}
 
-		$comma = $phpcsFile->findNext( Tokens::$emptyTokens, ( $plugin_name + 1 ), null, true );
+		$comma = $phpcsFile->findNext( Tokens::$emptyTokens, $plugin_name + 1, null, true );
 
 		if ( ! $comma || 'PHPCS_T_COMMA' !== $tokens[ $comma ]['code'] ) {
 			// We are loading the default version.
 			return;
 		}
 
-		$folder = $phpcsFile->findNext( Tokens::$emptyTokens, ( $comma + 1 ), null, true );
+		$folder = $phpcsFile->findNext( Tokens::$emptyTokens, $comma + 1, null, true );
 
-		$comma = $phpcsFile->findNext( Tokens::$emptyTokens, ( $folder + 1 ), null, true );
+		$comma = $phpcsFile->findNext( Tokens::$emptyTokens, $folder + 1, null, true );
 
 		if ( ! $comma || 'PHPCS_T_COMMA' !== $tokens[ $comma ]['code'] ) {
 			// We are loading the default version.
 			return;
 		}
 
-		$version = $phpcsFile->findNext( Tokens::$emptyTokens, ( $comma + 1 ), null, true );
+		$version = $phpcsFile->findNext( Tokens::$emptyTokens, $comma + 1, null, true );
 		$version = $this->remove_wrapping_quotation_marks( $tokens[ $version ]['content'] );
 
 		if ( true === version_compare( $version, '0.8', '>=' ) ) {

--- a/WordPressVIPMinimum/Sniffs/Constants/ConstantStringSniff.php
+++ b/WordPressVIPMinimum/Sniffs/Constants/ConstantStringSniff.php
@@ -47,7 +47,7 @@ class ConstantStringSniff implements Sniff {
 		}
 
 		// Find the next non-empty token.
-		$nextToken = $phpcsFile->findNext( Tokens::$emptyTokens, ( $stackPtr + 1 ), null, true, null, true );
+		$nextToken = $phpcsFile->findNext( Tokens::$emptyTokens, $stackPtr + 1, null, true, null, true );
 
 		if ( T_OPEN_PARENTHESIS !== $tokens[ $nextToken ]['code'] ) {
 			// Not a function call.
@@ -59,7 +59,7 @@ class ConstantStringSniff implements Sniff {
 			return;
 		}
 
-		$nextToken = $phpcsFile->findNext( Tokens::$emptyTokens, ( $nextToken + 1 ), null, true, null, true );
+		$nextToken = $phpcsFile->findNext( Tokens::$emptyTokens, $nextToken + 1, null, true, null, true );
 
 		if ( T_CONSTANT_ENCAPSED_STRING !== $tokens[ $nextToken ]['code'] ) {
 			$message = 'Constant name, as a string, should be used along with `%s()`.';

--- a/WordPressVIPMinimum/Sniffs/Constants/RestrictedConstantsSniff.php
+++ b/WordPressVIPMinimum/Sniffs/Constants/RestrictedConstantsSniff.php
@@ -81,7 +81,7 @@ class RestrictedConstantsSniff implements Sniff {
 		}
 
 		// Find the previous non-empty token.
-		$openBracket = $phpcsFile->findPrevious( Tokens::$emptyTokens, ( $stackPtr - 1 ), null, true, null, true );
+		$openBracket = $phpcsFile->findPrevious( Tokens::$emptyTokens, $stackPtr - 1, null, true, null, true );
 
 		if ( T_OPEN_PARENTHESIS !== $tokens[ $openBracket ]['code'] ) {
 			// Not a function call.
@@ -96,7 +96,7 @@ class RestrictedConstantsSniff implements Sniff {
 		// Find the previous non-empty token.
 		$search   = Tokens::$emptyTokens;
 		$search[] = T_BITWISE_AND;
-		$previous = $phpcsFile->findPrevious( $search, ( $openBracket - 1 ), null, true );
+		$previous = $phpcsFile->findPrevious( $search, $openBracket - 1, null, true );
 		if ( T_FUNCTION === $tokens[ $previous ]['code'] ) {
 			// It's a function definition, not a function call.
 			return;

--- a/WordPressVIPMinimum/Sniffs/Files/IncludingNonPHPFileSniff.php
+++ b/WordPressVIPMinimum/Sniffs/Files/IncludingNonPHPFileSniff.php
@@ -43,8 +43,8 @@ class IncludingNonPHPFileSniff implements Sniff {
 		$tokens = $phpcsFile->getTokens();
 
 		$curStackPtr = $stackPtr;
-		while ( false !== $phpcsFile->findNext( Tokens::$stringTokens, ( $curStackPtr + 1 ), null, false, null, true ) ) {
-			$curStackPtr = $phpcsFile->findNext( Tokens::$stringTokens, ( $curStackPtr + 1 ), null, false, null, true );
+		while ( false !== $phpcsFile->findNext( Tokens::$stringTokens, $curStackPtr + 1, null, false, null, true ) ) {
+			$curStackPtr = $phpcsFile->findNext( Tokens::$stringTokens, $curStackPtr + 1, null, false, null, true );
 
 			if ( T_CONSTANT_ENCAPSED_STRING === $tokens[ $curStackPtr ]['code'] ) {
 				$stringWithoutEnclosingQuotationMarks = trim( $tokens[ $curStackPtr ]['content'], "\"'" );

--- a/WordPressVIPMinimum/Sniffs/Functions/CheckReturnValueSniff.php
+++ b/WordPressVIPMinimum/Sniffs/Functions/CheckReturnValueSniff.php
@@ -113,7 +113,7 @@ class CheckReturnValueSniff implements Sniff {
 		}
 
 		// Find the next non-empty token.
-		$openBracket = $phpcsFile->findNext( Tokens::$emptyTokens, ( $stackPtr + 1 ), null, true );
+		$openBracket = $phpcsFile->findNext( Tokens::$emptyTokens, $stackPtr + 1, null, true );
 
 		if ( T_OPEN_PARENTHESIS !== $tokens[ $openBracket ]['code'] ) {
 			// Not a function call.
@@ -123,13 +123,10 @@ class CheckReturnValueSniff implements Sniff {
 		// Find the previous non-empty token.
 		$search   = Tokens::$emptyTokens;
 		$search[] = T_BITWISE_AND;
-		$previous = $phpcsFile->findPrevious( $search, ( $stackPtr - 1 ), null, true );
-		if ( T_FUNCTION === $tokens[ $previous ]['code'] ) {
-			// It's a function definition, not a function call.
-			return false;
-		}
+		$previous = $phpcsFile->findPrevious( $search, $stackPtr - 1, null, true );
 
-		return true;
+		// It's a function definition, not a function call, so return false.
+		return ! ( T_FUNCTION === $tokens[ $previous ]['code'] );
 	}
 
 	/**
@@ -147,14 +144,14 @@ class CheckReturnValueSniff implements Sniff {
 		// Find the previous non-empty token.
 		$search   = Tokens::$emptyTokens;
 		$search[] = T_BITWISE_AND;
-		$previous = $phpcsFile->findPrevious( $search, ( $stackPtr - 1 ), null, true );
+		$previous = $phpcsFile->findPrevious( $search, $stackPtr - 1, null, true );
 
 		if ( T_EQUAL !== $tokens[ $previous ]['code'] ) {
 			// It's not a variable assignment.
 			return false;
 		}
 
-		$previous = $phpcsFile->findPrevious( $search, ( $previous - 1 ), null, true );
+		$previous = $phpcsFile->findPrevious( $search, $previous - 1, null, true );
 
 		if ( T_VARIABLE !== $tokens[ $previous ]['code'] ) {
 			// It's not a variable assignment.
@@ -186,7 +183,7 @@ class CheckReturnValueSniff implements Sniff {
 		}
 
 		// Find the next non-empty token.
-		$openBracket = $phpcsFile->findNext( Tokens::$emptyTokens, ( $stackPtr + 1 ), null, true );
+		$openBracket = $phpcsFile->findNext( Tokens::$emptyTokens, $stackPtr + 1, null, true );
 
 		// Find the closing bracket.
 		$closeBracket = $tokens[ $openBracket ]['parenthesis_closer'];
@@ -199,7 +196,7 @@ class CheckReturnValueSniff implements Sniff {
 				$data    = [ $tokens[ $next ]['content'], $functionName ];
 				$phpcsFile->addError( $message, $next, 'DirectFunctionCall', $data );
 			}
-			$next = $phpcsFile->findNext( Tokens::$functionNameTokens, ( $next + 1 ), $closeBracket, false, null, true );
+			$next = $phpcsFile->findNext( Tokens::$functionNameTokens, $next + 1, $closeBracket, false, null, true );
 		}
 	}
 
@@ -252,7 +249,7 @@ class CheckReturnValueSniff implements Sniff {
 		$variableName  = $variableToken['content'];
 
 		// Find the next non-empty token.
-		$openBracket = $phpcsFile->findNext( Tokens::$emptyTokens, ( $stackPtr + 1 ), null, true );
+		$openBracket = $phpcsFile->findNext( Tokens::$emptyTokens, $stackPtr + 1, null, true );
 
 		// Find the closing bracket.
 		$closeBracket = $tokens[ $openBracket ]['parenthesis_closer'];
@@ -287,7 +284,7 @@ class CheckReturnValueSniff implements Sniff {
 			}
 		}
 
-		$nextVariableOccurrence = $phpcsFile->findNext( T_VARIABLE, ( $closeBracket + 1 ), null, false, $variableName, false );
+		$nextVariableOccurrence = $phpcsFile->findNext( T_VARIABLE, $closeBracket + 1, null, false, $variableName );
 
 		// Find previous non-empty token, which is not an open parenthesis, comma nor variable.
 		$search   = Tokens::$emptyTokens;
@@ -297,7 +294,7 @@ class CheckReturnValueSniff implements Sniff {
 		$search[] = T_VARIABLE;
 		$search[] = T_CONSTANT_ENCAPSED_STRING;
 
-		$nextFunctionCallWithVariable = $phpcsFile->findPrevious( $search, ( $nextVariableOccurrence - 1 ), null, true );
+		$nextFunctionCallWithVariable = $phpcsFile->findPrevious( $search, $nextVariableOccurrence - 1, null, true );
 
 		foreach ( $callees as $callee ) {
 			$notFunctionsCallee = array_key_exists( $callee, $this->notFunctions ) ? (array) $this->notFunctions[ $callee ] : [];
@@ -310,7 +307,7 @@ class CheckReturnValueSniff implements Sniff {
 			}
 
 			$search = array_merge( Tokens::$emptyTokens, [ T_EQUAL ] );
-			$next   = $phpcsFile->findNext( $search, ( $nextVariableOccurrence + 1 ), null, true, null, false );
+			$next   = $phpcsFile->findNext( $search, $nextVariableOccurrence + 1, null, true );
 			if ( true === in_array( $tokens[ $next ]['code'], Tokens::$functionNameTokens, true )
 				&& $tokens[ $next ]['content'] === $callee
 			) {

--- a/WordPressVIPMinimum/Sniffs/Functions/RestrictedFunctionsSniff.php
+++ b/WordPressVIPMinimum/Sniffs/Functions/RestrictedFunctionsSniff.php
@@ -358,25 +358,22 @@ class RestrictedFunctionsSniff extends AbstractFunctionRestrictionsSniff {
 	 */
 	public function is_targetted_token( $stackPtr ) {
 		// Exclude function definitions, class methods, and namespaced calls.
-		if ( \T_STRING === $this->tokens[ $stackPtr ]['code'] && isset( $this->tokens[ ( $stackPtr - 1 ) ] ) ) {
+		if ( \T_STRING === $this->tokens[ $stackPtr ]['code'] && isset( $this->tokens[ $stackPtr - 1 ] ) ) {
 			// Check if this is really a function.
-			$next = $this->phpcsFile->findNext( Tokens::$emptyTokens, ( $stackPtr + 1 ), null, true );
+			$next = $this->phpcsFile->findNext( Tokens::$emptyTokens, $stackPtr + 1, null, true );
 			if ( false !== $next && T_OPEN_PARENTHESIS !== $this->tokens[ $next ]['code'] ) {
 				return false;
 			}
 
-			$prev = $this->phpcsFile->findPrevious( Tokens::$emptyTokens, ( $stackPtr - 1 ), null, true );
+			$prev = $this->phpcsFile->findPrevious( Tokens::$emptyTokens, $stackPtr - 1, null, true );
 			if ( false !== $prev ) {
 
 				// Start difference to parent class method.
 				// Check to see if function is a method on a specific object variable.
 				if ( ! empty( $this->groups[ $this->tokens[ $stackPtr ]['content'] ]['object_var'] ) ) {
-					$prevPrev = $this->phpcsFile->findPrevious( Tokens::$emptyTokens, ( $stackPtr - 2 ), null, true );
-					if ( \T_OBJECT_OPERATOR === $this->tokens[ $prev ]['code'] && isset( $this->groups[ $this->tokens[ $stackPtr ]['content'] ]['object_var'][ $this->tokens[ $prevPrev ]['content'] ] ) ) {
-						return true;
-					} else {
-						return false;
-					}
+					$prevPrev = $this->phpcsFile->findPrevious( Tokens::$emptyTokens, $stackPtr - 2, null, true );
+
+					return \T_OBJECT_OPERATOR === $this->tokens[ $prev ]['code'] && isset( $this->groups[ $this->tokens[ $stackPtr ]['content'] ]['object_var'][ $this->tokens[ $prevPrev ]['content'] ] );
 				} // End difference to parent class method.
 
 				// Skip sniffing if calling a same-named method, or on function definitions.
@@ -392,7 +389,7 @@ class RestrictedFunctionsSniff extends AbstractFunctionRestrictionsSniff {
 				}
 				// Skip namespaced functions, ie: \foo\bar() not \bar().
 				if ( \T_NS_SEPARATOR === $this->tokens[ $prev ]['code'] ) {
-					$pprev = $this->phpcsFile->findPrevious( Tokens::$emptyTokens, ( $prev - 1 ), null, true );
+					$pprev = $this->phpcsFile->findPrevious( Tokens::$emptyTokens, $prev - 1, null, true );
 					if ( false !== $pprev && \T_STRING === $this->tokens[ $pprev ]['code'] ) {
 						return false;
 					}

--- a/WordPressVIPMinimum/Sniffs/Hooks/AlwaysReturnInFilterSniff.php
+++ b/WordPressVIPMinimum/Sniffs/Hooks/AlwaysReturnInFilterSniff.php
@@ -69,12 +69,12 @@ class AlwaysReturnInFilterSniff implements Sniff {
 		}
 
 		$this->filterNamePtr = $this->phpcsFile->findNext(
-			array_merge( Tokens::$emptyTokens, [ T_OPEN_PARENTHESIS ] ), // types.
-			$stackPtr + 1, // start.
-			null, // end.
-			true, // exclude.
-			null, // value.
-			true // local.
+			array_merge( Tokens::$emptyTokens, [ T_OPEN_PARENTHESIS ] ),
+			$stackPtr + 1,
+			null,
+			true,
+			null,
+			true
 		);
 
 		if ( ! $this->filterNamePtr ) {
@@ -83,12 +83,12 @@ class AlwaysReturnInFilterSniff implements Sniff {
 		}
 
 		$callbackPtr = $this->phpcsFile->findNext(
-			array_merge( Tokens::$emptyTokens, [ T_COMMA ] ), // types.
-			$this->filterNamePtr + 1, // start.
-			null, // end.
-			true, // exclude.
-			null, // value.
-			true // local.
+			array_merge( Tokens::$emptyTokens, [ T_COMMA ] ),
+			$this->filterNamePtr + 1,
+			null,
+			true,
+			null,
+			true
 		);
 
 		if ( ! $callbackPtr ) {
@@ -113,12 +113,10 @@ class AlwaysReturnInFilterSniff implements Sniff {
 	private function processArray( $stackPtr ) {
 
 		$previous = $this->phpcsFile->findPrevious(
-			Tokens::$emptyTokens, // types.
-			$this->tokens[ $stackPtr ]['parenthesis_closer'] - 1, // start.
-			null, // end.
-			true, // exclude.
-			null, // value.
-			false // local.
+			Tokens::$emptyTokens,
+			$this->tokens[ $stackPtr ]['parenthesis_closer'] - 1,
+			null,
+			true
 		);
 
 		if ( true === in_array( T_CLASS, $this->tokens[ $stackPtr ]['conditions'], true ) ) {
@@ -145,12 +143,11 @@ class AlwaysReturnInFilterSniff implements Sniff {
 		$callbackFunctionName = substr( $this->tokens[ $stackPtr ]['content'], 1, -1 );
 
 		$callbackFunctionPtr = $this->phpcsFile->findNext(
-			Tokens::$functionNameTokens, // types.
-			$start, // start.
-			$end, // end.
-			false, // exclude.
-			$callbackFunctionName, // value.
-			false // local.
+			Tokens::$functionNameTokens,
+			$start,
+			$end,
+			false,
+			$callbackFunctionName
 		);
 
 		if ( ! $callbackFunctionPtr ) {
@@ -173,14 +170,12 @@ class AlwaysReturnInFilterSniff implements Sniff {
 		$functionName = $this->tokens[ $stackPtr ]['content'];
 
 		$offset = $start;
-		while ( false !== $this->phpcsFile->findNext( [ T_FUNCTION ], $offset, $end, false, null, false ) ) {
-			$functionStackPtr = $this->phpcsFile->findNext( [ T_FUNCTION ], $offset, $end, false, null, false );
+		while ( false !== $this->phpcsFile->findNext( [ T_FUNCTION ], $offset, $end ) ) {
+			$functionStackPtr = $this->phpcsFile->findNext( [ T_FUNCTION ], $offset, $end );
 			$functionNamePtr  = $this->phpcsFile->findNext( Tokens::$emptyTokens, $functionStackPtr + 1, null, true, null, true );
-			if ( T_STRING === $this->tokens[ $functionNamePtr ]['code'] ) {
-				if ( $this->tokens[ $functionNamePtr ]['content'] === $functionName ) {
-					$this->processFunctionBody( $functionStackPtr );
-					return;
-				}
+			if ( T_STRING === $this->tokens[ $functionNamePtr ]['code'] && $this->tokens[ $functionNamePtr ]['content'] === $functionName ) {
+				$this->processFunctionBody( $functionStackPtr );
+				return;
 			}
 			$offset = $functionStackPtr + 1;
 		}
@@ -194,12 +189,12 @@ class AlwaysReturnInFilterSniff implements Sniff {
 	private function processFunctionBody( $stackPtr ) {
 
 		$argPtr = $this->phpcsFile->findNext(
-			array_merge( Tokens::$emptyTokens, [ T_STRING, T_OPEN_PARENTHESIS ] ), // types.
-			$stackPtr + 1, // start.
-			null, // end.
-			true, // exclude.
-			null, // value.
-			true // local.
+			array_merge( Tokens::$emptyTokens, [ T_STRING, T_OPEN_PARENTHESIS ] ),
+			$stackPtr + 1,
+			null,
+			true,
+			null,
+			true
 		);
 
 		// If arg is being passed by reference, we can skip.
@@ -213,12 +208,9 @@ class AlwaysReturnInFilterSniff implements Sniff {
 		$functionBodyScopeEnd   = $this->tokens[ $stackPtr ]['scope_closer'];
 
 		$returnTokenPtr = $this->phpcsFile->findNext(
-			[ T_RETURN ], // types.
-			( $functionBodyScopeStart + 1 ), // start.
-			$functionBodyScopeEnd, // end.
-			false, // exclude.
-			null, // value.
-			false // local.
+			[ T_RETURN ],
+			$functionBodyScopeStart + 1,
+			$functionBodyScopeEnd
 		);
 
 		$insideIfConditionalReturn = 0;
@@ -236,12 +228,9 @@ class AlwaysReturnInFilterSniff implements Sniff {
 				$this->phpcsFile->addError( $message, $functionBodyScopeStart, 'VoidReturn', $data );
 			}
 			$returnTokenPtr = $this->phpcsFile->findNext(
-				[ T_RETURN ], // types.
-				( $returnTokenPtr + 1 ), // start.
-				$functionBodyScopeEnd, // end.
-				false, // exclude.
-				null, // value.
-				false // local.
+				[ T_RETURN ],
+				$returnTokenPtr + 1,
+				$functionBodyScopeEnd
 			);
 		}
 
@@ -299,18 +288,12 @@ class AlwaysReturnInFilterSniff implements Sniff {
 	private function isReturningVoid( $stackPtr ) {
 
 		$nextToReturnTokenPtr = $this->phpcsFile->findNext(
-			[ Tokens::$emptyTokens ], // types.
-			( $stackPtr + 1 ), // start.
-			null, // end.
-			true, // exclude.
-			null, // value.
-			false // local.
+			[ Tokens::$emptyTokens ],
+			$stackPtr + 1,
+			null,
+			true
 		);
 
-		if ( T_SEMICOLON === $this->tokens[ $nextToReturnTokenPtr ]['code'] ) {
-			return true;
-		}
-
-		return false;
+		return T_SEMICOLON === $this->tokens[ $nextToReturnTokenPtr ]['code'];
 	}
 }

--- a/WordPressVIPMinimum/Sniffs/Hooks/PreGetPostsSniff.php
+++ b/WordPressVIPMinimum/Sniffs/Hooks/PreGetPostsSniff.php
@@ -66,12 +66,12 @@ class PreGetPostsSniff implements Sniff {
 		}
 
 		$actionNamePtr = $this->_phpcsFile->findNext(
-			array_merge( Tokens::$emptyTokens, [ T_OPEN_PARENTHESIS ] ), // types.
-			$stackPtr + 1, // start.
-			null, // end.
-			true, // exclude.
-			null, // value.
-			true // local.
+			array_merge( Tokens::$emptyTokens, [ T_OPEN_PARENTHESIS ] ),
+			$stackPtr + 1,
+			null,
+			true,
+			null,
+			true
 		);
 
 		if ( ! $actionNamePtr ) {
@@ -85,12 +85,12 @@ class PreGetPostsSniff implements Sniff {
 		}
 
 		$callbackPtr = $this->_phpcsFile->findNext(
-			array_merge( Tokens::$emptyTokens, [ T_COMMA ] ), // types.
-			$actionNamePtr + 1, // start.
-			null, // end.
-			true, // exclude.
-			null, // value.
-			true // local.
+			array_merge( Tokens::$emptyTokens, [ T_COMMA ] ),
+			$actionNamePtr + 1,
+			null,
+			true,
+			null,
+			true
 		);
 
 		if ( ! $callbackPtr ) {
@@ -115,12 +115,10 @@ class PreGetPostsSniff implements Sniff {
 	private function processArray( $stackPtr ) {
 
 		$previous = $this->_phpcsFile->findPrevious(
-			Tokens::$emptyTokens, // types.
-			$this->_tokens[ $stackPtr ]['parenthesis_closer'] - 1, // start.
-			null, // end.
-			true, // exclude.
-			null, // value.
-			false // local.
+			Tokens::$emptyTokens,
+			$this->_tokens[ $stackPtr ]['parenthesis_closer'] - 1,
+			null,
+			true
 		);
 
 		$this->processString( $previous );
@@ -136,12 +134,11 @@ class PreGetPostsSniff implements Sniff {
 		$callbackFunctionName = substr( $this->_tokens[ $stackPtr ]['content'], 1, -1 );
 
 		$callbackFunctionPtr = $this->_phpcsFile->findNext(
-			Tokens::$functionNameTokens, // types.
-			0, // start.
-			null, // end.
-			false, // exclude.
-			$callbackFunctionName, // value.
-			false // local.
+			Tokens::$functionNameTokens,
+			0,
+			null,
+			false,
+			$callbackFunctionName
 		);
 
 		if ( ! $callbackFunctionPtr ) {
@@ -160,12 +157,12 @@ class PreGetPostsSniff implements Sniff {
 	private function processFunction( $stackPtr ) {
 
 		$wpQueryObjectNamePtr = $this->_phpcsFile->findNext(
-			[ T_VARIABLE ], // types.
-			$stackPtr + 1, // start.
-			null, // end.
-			false, // exclude.
-			null, // value.
-			true // local.
+			[ T_VARIABLE ],
+			$stackPtr + 1,
+			null,
+			false,
+			null,
+			true
 		);
 
 		if ( ! $wpQueryObjectNamePtr ) {
@@ -175,14 +172,7 @@ class PreGetPostsSniff implements Sniff {
 
 		$wpQueryObjectVariableName = $this->_tokens[ $wpQueryObjectNamePtr ]['content'];
 
-		$functionDefinitionPtr = $this->_phpcsFile->findPrevious(
-			[ T_FUNCTION ], // types.
-			$wpQueryObjectNamePtr - 1, // start.
-			null, // end.
-			false, // exclude.
-			null, // value.
-			false // local.
-		);
+		$functionDefinitionPtr = $this->_phpcsFile->findPrevious( [ T_FUNCTION ], $wpQueryObjectNamePtr - 1 );
 
 		if ( ! $functionDefinitionPtr ) {
 			// Something is wrong.
@@ -200,12 +190,12 @@ class PreGetPostsSniff implements Sniff {
 	private function processClosure( $stackPtr ) {
 
 		$wpQueryObjectNamePtr = $this->_phpcsFile->findNext(
-			[ T_VARIABLE ], // types.
-			$stackPtr + 1, // start.
-			null, // end.
-			false, // exclude.
-			null, // value.
-			true // local.
+			[ T_VARIABLE ],
+			$stackPtr + 1,
+			null,
+			false,
+			null,
+			true
 		);
 
 		if ( ! $wpQueryObjectNamePtr ) {
@@ -228,12 +218,11 @@ class PreGetPostsSniff implements Sniff {
 		$functionBodyScopeEnd   = $this->_tokens[ $stackPtr ]['scope_closer'];
 
 		$wpQueryVarUsed = $this->_phpcsFile->findNext(
-			[ T_VARIABLE ], // types.
-			( $functionBodyScopeStart + 1 ), // start.
-			$functionBodyScopeEnd, // end.
-			false, // exclude.
-			$variableName, // value.
-			false // local.
+			[ T_VARIABLE ],
+			$functionBodyScopeStart + 1,
+			$functionBodyScopeEnd,
+			false,
+			$variableName
 		);
 		while ( $wpQueryVarUsed ) {
 			if ( $this->isPartOfIfConditional( $wpQueryVarUsed ) ) {
@@ -248,12 +237,11 @@ class PreGetPostsSniff implements Sniff {
 				$this->addPreGetPostsWarning( $wpQueryVarUsed );
 			}
 			$wpQueryVarUsed = $this->_phpcsFile->findNext(
-				[ T_VARIABLE ], // types.
-				( $wpQueryVarUsed + 1 ), // start.
-				$functionBodyScopeEnd, // end.
-				false, // exclude.
-				$variableName, // value.
-				false // local.
+				[ T_VARIABLE ],
+				$wpQueryVarUsed + 1,
+				$functionBodyScopeEnd,
+				false,
+				$variableName
 			);
 		}
 	}
@@ -290,24 +278,24 @@ class PreGetPostsSniff implements Sniff {
 		while ( T_IF === $this->_tokens[ $stackPtr ]['conditions'][ $lastConditionStackPtr ] ) {
 
 			$next = $this->_phpcsFile->findNext(
-				[ T_VARIABLE ], // types.
-				( $lastConditionStackPtr + 1 ), // start.
-				null, // end.
-				false, // exclude.
-				$this->_tokens[ $stackPtr ]['content'], // value.
-				true // local.
+				[ T_VARIABLE ],
+				$lastConditionStackPtr + 1,
+				null,
+				false,
+				$this->_tokens[ $stackPtr ]['content'],
+				true
 			);
 			while ( $next ) {
 				if ( true === $this->isWPQueryMethodCall( $next, 'is_main_query' ) ) {
 					return true;
 				}
 				$next = $this->_phpcsFile->findNext(
-					[ T_VARIABLE ], // types.
-					( $next + 1 ), // start.
-					null, // end.
-					false, // exclude.
-					$this->_tokens[ $stackPtr ]['content'], // value.
-					true // local.
+					[ T_VARIABLE ],
+					$next + 1,
+					null,
+					false,
+					$this->_tokens[ $stackPtr ]['content'],
+					true
 				);
 			}
 
@@ -343,12 +331,12 @@ class PreGetPostsSniff implements Sniff {
 		}
 
 		$next = $this->_phpcsFile->findNext(
-			[ T_RETURN ], // types.
-			$this->_tokens[ $this->_tokens[ $nestedParenthesisEnd ]['parenthesis_owner'] ]['scope_opener'], // start.
-			$this->_tokens[ $this->_tokens[ $nestedParenthesisEnd ]['parenthesis_owner'] ]['scope_closer'], // end.
-			false, // exclude.
-			'return', // value.
-			true // local.
+			[ T_RETURN ],
+			$this->_tokens[ $this->_tokens[ $nestedParenthesisEnd ]['parenthesis_owner'] ]['scope_opener'],
+			$this->_tokens[ $this->_tokens[ $nestedParenthesisEnd ]['parenthesis_owner'] ]['scope_closer'],
+			false,
+			'return',
+			true
 		);
 
 		if ( $next ) {
@@ -368,12 +356,12 @@ class PreGetPostsSniff implements Sniff {
 	 */
 	private function isWPQueryMethodCall( $stackPtr, $method = null ) {
 		$next = $this->_phpcsFile->findNext(
-			Tokens::$emptyTokens, // types.
-			$stackPtr + 1, // start.
-			null, // end.
-			true, // exclude.
-			null, // value.
-			true // local.
+			Tokens::$emptyTokens,
+			$stackPtr + 1,
+			null,
+			true,
+			null,
+			true
 		);
 
 		if ( ! $next || 'T_OBJECT_OPERATOR' !== $this->_tokens[ $next ]['type'] ) {
@@ -385,22 +373,15 @@ class PreGetPostsSniff implements Sniff {
 		}
 
 		$next = $this->_phpcsFile->findNext(
-			Tokens::$emptyTokens, // types.
-			$next + 1, // start.
-			null, // end.
-			true, // exclude.
-			null, // value.
-			true // local.
+			Tokens::$emptyTokens,
+			$next + 1,
+			null,
+			true,
+			null,
+			true
 		);
 
-		if ( $next
-			&& true === in_array( $this->_tokens[ $next ]['code'], Tokens::$functionNameTokens, true )
-			&& $method === $this->_tokens[ $next ]['content']
-		) {
-			return true;
-		} else {
-			return false;
-		}
+		return $next && true === in_array( $this->_tokens[ $next ]['code'], Tokens::$functionNameTokens, true ) && $method === $this->_tokens[ $next ]['content'];
 	}
 
 	/**
@@ -410,19 +391,19 @@ class PreGetPostsSniff implements Sniff {
 	 *
 	 * @return bool
 	 */
-	private function isPartofIfConditional( $stackPtr ) {
+	private function isPartOfIfConditional( $stackPtr ) {
 
 		if ( true === array_key_exists( 'nested_parenthesis', $this->_tokens[ $stackPtr ] )
 			&& true === is_array( $this->_tokens[ $stackPtr ]['nested_parenthesis'] )
 			&& false === empty( $this->_tokens[ $stackPtr ]['nested_parenthesis'] )
 		) {
 			$previousLocalIf = $this->_phpcsFile->findPrevious(
-				[ T_IF ], // types.
-				$stackPtr - 1, // start.
-				null, // end.
-				false, // exclude.
-				null, // value.
-				true // local.
+				[ T_IF ],
+				$stackPtr - 1,
+				null,
+				false,
+				null,
+				true
 			);
 			if ( false !== $previousLocalIf
 				&& $this->_tokens[ $previousLocalIf ]['parenthesis_opener'] < $stackPtr

--- a/WordPressVIPMinimum/Sniffs/JS/DangerouslySetInnerHTMLSniff.php
+++ b/WordPressVIPMinimum/Sniffs/JS/DangerouslySetInnerHTMLSniff.php
@@ -23,11 +23,9 @@ class DangerouslySetInnerHTMLSniff implements Sniff {
 	/**
 	 * A list of tokenizers this sniff supports.
 	 *
-	 * @var array
+	 * @var string[]
 	 */
-	public $supportedTokenizers = [
-		'JS',
-	];
+	public $supportedTokenizers = [ 'JS' ];
 
 	/**
 	 * Returns an array of tokens this test wants to listen for.
@@ -56,14 +54,14 @@ class DangerouslySetInnerHTMLSniff implements Sniff {
 			return;
 		}
 
-		$nextToken = $phpcsFile->findNext( Tokens::$emptyTokens, ( $stackPtr + 1 ), null, true, null, true );
+		$nextToken = $phpcsFile->findNext( Tokens::$emptyTokens, $stackPtr + 1, null, true, null, true );
 
 		if ( T_EQUAL !== $tokens[ $nextToken ]['code'] ) {
 			// Not an assignment.
 			return;
 		}
 
-		$nextNextToken = $phpcsFile->findNext( Tokens::$emptyTokens, ( $nextToken + 1 ), null, true, null, true );
+		$nextNextToken = $phpcsFile->findNext( Tokens::$emptyTokens, $nextToken + 1, null, true, null, true );
 
 		if ( T_OBJECT !== $tokens[ $nextNextToken ]['code'] ) {
 			// Not react syntax.

--- a/WordPressVIPMinimum/Sniffs/JS/HTMLExecutingFunctionsSniff.php
+++ b/WordPressVIPMinimum/Sniffs/JS/HTMLExecutingFunctionsSniff.php
@@ -35,11 +35,9 @@ class HTMLExecutingFunctionsSniff implements Sniff {
 	/**
 	 * A list of tokenizers this sniff supports.
 	 *
-	 * @var array
+	 * @var string[]
 	 */
-	public $supportedTokenizers = [
-		'JS',
-	];
+	public $supportedTokenizers = [ 'JS' ];
 
 	/**
 	 * Returns an array of tokens this test wants to listen for.
@@ -68,7 +66,7 @@ class HTMLExecutingFunctionsSniff implements Sniff {
 			return;
 		}
 
-		$nextToken = $phpcsFile->findNext( Tokens::$emptyTokens, ( $stackPtr + 1 ), null, true, null, true );
+		$nextToken = $phpcsFile->findNext( Tokens::$emptyTokens, $stackPtr + 1, null, true, null, true );
 
 		if ( T_OPEN_PARENTHESIS !== $tokens[ $nextToken ]['code'] ) {
 			// Not a function.
@@ -78,7 +76,7 @@ class HTMLExecutingFunctionsSniff implements Sniff {
 		$parenthesis_closer = $tokens[ $nextToken ]['parenthesis_closer'];
 
 		while ( $nextToken < $parenthesis_closer ) {
-			$nextToken = $phpcsFile->findNext( Tokens::$emptyTokens, ( $nextToken + 1 ), null, true, null, true );
+			$nextToken = $phpcsFile->findNext( Tokens::$emptyTokens, $nextToken + 1, null, true, null, true );
 			if ( T_STRING === $tokens[ $nextToken ]['code'] ) {
 				$message = 'Any HTML passed to `%s` gets executed. Make sure it\'s properly escaped.';
 				$data    = [ $tokens[ $stackPtr ]['content'] ];

--- a/WordPressVIPMinimum/Sniffs/JS/InnerHTMLSniff.php
+++ b/WordPressVIPMinimum/Sniffs/JS/InnerHTMLSniff.php
@@ -23,11 +23,9 @@ class InnerHTMLSniff implements Sniff {
 	/**
 	 * A list of tokenizers this sniff supports.
 	 *
-	 * @var array
+	 * @var string[]
 	 */
-	public $supportedTokenizers = [
-		'JS',
-	];
+	public $supportedTokenizers = [ 'JS' ];
 
 	/**
 	 * Returns an array of tokens this test wants to listen for.
@@ -56,20 +54,20 @@ class InnerHTMLSniff implements Sniff {
 			return;
 		}
 
-		$prevToken = $phpcsFile->findPrevious( Tokens::$emptyTokens, ( $stackPtr - 1 ), null, true, null, true );
+		$prevToken = $phpcsFile->findPrevious( Tokens::$emptyTokens, $stackPtr - 1, null, true, null, true );
 
 		if ( T_OBJECT_OPERATOR !== $tokens[ $prevToken ]['code'] ) {
 				return;
 		}
 
-		$nextToken = $phpcsFile->findNext( Tokens::$emptyTokens, ( $stackPtr + 1 ), null, true, null, true );
+		$nextToken = $phpcsFile->findNext( Tokens::$emptyTokens, $stackPtr + 1, null, true, null, true );
 
 		if ( T_EQUAL !== $tokens[ $nextToken ]['code'] ) {
 			// Not an assignment.
 			return;
 		}
 
-		$nextToken     = $phpcsFile->findNext( Tokens::$emptyTokens, ( $nextToken + 1 ), null, true, null, true );
+		$nextToken     = $phpcsFile->findNext( Tokens::$emptyTokens, $nextToken + 1, null, true, null, true );
 		$foundVariable = false;
 
 		while ( false !== $nextToken && T_SEMICOLON !== $tokens[ $nextToken ]['code'] ) {
@@ -79,7 +77,7 @@ class InnerHTMLSniff implements Sniff {
 				break;
 			}
 
-			$nextToken = $phpcsFile->findNext( Tokens::$emptyTokens, ( $nextToken + 1 ), null, true, null, true );
+			$nextToken = $phpcsFile->findNext( Tokens::$emptyTokens, $nextToken + 1, null, true, null, true );
 		}
 
 		if ( true === $foundVariable ) {

--- a/WordPressVIPMinimum/Sniffs/JS/StringConcatSniff.php
+++ b/WordPressVIPMinimum/Sniffs/JS/StringConcatSniff.php
@@ -23,11 +23,9 @@ class StringConcatSniff implements Sniff {
 	/**
 	 * A list of tokenizers this sniff supports.
 	 *
-	 * @var array
+	 * @var string[]
 	 */
-	public $supportedTokenizers = [
-		'JS',
-	];
+	public $supportedTokenizers = [ 'JS' ];
 
 	/**
 	 * Returns an array of tokens this test wants to listen for.
@@ -52,22 +50,18 @@ class StringConcatSniff implements Sniff {
 	public function process( File $phpcsFile, $stackPtr ) {
 		$tokens = $phpcsFile->getTokens();
 
-		$nextToken = $phpcsFile->findNext( Tokens::$emptyTokens, ( $stackPtr + 1 ), null, true, null, true );
+		$nextToken = $phpcsFile->findNext( Tokens::$emptyTokens, $stackPtr + 1, null, true, null, true );
 
-		if ( T_CONSTANT_ENCAPSED_STRING === $tokens[ $nextToken ]['code'] ) {
-			if ( false !== strpos( $tokens[ $nextToken ]['content'], '<' ) && 1 === preg_match( '/\<\/[a-zA-Z]+/', $tokens[ $nextToken ]['content'] ) ) {
-				$data = [ '+' . $tokens[ $nextToken ]['content'] ];
-				$this->addFoundError( $phpcsFile, $stackPtr, $data );
-			}
+		if ( T_CONSTANT_ENCAPSED_STRING === $tokens[ $nextToken ]['code'] && false !== strpos( $tokens[ $nextToken ]['content'], '<' ) && 1 === preg_match( '/\<\/[a-zA-Z]+/', $tokens[ $nextToken ]['content'] ) ) {
+			$data = [ '+' . $tokens[ $nextToken ]['content'] ];
+			$this->addFoundError( $phpcsFile, $stackPtr, $data );
 		}
 
-		$prevToken = $phpcsFile->findPrevious( Tokens::$emptyTokens, ( $stackPtr - 1 ), null, true, null, true );
+		$prevToken = $phpcsFile->findPrevious( Tokens::$emptyTokens, $stackPtr - 1, null, true, null, true );
 
-		if ( T_CONSTANT_ENCAPSED_STRING === $tokens[ $prevToken ]['code'] ) {
-			if ( false !== strpos( $tokens[ $prevToken ]['content'], '<' ) && 1 === preg_match( '/\<[a-zA-Z]+/', $tokens[ $prevToken ]['content'] ) ) {
-				$data = [ $tokens[ $nextToken ]['content'] . '+' ];
-				$this->addFoundError( $phpcsFile, $stackPtr, $data );
-			}
+		if ( T_CONSTANT_ENCAPSED_STRING === $tokens[ $prevToken ]['code'] && false !== strpos( $tokens[ $prevToken ]['content'], '<' ) && 1 === preg_match( '/\<[a-zA-Z]+/', $tokens[ $prevToken ]['content'] ) ) {
+			$data = [ $tokens[ $nextToken ]['content'] . '+' ];
+			$this->addFoundError( $phpcsFile, $stackPtr, $data );
 		}
 	}
 

--- a/WordPressVIPMinimum/Sniffs/JS/StrippingTagsSniff.php
+++ b/WordPressVIPMinimum/Sniffs/JS/StrippingTagsSniff.php
@@ -23,11 +23,9 @@ class StrippingTagsSniff implements Sniff {
 	/**
 	 * A list of tokenizers this sniff supports.
 	 *
-	 * @var array
+	 * @var string[]
 	 */
-	public $supportedTokenizers = [
-		'JS',
-	];
+	public $supportedTokenizers = [ 'JS' ];
 
 	/**
 	 * Returns an array of tokens this test wants to listen for.
@@ -57,20 +55,20 @@ class StrippingTagsSniff implements Sniff {
 			return;
 		}
 
-		$nextToken = $phpcsFile->findNext( Tokens::$emptyTokens, ( $stackPtr + 1 ), null, true, null, true );
+		$nextToken = $phpcsFile->findNext( Tokens::$emptyTokens, $stackPtr + 1, null, true, null, true );
 
 		if ( T_OPEN_PARENTHESIS !== $tokens[ $nextToken ]['code'] ) {
 			// Not a function.
 			return;
 		}
 
-		$afterFunctionCall = $phpcsFile->findNext( Tokens::$emptyTokens, ( $tokens[ $nextToken ]['parenthesis_closer'] + 1 ), null, true, null, true );
+		$afterFunctionCall = $phpcsFile->findNext( Tokens::$emptyTokens, $tokens[ $nextToken ]['parenthesis_closer'] + 1, null, true, null, true );
 
 		if ( T_OBJECT_OPERATOR !== $tokens[ $afterFunctionCall ]['code'] ) {
 			return;
 		}
 
-		$nextToken = $phpcsFile->findNext( Tokens::$emptyTokens, ( $afterFunctionCall + 1 ), null, true, null, true );
+		$nextToken = $phpcsFile->findNext( Tokens::$emptyTokens, $afterFunctionCall + 1, null, true, null, true );
 
 		if ( T_STRING === $tokens[ $nextToken ]['code'] && 'text' === $tokens[ $nextToken ]['content'] ) {
 			$message = 'Vulnerable tag stripping approach detected.';

--- a/WordPressVIPMinimum/Sniffs/JS/WindowSniff.php
+++ b/WordPressVIPMinimum/Sniffs/JS/WindowSniff.php
@@ -23,11 +23,9 @@ class WindowSniff implements Sniff {
 	/**
 	 * A list of tokenizers this sniff supports.
 	 *
-	 * @var array
+	 * @var string[]
 	 */
-	public $supportedTokenizers = [
-		'JS',
-	];
+	public $supportedTokenizers = [ 'JS' ];
 
 	/**
 	 * Returns an array of tokens this test wants to listen for.
@@ -78,14 +76,14 @@ class WindowSniff implements Sniff {
 			return;
 		}
 
-		$nextTokenPtr = $phpcsFile->findNext( Tokens::$emptyTokens, ( $stackPtr + 1 ), null, true, null, true );
+		$nextTokenPtr = $phpcsFile->findNext( Tokens::$emptyTokens, $stackPtr + 1, null, true, null, true );
 		$nextToken    = $tokens[ $nextTokenPtr ]['code'];
 		if ( T_OBJECT_OPERATOR !== $nextToken && T_OPEN_SQUARE_BRACKET !== $nextToken ) {
 			// No . or [' next, bail.
 			return;
 		}
 
-		$nextNextTokenPtr = $phpcsFile->findNext( Tokens::$emptyTokens, ( $nextTokenPtr + 1 ), null, true, null, true );
+		$nextNextTokenPtr = $phpcsFile->findNext( Tokens::$emptyTokens, $nextTokenPtr + 1, null, true, null, true );
 		if ( false === $nextNextTokenPtr ) {
 			// Something went wrong, bail.
 			return;
@@ -97,12 +95,12 @@ class WindowSniff implements Sniff {
 			return;
 		}
 
-		$nextNextNextTokenPtr = $phpcsFile->findNext( array_merge( [ T_CLOSE_SQUARE_BRACKET ], Tokens::$emptyTokens ), ( $nextNextTokenPtr + 1 ), null, true, null, true );
+		$nextNextNextTokenPtr = $phpcsFile->findNext( array_merge( [ T_CLOSE_SQUARE_BRACKET ], Tokens::$emptyTokens ), $nextNextTokenPtr + 1, null, true, null, true );
 		$nextNextNextToken    = $tokens[ $nextNextNextTokenPtr ]['code'];
 
 		$nextNextNextNextToken = false;
 		if ( T_OBJECT_OPERATOR === $nextNextNextToken || T_OPEN_SQUARE_BRACKET === $nextNextNextToken ) {
-			$nextNextNextNextTokenPtr = $phpcsFile->findNext( Tokens::$emptyTokens, ( $nextNextNextTokenPtr + 1 ), null, true, null, true );
+			$nextNextNextNextTokenPtr = $phpcsFile->findNext( Tokens::$emptyTokens, $nextNextNextTokenPtr + 1, null, true, null, true );
 			if ( false === $nextNextNextNextTokenPtr ) {
 				// Something went wrong, bail.
 				return;
@@ -119,7 +117,7 @@ class WindowSniff implements Sniff {
 		$windowProperty .= $nextNextNextNextToken ? $nextNextToken . '.' . $nextNextNextNextToken : $nextNextToken;
 		$data            = [ $windowProperty ];
 
-		$prevTokenPtr = $phpcsFile->findPrevious( Tokens::$emptyTokens, ( $stackPtr - 1 ), null, true, null, true );
+		$prevTokenPtr = $phpcsFile->findPrevious( Tokens::$emptyTokens, $stackPtr - 1, null, true, null, true );
 
 		if ( T_EQUAL === $tokens[ $prevTokenPtr ]['code'] ) {
 			// Variable assignment.

--- a/WordPressVIPMinimum/Sniffs/Performance/BatcacheWhitelistedParamsSniff.php
+++ b/WordPressVIPMinimum/Sniffs/Performance/BatcacheWhitelistedParamsSniff.php
@@ -96,7 +96,7 @@ class BatcacheWhitelistedParamsSniff implements Sniff {
 			return;
 		}
 
-		$key = $phpcsFile->findNext( array_merge( Tokens::$emptyTokens, [ T_OPEN_SQUARE_BRACKET ] ), ( $stackPtr + 1 ), null, true );
+		$key = $phpcsFile->findNext( array_merge( Tokens::$emptyTokens, [ T_OPEN_SQUARE_BRACKET ] ), $stackPtr + 1, null, true );
 
 		if ( T_CONSTANT_ENCAPSED_STRING !== $tokens[ $key ]['code'] ) {
 			return;

--- a/WordPressVIPMinimum/Sniffs/Performance/CacheValueOverrideSniff.php
+++ b/WordPressVIPMinimum/Sniffs/Performance/CacheValueOverrideSniff.php
@@ -85,21 +85,21 @@ class CacheValueOverrideSniff implements Sniff {
 		$variableName  = $variableToken['content'];
 
 		// Find the next non-empty token.
-		$openBracket = $phpcsFile->findNext( Tokens::$emptyTokens, ( $stackPtr + 1 ), null, true );
+		$openBracket = $phpcsFile->findNext( Tokens::$emptyTokens, $stackPtr + 1, null, true );
 
 		// Find the closing bracket.
 		$closeBracket = $tokens[ $openBracket ]['parenthesis_closer'];
 
-		$nextVariableOccurrence = $phpcsFile->findNext( T_VARIABLE, ( $closeBracket + 1 ), null, false, $variableName, false );
+		$nextVariableOccurrence = $phpcsFile->findNext( T_VARIABLE, $closeBracket + 1, null, false, $variableName );
 
-		$rightAfterNextVariableOccurence = $phpcsFile->findNext( Tokens::$emptyTokens, ( $nextVariableOccurrence + 1 ), null, true, null, true );
+		$rightAfterNextVariableOccurence = $phpcsFile->findNext( Tokens::$emptyTokens, $nextVariableOccurrence + 1, null, true, null, true );
 
 		if ( T_EQUAL !== $tokens[ $rightAfterNextVariableOccurence ]['code'] ) {
 			// Not a value override.
 			return;
 		}
 
-		$valueAfterEqualSign = $phpcsFile->findNext( Tokens::$emptyTokens, ( $rightAfterNextVariableOccurence + 1 ), null, true, null, true );
+		$valueAfterEqualSign = $phpcsFile->findNext( Tokens::$emptyTokens, $rightAfterNextVariableOccurence + 1, null, true, null, true );
 
 		if ( T_FALSE === $tokens[ $valueAfterEqualSign ]['code'] ) {
 			$message = 'Obtained cached value in `%s` is being overridden. Disabling caching?';
@@ -125,7 +125,7 @@ class CacheValueOverrideSniff implements Sniff {
 		}
 
 		// Find the next non-empty token.
-		$openBracket = $phpcsFile->findNext( Tokens::$emptyTokens, ( $stackPtr + 1 ), null, true );
+		$openBracket = $phpcsFile->findNext( Tokens::$emptyTokens, $stackPtr + 1, null, true );
 
 		if ( T_OPEN_PARENTHESIS !== $tokens[ $openBracket ]['code'] ) {
 			// Not a function call.
@@ -135,13 +135,10 @@ class CacheValueOverrideSniff implements Sniff {
 		// Find the previous non-empty token.
 		$search   = Tokens::$emptyTokens;
 		$search[] = T_BITWISE_AND;
-		$previous = $phpcsFile->findPrevious( $search, ( $stackPtr - 1 ), null, true );
-		if ( T_FUNCTION === $tokens[ $previous ]['code'] ) {
-			// It's a function definition, not a function call.
-			return false;
-		}
+		$previous = $phpcsFile->findPrevious( $search, $stackPtr - 1, null, true );
 
-		return true;
+		// It's a function definition, not a function call, so return false.
+		return ! ( T_FUNCTION === $tokens[ $previous ]['code'] );
 	}
 
 	/**
@@ -159,14 +156,14 @@ class CacheValueOverrideSniff implements Sniff {
 		// Find the previous non-empty token.
 		$search   = Tokens::$emptyTokens;
 		$search[] = T_BITWISE_AND;
-		$previous = $phpcsFile->findPrevious( $search, ( $stackPtr - 1 ), null, true );
+		$previous = $phpcsFile->findPrevious( $search, $stackPtr - 1, null, true );
 
 		if ( T_EQUAL !== $tokens[ $previous ]['code'] ) {
 			// It's not a variable assignment.
 			return false;
 		}
 
-		$previous = $phpcsFile->findPrevious( $search, ( $previous - 1 ), null, true );
+		$previous = $phpcsFile->findPrevious( $search, $previous - 1, null, true );
 
 		if ( T_VARIABLE !== $tokens[ $previous ]['code'] ) {
 			// It's not a variable assignment.

--- a/WordPressVIPMinimum/Sniffs/Performance/FetchingRemoteDataSniff.php
+++ b/WordPressVIPMinimum/Sniffs/Performance/FetchingRemoteDataSniff.php
@@ -47,7 +47,7 @@ class FetchingRemoteDataSniff implements Sniff {
 
 		$data = [ $tokens[ $stackPtr ]['content'] ];
 
-		$fileNameStackPtr = $phpcsFile->findNext( Tokens::$stringTokens, ( $stackPtr + 1 ), null, false, null, true );
+		$fileNameStackPtr = $phpcsFile->findNext( Tokens::$stringTokens, $stackPtr + 1, null, false, null, true );
 		if ( false === $fileNameStackPtr ) {
 			$message = '`%s()` is highly discouraged for remote requests, please use `wpcom_vip_file_get_contents()` or `vip_safe_wp_remote_get()` instead. If it\'s for a local file please use WP_Filesystem instead.';
 			$phpcsFile->addWarning( $message, $stackPtr, 'FileGetContentsUnknown', $data );

--- a/WordPressVIPMinimum/Sniffs/Performance/LowExpiryCacheTimeSniff.php
+++ b/WordPressVIPMinimum/Sniffs/Performance/LowExpiryCacheTimeSniff.php
@@ -73,7 +73,7 @@ class LowExpiryCacheTimeSniff extends AbstractFunctionParameterSniff {
 
 		if ( false === is_numeric( $time ) ) {
 			// If using time constants, we need to convert to a number.
-			$time = str_replace( array_keys( $this->wp_time_constants ), array_values( $this->wp_time_constants ), $time );
+			$time = str_replace( array_keys( $this->wp_time_constants ), $this->wp_time_constants, $time );
 
 			if ( preg_match( '#^[\s\d+*/-]+$#', $time ) > 0 ) {
 				$time = eval( "return $time;" ); // phpcs:ignore Squiz.PHP.Eval -- No harm here.

--- a/WordPressVIPMinimum/Sniffs/Performance/OrderByRandSniff.php
+++ b/WordPressVIPMinimum/Sniffs/Performance/OrderByRandSniff.php
@@ -51,9 +51,9 @@ class OrderByRandSniff extends AbstractArrayAssignmentRestrictionsSniff {
 	public function callback( $key, $val, $line, $group ) {
 		if ( 'rand' === strtolower( $val ) ) {
 			return 'Detected forbidden query_var "%s" of "%s". Use vip_get_random_posts() instead.';
-		} else {
-			return false;
 		}
+
+		return false;
 	}
 
 }

--- a/WordPressVIPMinimum/Sniffs/Performance/RegexpCompareSniff.php
+++ b/WordPressVIPMinimum/Sniffs/Performance/RegexpCompareSniff.php
@@ -7,12 +7,14 @@
 
 namespace WordPressVIPMinimum\Sniffs\Performance;
 
+use WordPress\AbstractArrayAssignmentRestrictionsSniff;
+
 /**
  * Flag REGEXP and NOT REGEXP in meta compare
  *
  *  @package VIPCS\WordPressVIPMinimum
  */
-class RegexpCompareSniff extends \WordPress\AbstractArrayAssignmentRestrictionsSniff {
+class RegexpCompareSniff extends AbstractArrayAssignmentRestrictionsSniff {
 
 	/**
 	 * Groups of variables to restrict.

--- a/WordPressVIPMinimum/Sniffs/Performance/RemoteRequestTimeoutSniff.php
+++ b/WordPressVIPMinimum/Sniffs/Performance/RemoteRequestTimeoutSniff.php
@@ -7,12 +7,14 @@
 
 namespace WordPressVIPMinimum\Sniffs\Performance;
 
+use WordPress\AbstractArrayAssignmentRestrictionsSniff;
+
 /**
  * Flag REGEXP and NOT REGEXP in meta compare
  *
  * @package VIPCS\WordPressVIPMinimum
  */
-class RemoteRequestTimeoutSniff extends \WordPress\AbstractArrayAssignmentRestrictionsSniff {
+class RemoteRequestTimeoutSniff extends AbstractArrayAssignmentRestrictionsSniff {
 
 	/**
 	 * Groups of variables to restrict.

--- a/WordPressVIPMinimum/Sniffs/Performance/TaxonomyMetaInOptionsSniff.php
+++ b/WordPressVIPMinimum/Sniffs/Performance/TaxonomyMetaInOptionsSniff.php
@@ -71,7 +71,7 @@ class TaxonomyMetaInOptionsSniff implements Sniff {
 			return;
 		}
 
-		$openBracket = $phpcsFile->findNext( Tokens::$emptyTokens, ( $stackPtr + 1 ), null, true );
+		$openBracket = $phpcsFile->findNext( Tokens::$emptyTokens, $stackPtr + 1, null, true );
 
 		if ( T_OPEN_PARENTHESIS !== $tokens[ $openBracket ]['code'] ) {
 			return;
@@ -88,12 +88,12 @@ class TaxonomyMetaInOptionsSniff implements Sniff {
 			}
 		} elseif ( T_CONSTANT_ENCAPSED_STRING === $tokens[ $param_ptr ]['code'] ) {
 
-			$string_concat = $phpcsFile->findNext( Tokens::$emptyTokens, ( $param_ptr + 1 ), null, true );
+			$string_concat = $phpcsFile->findNext( Tokens::$emptyTokens, $param_ptr + 1, null, true );
 			if ( T_STRING_CONCAT !== $tokens[ $string_concat ]['code'] ) {
 				return;
 			}
 
-			$variable_name = $phpcsFile->findNext( Tokens::$emptyTokens, ( $string_concat + 1 ), null, true );
+			$variable_name = $phpcsFile->findNext( Tokens::$emptyTokens, $string_concat + 1, null, true );
 			if ( T_VARIABLE !== $tokens[ $variable_name ]['code'] ) {
 				return;
 			}
@@ -105,12 +105,12 @@ class TaxonomyMetaInOptionsSniff implements Sniff {
 				}
 			}
 
-			$object_operator = $phpcsFile->findNext( Tokens::$emptyTokens, ( $variable_name + 1 ), null, true );
+			$object_operator = $phpcsFile->findNext( Tokens::$emptyTokens, $variable_name + 1, null, true );
 			if ( T_OBJECT_OPERATOR !== $tokens[ $object_operator ]['code'] ) {
 				return;
 			}
 
-			$object_property = $phpcsFile->findNext( Tokens::$emptyTokens, ( $object_operator + 1 ), null, true );
+			$object_property = $phpcsFile->findNext( Tokens::$emptyTokens, $object_operator + 1, null, true );
 			if ( T_STRING !== $tokens[ $object_property ]['code'] ) {
 				return;
 			}

--- a/WordPressVIPMinimum/Sniffs/Performance/WPQueryParamsSniff.php
+++ b/WordPressVIPMinimum/Sniffs/Performance/WPQueryParamsSniff.php
@@ -44,7 +44,7 @@ class WPQueryParamsSniff implements Sniff {
 
 		if ( 'suppress_filters' === trim( $tokens[ $stackPtr ]['content'], '\'' ) ) {
 
-			$next_token = $phpcsFile->findNext( array_merge( Tokens::$emptyTokens, [ T_EQUAL, T_CLOSE_SQUARE_BRACKET, T_DOUBLE_ARROW ] ), ( $stackPtr + 1 ), null, true );
+			$next_token = $phpcsFile->findNext( array_merge( Tokens::$emptyTokens, [ T_EQUAL, T_CLOSE_SQUARE_BRACKET, T_DOUBLE_ARROW ] ), $stackPtr + 1, null, true );
 
 			if ( T_TRUE === $tokens[ $next_token ]['code'] ) {
 				// WordPress.com: https://lobby.vip.wordpress.com/wordpress-com-documentation/uncached-functions/.

--- a/WordPressVIPMinimum/Sniffs/Security/EscapingVoidReturnFunctionsSniff.php
+++ b/WordPressVIPMinimum/Sniffs/Security/EscapingVoidReturnFunctionsSniff.php
@@ -47,14 +47,14 @@ class EscapingVoidReturnFunctionsSniff implements Sniff {
 			return;
 		}
 
-		$next_token = $phpcsFile->findNext( Tokens::$emptyTokens, ( $stackPtr + 1 ), null, true );
+		$next_token = $phpcsFile->findNext( Tokens::$emptyTokens, $stackPtr + 1, null, true );
 
 		if ( T_OPEN_PARENTHESIS !== $tokens[ $next_token ]['code'] ) {
 			// Not a function call.
 			return;
 		}
 
-		$next_token = $phpcsFile->findNext( Tokens::$emptyTokens, ( $next_token + 1 ), null, true );
+		$next_token = $phpcsFile->findNext( Tokens::$emptyTokens, $next_token + 1, null, true );
 
 		if ( T_STRING !== $tokens[ $next_token ]['code'] ) {
 			// Not what we are looking for.

--- a/WordPressVIPMinimum/Sniffs/Security/ExitAfterRedirectSniff.php
+++ b/WordPressVIPMinimum/Sniffs/Security/ExitAfterRedirectSniff.php
@@ -44,13 +44,13 @@ class ExitAfterRedirectSniff implements Sniff {
 			return;
 		}
 
-		$openBracket = $phpcsFile->findNext( Tokens::$emptyTokens, ( $stackPtr + 1 ), null, true );
+		$openBracket = $phpcsFile->findNext( Tokens::$emptyTokens, $stackPtr + 1, null, true );
 
 		if ( T_OPEN_PARENTHESIS !== $tokens[ $openBracket ]['code'] ) {
 			return;
 		}
 
-		$next_token = $phpcsFile->findNext( array_merge( Tokens::$emptyTokens, [ T_SEMICOLON, T_CLOSE_PARENTHESIS ] ), ( $tokens[ $openBracket ]['parenthesis_closer'] + 1 ), null, true );
+		$next_token = $phpcsFile->findNext( array_merge( Tokens::$emptyTokens, [ T_SEMICOLON, T_CLOSE_PARENTHESIS ] ), $tokens[ $openBracket ]['parenthesis_closer'] + 1, null, true );
 
 		$message = '`%s()` should almost always be followed by a call to `exit;`.';
 		$data    = [ $tokens[ $stackPtr ]['content'] ];

--- a/WordPressVIPMinimum/Sniffs/Security/MustacheSniff.php
+++ b/WordPressVIPMinimum/Sniffs/Security/MustacheSniff.php
@@ -21,12 +21,9 @@ class MustacheSniff implements Sniff {
 	/**
 	 * A list of tokenizers this sniff supports.
 	 *
-	 * @var array
+	 * @var string[]
 	 */
-	public $supportedTokenizers = [
-		'JS',
-		'PHP',
-	];
+	public $supportedTokenizers = [ 'JS', 'PHP' ];
 
 	/**
 	 * Returns an array of tokens this test wants to listen for.

--- a/WordPressVIPMinimum/Sniffs/Security/PHPFilterFunctionsSniff.php
+++ b/WordPressVIPMinimum/Sniffs/Security/PHPFilterFunctionsSniff.php
@@ -68,7 +68,7 @@ class PHPFilterFunctionsSniff extends AbstractFunctionParameterSniff {
 				$this->phpcsFile->addWarning( $message, $stackPtr, 'MissingThirdParameter', $data );
 			}
 
-			if ( isset( $parameters[3] ) && isset( $this->restricted_filters[ $parameters[3]['raw'] ] ) ) {
+			if ( isset( $parameters[3], $this->restricted_filters[ $parameters[3]['raw'] ] ) ) {
 				$message = 'Please use an appropriate filter to sanitize, as "%s" does no filtering, see: http://php.net/manual/en/filter.filters.sanitize.php.';
 				$data    = [ strtoupper( $parameters[3]['raw'] ) ];
 				$this->phpcsFile->addWarning( $message, $stackPtr, 'RestrictedFilter', $data );
@@ -80,7 +80,7 @@ class PHPFilterFunctionsSniff extends AbstractFunctionParameterSniff {
 				$this->phpcsFile->addWarning( $message, $stackPtr, 'MissingSecondParameter', $data );
 			}
 
-			if ( isset( $parameters[2] ) && isset( $this->restricted_filters[ $parameters[2]['raw'] ] ) ) {
+			if ( isset( $parameters[2], $this->restricted_filters[ $parameters[2]['raw'] ] ) ) {
 				$message = 'Please use an appropriate filter to sanitize, as "%s" does no filtering, see http://php.net/manual/en/filter.filters.sanitize.php.';
 				$data    = [ strtoupper( $parameters[2]['raw'] ) ];
 				$this->phpcsFile->addWarning( $message, $stackPtr, 'RestrictedFilter', $data );

--- a/WordPressVIPMinimum/Sniffs/Security/ProperEscapingFunctionSniff.php
+++ b/WordPressVIPMinimum/Sniffs/Security/ProperEscapingFunctionSniff.php
@@ -57,24 +57,24 @@ class ProperEscapingFunctionSniff implements Sniff {
 
 		$function_name = $tokens[ $stackPtr ]['content'];
 
-		$echo_or_string_concat = $phpcsFile->findPrevious( Tokens::$emptyTokens, ( $stackPtr - 1 ), null, true );
+		$echo_or_string_concat = $phpcsFile->findPrevious( Tokens::$emptyTokens, $stackPtr - 1, null, true );
 
 		if ( T_ECHO === $tokens[ $echo_or_string_concat ]['code'] ) {
 			// Very likely inline HTML with <?php tag.
-			$php_open = $phpcsFile->findPrevious( Tokens::$emptyTokens, ( $echo_or_string_concat - 1 ), null, true );
+			$php_open = $phpcsFile->findPrevious( Tokens::$emptyTokens, $echo_or_string_concat - 1, null, true );
 
 			if ( T_OPEN_TAG !== $tokens[ $php_open ]['code'] ) {
 				return;
 			}
 
-			$html = $phpcsFile->findPrevious( Tokens::$emptyTokens, ( $php_open - 1 ), null, true );
+			$html = $phpcsFile->findPrevious( Tokens::$emptyTokens, $php_open - 1, null, true );
 
 			if ( T_INLINE_HTML !== $tokens[ $html ]['code'] ) {
 				return;
 			}
 		} elseif ( T_STRING_CONCAT === $tokens[ $echo_or_string_concat ]['code'] ) {
 			// Very likely string concatenation mixing strings and functions/variables.
-			$html = $phpcsFile->findPrevious( Tokens::$emptyTokens, ( $echo_or_string_concat - 1 ), null, true );
+			$html = $phpcsFile->findPrevious( Tokens::$emptyTokens, $echo_or_string_concat - 1, null, true );
 
 			if ( T_CONSTANT_ENCAPSED_STRING !== $tokens[ $html ]['code'] ) {
 				return;

--- a/WordPressVIPMinimum/Sniffs/Security/StaticStrreplaceSniff.php
+++ b/WordPressVIPMinimum/Sniffs/Security/StaticStrreplaceSniff.php
@@ -44,7 +44,7 @@ class StaticStrreplaceSniff implements Sniff {
 			return;
 		}
 
-		$openBracket = $phpcsFile->findNext( Tokens::$emptyTokens, ( $stackPtr + 1 ), null, true );
+		$openBracket = $phpcsFile->findNext( Tokens::$emptyTokens, $stackPtr + 1, null, true );
 
 		if ( T_OPEN_PARENTHESIS !== $tokens[ $openBracket ]['code'] ) {
 			return;
@@ -55,7 +55,7 @@ class StaticStrreplaceSniff implements Sniff {
 			$param_ptr = $phpcsFile->findNext( array_merge( Tokens::$emptyTokens, [ T_COMMA ] ), $next_start_ptr, null, true );
 
 			if ( T_ARRAY === $tokens[ $param_ptr ]['code'] ) {
-				$openBracket = $phpcsFile->findNext( Tokens::$emptyTokens, ( $param_ptr + 1 ), null, true );
+				$openBracket = $phpcsFile->findNext( Tokens::$emptyTokens, $param_ptr + 1, null, true );
 				if ( T_OPEN_PARENTHESIS !== $tokens[ $openBracket ]['code'] ) {
 					return;
 				}
@@ -63,19 +63,21 @@ class StaticStrreplaceSniff implements Sniff {
 				// Find the closing bracket.
 				$closeBracket = $tokens[ $openBracket ]['parenthesis_closer'];
 
-				$array_item_ptr = $phpcsFile->findNext( array_merge( Tokens::$emptyTokens, [ T_COMMA ] ), ( $openBracket + 1 ), $closeBracket, true );
+				$array_item_ptr = $phpcsFile->findNext( array_merge( Tokens::$emptyTokens, [ T_COMMA ] ), $openBracket + 1, $closeBracket, true );
 				while ( false !== $array_item_ptr ) {
 
 					if ( T_CONSTANT_ENCAPSED_STRING !== $tokens[ $array_item_ptr ]['code'] ) {
 						return;
 					}
-					$array_item_ptr = $phpcsFile->findNext( array_merge( Tokens::$emptyTokens, [ T_COMMA ] ), ( $array_item_ptr + 1 ), $closeBracket, true );
+					$array_item_ptr = $phpcsFile->findNext( array_merge( Tokens::$emptyTokens, [ T_COMMA ] ), $array_item_ptr + 1, $closeBracket, true );
 				}
 
 				$next_start_ptr = $closeBracket + 1;
 				continue;
 
-			} elseif ( T_CONSTANT_ENCAPSED_STRING !== $tokens[ $param_ptr ]['code'] ) {
+			}
+
+			if ( T_CONSTANT_ENCAPSED_STRING !== $tokens[ $param_ptr ]['code'] ) {
 				return;
 			}
 

--- a/WordPressVIPMinimum/Sniffs/Security/TwigSniff.php
+++ b/WordPressVIPMinimum/Sniffs/Security/TwigSniff.php
@@ -21,12 +21,9 @@ class TwigSniff implements Sniff {
 	/**
 	 * A list of tokenizers this sniff supports.
 	 *
-	 * @var array
+	 * @var string[]
 	 */
-	public $supportedTokenizers = [
-		'JS',
-		'PHP',
-	];
+	public $supportedTokenizers = [ 'JS', 'PHP' ];
 
 	/**
 	 * Returns an array of tokens this test wants to listen for.

--- a/WordPressVIPMinimum/Sniffs/Security/UnderscorejsSniff.php
+++ b/WordPressVIPMinimum/Sniffs/Security/UnderscorejsSniff.php
@@ -21,12 +21,9 @@ class UnderscorejsSniff implements Sniff {
 	/**
 	 * A list of tokenizers this sniff supports.
 	 *
-	 * @var array
+	 * @var string[]
 	 */
-	public $supportedTokenizers = [
-		'JS',
-		'PHP',
-	];
+	public $supportedTokenizers = [ 'JS', 'PHP' ];
 
 	/**
 	 * Returns an array of tokens this test wants to listen for.

--- a/WordPressVIPMinimum/Sniffs/Security/VuejsSniff.php
+++ b/WordPressVIPMinimum/Sniffs/Security/VuejsSniff.php
@@ -21,12 +21,9 @@ class VuejsSniff implements Sniff {
 	/**
 	 * A list of tokenizers this sniff supports.
 	 *
-	 * @var array
+	 * @var string[]
 	 */
-	public $supportedTokenizers = [
-		'JS',
-		'PHP',
-	];
+	public $supportedTokenizers = [ 'JS', 'PHP' ];
 
 	/**
 	 * Returns an array of tokens this test wants to listen for.

--- a/WordPressVIPMinimum/Sniffs/Variables/ServerVariablesSniff.php
+++ b/WordPressVIPMinimum/Sniffs/Variables/ServerVariablesSniff.php
@@ -63,7 +63,7 @@ class ServerVariablesSniff implements Sniff {
 			return;
 		}
 
-		$variableNamePtr = $phpcsFile->findNext( [ T_CONSTANT_ENCAPSED_STRING ], ( $stackPtr + 1 ), null, false, null, true );
+		$variableNamePtr = $phpcsFile->findNext( [ T_CONSTANT_ENCAPSED_STRING ], $stackPtr + 1, null, false, null, true );
 		$variableName    = str_replace( [ "'", '"' ], '', $tokens[ $variableNamePtr ]['content'] );
 
 		if ( isset( $this->restrictedVariables['authVariables'][ $variableName ] ) ) {

--- a/WordPressVIPMinimum/Sniffs/Variables/VariableAnalysisHelper.php
+++ b/WordPressVIPMinimum/Sniffs/Variables/VariableAnalysisHelper.php
@@ -30,7 +30,7 @@ class ScopeInfo {
     public $closer;
     public $variables = array();
 
-    function __construct( $currScope ) {
+    public function __construct( $currScope ) {
         $this->owner = $currScope;
         // TODO: extract opener/closer
     }
@@ -58,7 +58,7 @@ class VariableInfo {
     public $firstRead;
     public $ignoreUnused = false;
 
-    static $scopeTypeDescriptions = array(
+    public static $scopeTypeDescriptions = array(
         'local'  => 'variable',
         'param'  => 'function parameter',
         'static' => 'static variable',
@@ -66,7 +66,7 @@ class VariableInfo {
         'bound'  => 'bound variable',
     );
 
-    function __construct( $varName ) {
+    public function __construct( $varName ) {
         $this->name = $varName;
     }
 }

--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -37,9 +37,7 @@ if ( false !== $phpcsDir && file_exists( $phpcsDir . $ds . 'autoload.php' ) ) {
 	 * As of PHPCS 3.1, PHPCS supports PHPUnit 6.x and above, but needs a bootstrap,
 	 * so load it if it's available.
 	 */
-	if ( file_exists( $phpcsDir . $ds . 'tests' . $ds . 'bootstrap.php' ) ) {
-		require_once $phpcsDir . $ds . 'tests' . $ds . 'bootstrap.php';
-	}
+	require_once $phpcsDir . $ds . 'tests' . $ds . 'bootstrap.php';
 } else {
 	echo 'Uh oh... can\'t find PHPCS. Are you sure you are using PHPCS 3.x ?
 


### PR DESCRIPTION
- Add strict comparisons
- Added missing scope keywords
- Added parentheses to clarify one specific conditional
- Consolidate multiple `isset()` calls
- Consolidate positive nested `if()`’s
- Fix difference in case for function calls
- Simplify return statements
- Switch to __DIR__
- Switched FQCN to import statements
- Use static property
- Use more performant `strpos()` instead of `substr()`
- Split or remove `else` / `elseif` workflows for lower complexity and more comprehension
- Remove misuse of `array_push()`
- Remove misuse of `array_values()`
- Remove misuse of `in_array()`
- Remove useless `return`
- Remove redundant `continue`
- Removed comments that were naming parameters
- Remove default assignments of `null` to class properties
- Remove function parameters that match default arg values
- Remove redundant parentheses

This should be the bulk of the inspections now completed, so marking this as fixes #394.