### PR TITLE
Ruleset test: Fix bug where it doesn't catch proper number of errors/warnings on a line basis

### DIFF
--- a/tests/RulesetTest.php
+++ b/tests/RulesetTest.php
@@ -188,7 +188,7 @@ class RulesetTest {
 	 * @param int $line Line number.
 	 */
 	private function add_error_for_line( $line ) {
-		$this->errors[ $line ] = isset( $this->errors[ $line ] ) ? $this->errors[ $line ]++ : 1;
+		$this->errors[ $line ] = isset( $this->errors[ $line ] ) ? ++$this->errors[ $line ] : 1;
 	}
 
 	/**
@@ -197,7 +197,7 @@ class RulesetTest {
 	 * @param int $line Line number.
 	 */
 	private function add_warning_for_line( $line ) {
-		$this->warnings[ $line ] = isset( $this->warnings[ $line ] ) ? $this->warnings[ $line ]++ : 1;
+		$this->warnings[ $line ] = isset( $this->warnings[ $line ] ) ? ++$this->warnings[ $line ] : 1;
 	}
 
 	/**


### PR DESCRIPTION
## Example:

We expect two errors on line 2 of the code block below:

```
if ( isset( $_POST['nonce'] ) && wp_verify_nonce( sanitize_text_field( $_POST['nonce'] ) ) ) {
	bar( $_POST['foo2'] ); // Error x 2.
	$foo2 = isset( $_POST['foo2'] ) ?? foo( sanitize_text_field( $_POST['foo2'] ) ); // Ok - exclude WordPress.Security.ValidatedSanitizedInput.MissingUnslash.
}
```

But it doesn't find it in ruletest:

```
Expected 2 errors, found 1 on line 2.
```

This is because we are incrementing after assignment and thus, we lose the true value since it continues to be overwritten and it stays at `1` forever.  

We should increment prior to assignment.