### PR TITLE
WIP: Silence Short Echo Tag on VIP Go

### DIFF
--- a/WordPress-VIP-Go/ruleset.xml
+++ b/WordPress-VIP-Go/ruleset.xml
@@ -283,5 +283,8 @@
 	<rule ref="WordPressVIPMinimum.Functions.RestrictedFunctions.site_option_add_site_option">
 		<severity>0</severity>
 	</rule>
+	<rule ref="Generic.PHP.DisallowShortOpenTag.EchoFound">
+		<severity>0</severity>
+	</rule>
 
 </ruleset>


### PR DESCRIPTION
Short echo tags `<?=` has been constantly on since PHP 5.4. There is no fundamental reason why these should be disallowed.

This still forbids them for `WordPressVIPMinimum`, and it still forbids short open tags `<?` for both platforms.

I'd be open in removing them for `WordPressVIPMinimum` as well if needed.

WIP, since it needs ruleset tests to be updated.