### PR TITLE
Allow for short array syntax

### DIFF
--- a/.phpcs.xml.dist
+++ b/.phpcs.xml.dist
@@ -34,6 +34,11 @@
 	<!-- Disallow long array syntax -->
 	<rule ref="Generic.Arrays.DisallowLongArraySyntax"/>
 
+	<!-- Allow short array syntax -->
+	<rule ref="Generic.Arrays.DisallowShortArraySyntax.Found">
+		<exclude name="Generic.Arrays.DisallowShortArraySyntax.Found"/>
+	</rule>
+
 	<!-- Check code for cross-version PHP compatibility. -->
 	<config name="testVersion" value="5.6-"/>
 	<rule ref="PHPCompatibility">

--- a/WordPressVIPMinimum/Sniffs/Functions/DynamicCallsSniff.php
+++ b/WordPressVIPMinimum/Sniffs/Functions/DynamicCallsSniff.php
@@ -106,9 +106,7 @@ class DynamicCallsSniff extends Sniff {
 			return;
 		}
 
-		$current_var_name = $this->tokens[
-			$this->stackPtr
-		]['content'];
+		$current_var_name = $this->tokens[ $this->stackPtr ]['content'];
 
 		/*
 		 * Find assignments ( $foo = "bar"; )
@@ -202,9 +200,7 @@ class DynamicCallsSniff extends Sniff {
 		 */
 
 		if ( ! isset(
-			$this->variables_arr[
-				$this->tokens[ $this->stackPtr ]['content']
-			]
+			$this->variables_arr[ $this->tokens[ $this->stackPtr ]['content'] ]
 		) ) {
 			return;
 		}
@@ -220,16 +216,12 @@ class DynamicCallsSniff extends Sniff {
 			$i++;
 		} while (
 			'T_WHITESPACE' ===
-				$this->tokens[
-					$this->stackPtr + $i
-				]['type']
+				$this->tokens[ $this->stackPtr + $i ]['type']
 		);
 
 		if (
 			'T_OPEN_PARENTHESIS' !==
-				$this->tokens[
-					$this->stackPtr + $i
-				]['type']
+				$this->tokens[ $this->stackPtr + $i ]['type']
 		) {
 			return;
 		}
@@ -242,9 +234,7 @@ class DynamicCallsSniff extends Sniff {
 		 */
 
 		if ( ! in_array(
-			$this->variables_arr[
-				$this->tokens[ $this->stackPtr ]['content']
-			],
+			$this->variables_arr[ $this->tokens[ $this->stackPtr ]['content'] ],
 			$this->blacklisted_functions,
 			true
 		) ) {


### PR DESCRIPTION
[Tests are currently failing](https://travis-ci.org/Automattic/VIP-Coding-Standards/jobs/615177473?utm_medium=notification&utm_source=github_status) because of the rule `Generic.Arrays.DisallowShortArraySyntax.Found` and it looks like the formatting in `DynamicCallsSniff` is also failing tests for `WordPress.Arrays.ArrayKeySpacingRestrictions.TooMuchSpaceAfterKey`.