### PR TITLE
Add get_page_by_path() warning to VIP restricted function sniffs.

### DIFF
--- a/WordPressVIPMinimum/Sniffs/Functions/RestrictedFunctionsSniff.php
+++ b/WordPressVIPMinimum/Sniffs/Functions/RestrictedFunctionsSniff.php
@@ -326,6 +326,13 @@ class RestrictedFunctionsSniff extends AbstractFunctionRestrictionsSniff {
 					'create_function',
 				],
 			],
+			'get_page_by_path' => [
+				'type'      => 'warning',
+				'message'   => '%s() is highly discouraged due to not being cached; please use wpcom_vip_get_page_by_path() instead.',
+				'functions' => [
+					'get_page_by_path',
+				],
+			],
 		];
 
 		$deprecated_vip_helpers = [

--- a/WordPressVIPMinimum/Tests/Functions/RestrictedFunctionsUnitTest.inc
+++ b/WordPressVIPMinimum/Tests/Functions/RestrictedFunctionsUnitTest.inc
@@ -221,3 +221,6 @@ update_site_option(  $bar, 'foo' ); // Warning.
 update_option( 'foo', $bar ); // Ok.
 delete_site_option( $foo   ); // Warning.
 delete_option(  $bar ); // Ok.
+
+wpcom_vip_get_page_by_path(); // Ok - VIP recommended version of get_page_by_path().
+get_page_by_path( $page_path ); // Warning.

--- a/WordPressVIPMinimum/Tests/Functions/RestrictedFunctionsUnitTest.php
+++ b/WordPressVIPMinimum/Tests/Functions/RestrictedFunctionsUnitTest.php
@@ -133,6 +133,7 @@ class RestrictedFunctionsUnitTest extends AbstractSniffUnitTest {
 			138 => 1,
 			139 => 1,
 			208 => 1,
+			226 => 1,
 		];
 	}
 


### PR DESCRIPTION
On VIP there is an alternative which should be used for caching
`wpcom_vip_get_page_by_path()` make developers aware of this by warning
of usage of `get_page_by_path()`.