### PR TITLE
Fix undefined variable: tokens

### DIFF
--- a/WordPressVIPMinimum/Sniffs/Variables/VariableAnalysisSniff.php
+++ b/WordPressVIPMinimum/Sniffs/Variables/VariableAnalysisSniff.php
@@ -785,7 +785,7 @@ class VariableAnalysisSniff extends Sniff {
 		// TODO: not sure this is our business or should be some other sniff.
 		if ( ( $this->tokens[$classNamePtr]['code'] === T_SELF ) ||
 			( $this->tokens[$classNamePtr]['code'] === T_STATIC ) ) {
-			if ( $tokens[$classNamePtr]['code'] === T_SELF ) {
+			if ( $this->tokens[$classNamePtr]['code'] === T_SELF ) {
 				$err_prefix = 'Self';
 				$err_desc  = 'self::';
 			} else {


### PR DESCRIPTION
When performing a refactor of the sniffs here - 60283aa - it appears that one $tokens variable was not updated to $this->tokens.

Hat-tip to @kjbenk for reporting it.

Fixes #389.