### PR TITLE
append: Remove error for use of append in VIP Go

### DIFF
--- a/WordPress-VIP-Go/ruleset.xml
+++ b/WordPress-VIP-Go/ruleset.xml
@@ -112,9 +112,6 @@
 		<type>warning</type>
 		<message>File system operations only work on the `/tmp/` and `wp-content/uploads/` directories. To avoid unexpected results, please use helper functions like `get_temp_dir()`  or `wp_get_upload_dir()` to get the proper directory path when using functions such as %s(). For more details, please see: https://wpvip.com/documentation/vip-go/writing-files-on-vip-go/</message>
 	</rule>
-	<rule ref="WordPressVIPMinimum.JS.HTMLExecutingFunctions.append">
-		<type>error</type>
-	</rule>
 	<rule ref="WordPressVIPMinimum.Performance.FetchingRemoteData.FileGetContentsUnknown">
 		<type>warning</type>
 		<message>%s() is uncached. If the function is being used to fetch a remote file (e.g. a URL starting with https://), please use wpcom_vip_file_get_contents() to ensure the results are cached. For more details, please see https://wpvip.com/documentation/vip-go/fetching-remote-data/</message>


### PR DESCRIPTION
It's not clear why this violation is marked as an Error for VIP Go ruleset, when none of the other HTMLExecutingFunctions are left as their default of Warnings.

Since the best the Sniff can do is provide warnings when a variable is used (though that variable may already be safe, and not contain user input), then it would seem odd to change just one function call to an Error for VIP Go.