### PR TITLE
Remove a WordPress-Extra exclusion

### DIFF
--- a/.phpcs.xml.dist
+++ b/.phpcs.xml.dist
@@ -16,7 +16,6 @@
 	<rule ref="WordPress-Extra">
 		<exclude name="WordPress.Files.FileName"/>
 		<exclude name="WordPress.NamingConventions.ValidVariableName"/>
-		<exclude name="WordPress.CodeAnalysis.AssignmentInCondition.FoundInWhileCondition"/>
 	</rule>
 
 	<rule ref="WordPress-Docs"/>


### PR DESCRIPTION
The PHPCS check of our VIPCS code passes without needing the exclusion of the `WordPress.CodeAnalysis.AssignmentInCondition.FoundInWhileCondition` check.