### PR TITLE
Travis improvements

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,3 @@
-sudo: false
-
 dist: trusty
 
 cache:

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,4 @@
-dist: trusty
+dist: xenial
 
 cache:
   directories:

--- a/.travis.yml
+++ b/.travis.yml
@@ -42,7 +42,7 @@ stages:
 
 jobs:
   allow_failures:
-    - php: nightly
+    - php: "7.4snapshot"
   fast_finish: true
   include:
 
@@ -117,5 +117,5 @@ jobs:
       env: PHPCS_BRANCH="dev-master"
 
     - stage: test
-      php: nightly
+      php: "7.4snapshot"
       env: PHPCS_BRANCH="dev-master"


### PR DESCRIPTION
## Remove `sudo: false`

Switch from _Container-Based Builds_ to _Virtual-Machine-Based_.

Travis: Remove sudo: false  …
Switch from _Container-Based Builds_ to _Virtual-Machine-Based_.

----
Via: blog.travis-ci.com/2018-11-19-required-linux-infrastructure-migration

Over the next few weeks, we encourage everyone to remove any `sudo: false` configurations from your `.travis.yml`. Soon we will run all projects on the virtual-machine-based infrastructure, the `sudo` keyword will be fully deprecated.

The timeline for this migration will be as follows:

- 19 November, 2018 - Today we publish this post and are ready to [answer all your questions](travis-ci.community/t/combining-the-linux-infrastructures/310/3)!
- 28 November, 2018 - We will send a service email to remind folks still using `sudo: false` on recent builds to remind you to migrate.
- 03 December, 2018 - We will start randomly sampling projects on both travis-ci.org and travis-ci.com to move them permanently to using the virtual-machine-based infrastructure for all builds. The projects will be migrated incrementally over a few days
- 07 December, 2018 - All projects that use a Linux build environment will be fully migrated to using the same Linux infrastructure, which runs builds in virtual-machines.

----

With Travis CI plans to remove the `sudo` keyword from configurations we should seek to ensure builds will continue to build as expected using the new virtual machine infrastructure.

## Use "7.4snapshot" instead of nightly
`nightly` means the PHP 8 dev branch, which `phpcodesniffer-composer-installer` does not support yet, but we can force a check on the 7.4 development branch with "7.4snapshot".

## Switch from Trusty to Xenial distribution
For the differences between the distributions, see https://docs.travis-ci.com/user/reference/xenial. Should be quicker boot time, and newer PHP versions pre-installed.