### PR TITLE
Use new sniff WordPress.DateTime.RestrictedFunctions

### DIFF
--- a/WordPressVIPMinimum/ruleset-test.inc
+++ b/WordPressVIPMinimum/ruleset-test.inc
@@ -41,7 +41,7 @@ $args = array(
 _query_posts( 'posts_per_page=999' ); // Warning.
 $query_args['posts_per_page'] = 999; // Warning.
 
-// WordPress.WP.TimezoneChange
+// WordPress.DateTime.RestrictedFunctions
 date_default_timezone_set( 'FooBar' ); // Error.
 
 // WordPress.DB.PreparedSQL

--- a/WordPressVIPMinimum/ruleset.xml
+++ b/WordPressVIPMinimum/ruleset.xml
@@ -26,7 +26,7 @@
 	<rule ref="WordPress.PHP.IniSet"/>
 	<rule ref="WordPress.WP.EnqueuedResources"/>
 	<rule ref="WordPress.WP.PostsPerPage"/>
-	<rule ref="WordPress.WP.TimezoneChange"/>
+	<rule ref="WordPress.DateTime.RestrictedFunctions"/>
 	<rule ref="WordPress.DB.PreparedSQL"/>
 	<rule ref="WordPress.DB.DirectDatabaseQuery"/>
 	<rule ref="WordPress.DB.SlowDBQuery"/>


### PR DESCRIPTION
Note that `composer test` was failing for me on the `master` branch locally due to some issues unrelated to the code here, so I'd expect that there is some other work that needs to be done to fix the tests. When I ran the tests individually, the short array syntax sniff was flagging also, which is likewise unrelated to the changes in this PR.