### PR TITLE
Travis: Use "7.4snapshot" instead of nightly

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -44,7 +44,7 @@ stages:
 
 jobs:
   allow_failures:
-    - php: nightly
+    - php: "7.4snapshot"
   fast_finish: true
   include:
 
@@ -119,5 +119,5 @@ jobs:
       env: PHPCS_BRANCH="dev-master"
 
     - stage: test
-      php: nightly
+      php: "7.4snapshot"
       env: PHPCS_BRANCH="dev-master"


### PR DESCRIPTION
`nightly` means the PHP 8 dev branch, which phpcodesniffer-composer-installer does not support yet, but we can force a check on the 7.4 development branch with "7.4snapshot".