### PR TITLE
wp_remote_get: expand on message

### DIFF
--- a/WordPressVIPMinimum/Sniffs/Functions/RestrictedFunctionsSniff.php
+++ b/WordPressVIPMinimum/Sniffs/Functions/RestrictedFunctionsSniff.php
@@ -295,7 +295,7 @@ class RestrictedFunctionsSniff extends AbstractFunctionRestrictionsSniff {
 			// @link VIP Go: https://wpvip.com/documentation/vip-go/code-review-blockers-warnings-notices/#remote-calls
 			'wp_remote_get' => [
 				'type'      => 'warning',
-				'message'   => '%s() is highly discouraged, please use vip_safe_wp_remote_get() instead.',
+				'message'   => '%s() is highly discouraged. Please use vip_safe_wp_remote_get() instead which is designed to more gracefully handle failure than wp_remote_get() does.',
 				'functions' => [
 					'wp_remote_get',
 				],


### PR DESCRIPTION
Encourage developers to switch to the VIP version of the function by telling them a benefit.

Message pulled from [here](https://github.com/Automattic/vip-go-mu-plugins/blob/50c25c02753d7ba46a168b5206775cdecfcade57/vip-helpers/vip-utils.php#L721).

Fixes #436.