### PR TITLE
Travis: Restrict PHPUnit versions to match PHPCS

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -22,7 +22,7 @@
 	"require-dev": {
 		"dealerdirect/phpcodesniffer-composer-installer": "^0.5",
 		"phpcompatibility/php-compatibility": "^9",
-		"phpunit/phpunit": "*"
+		"phpunit/phpunit": "^5 || ^6 || ^7"
 	},
 	"suggest": {
 		"dealerdirect/phpcodesniffer-composer-installer": "^0.5 || This Composer plugin will sort out the PHPCS 'installed_paths' automatically."


### PR DESCRIPTION
PHPCS [supports](https://github.com/squizlabs/PHP_CodeSniffer/blob/49a3e26aa3aa042fece78b0061ba46ccc5f51e76/composer.json#L34) up to PHPUnit 7, but VIPCS was [pulling in `*`](https://github.com/Automattic/VIP-Coding-Standards/blob/5a581766b5c7c2a6e0120e6f94723c6f85a02e20/composer.json#L25), which at this time resolves to 8.0.1.

This caused an error in Travis jobs for PHP 7.2, 7.3 and nightly:

> PHP Fatal error:  Declaration of PHP_CodeSniffer\Tests\Core\File\FindEndOfStatementTest::setUp() must be compatible with PHPUnit\Framework\TestCase::setUp(): void in /home/travis/build/Automattic/VIP-Coding-Standards/vendor/squizlabs/php_codesniffer/tests/Core/File/FindEndOfStatementTest.php on line 203

[PHPUnit 8.0 dropped support for PHP 7.1](https://github.com/sebastianbergmann/phpunit/blob/master/ChangeLog-8.0.md), so the PHP 7.2 and PHP 7.3 Travis jobs installs 8.0.1, while the [jobs with older versions of PHP install PHPUnit 7.5.3](https://travis-ci.org/Automattic/VIP-Coding-Standards/jobs/488751914#L555) or earlier.

As a comparison, see the addition of the return type declaration in PHPUnit 8:

- PHPUnit [7.5.3](https://github.com/sebastianbergmann/phpunit/blob/7.5.3/src/Framework/TestCase.php#L407)  (and notice the comment)
- PHPUnit [8.0.0](https://github.com/sebastianbergmann/phpunit/blob/8.0.0/src/Framework/TestCase.php#L408) 

By setting a constraint on which PHPUnit versions we allow, we ensure compatibility with the version of PHPUnit that PHPCS supports.