### PR TITLE
Travis: Remove sudo: false

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,3 @@
-sudo: false
-
 dist: trusty
 
 cache:


### PR DESCRIPTION
Switch from _Container-Based Builds_ to _Virtual-Machine-Based_

----
Via: https://blog.travis-ci.com/2018-11-19-required-linux-infrastructure-migration

Over the next few weeks, we encourage everyone to remove any `sudo: false` configurations from your `.travis.yml`. Soon we will run all projects on the virtual-machine-based infrastructure, the `sudo` keyword will be fully deprecated.

The timeline for this migration will be as follows:

- 19 November, 2018 - Today we publish this post and are ready to [answer all your questions](https://travis-ci.community/t/combining-the-linux-infrastructures/310/3)!
- 28 November, 2018 - We will send a service email to remind folks still using `sudo: false` on recent builds to remind you to migrate.
- 03 December, 2018 - We will start randomly sampling projects on both travis-ci.org and travis-ci.com to move them permanently to using the virtual-machine-based infrastructure for all builds. The projects will be migrated incrementally over a few days
- 07 December, 2018 - All projects that use a Linux build environment will be fully migrated to using the same Linux infrastructure, which runs builds in virtual-machines.

----

Based on the timeline in the blog post, the `sudo: false` doesn't do anything now anyway.