### PR TITLE
Dependencies: Update versions

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,7 +6,7 @@ env:
   # `master` is now 3.x.
   - PHPCS_BRANCH="dev-master"
   # Lowest supported release in the 3.x series with which VIPCS is compatible.
-  - PHPCS_BRANCH="3.3.1"
+  - PHPCS_BRANCH="3.5.5"
 
 cache:
   directories:

--- a/composer.json
+++ b/composer.json
@@ -16,16 +16,16 @@
 	],
 	"require": {
 		"php": ">=5.6",
-		"squizlabs/php_codesniffer": "^3.3.1",
-		"wp-coding-standards/wpcs": "^2.1"
+		"squizlabs/php_codesniffer": "^3.5.5",
+		"wp-coding-standards/wpcs": "^2.3"
 	},
 	"require-dev": {
-		"dealerdirect/phpcodesniffer-composer-installer": "^0.5",
+		"dealerdirect/phpcodesniffer-composer-installer": "^0.7",
 		"phpcompatibility/php-compatibility": "^9",
 		"phpunit/phpunit": "^5 || ^6 || ^7"
 	},
 	"suggest": {
-		"dealerdirect/phpcodesniffer-composer-installer": "^0.5 || This Composer plugin will sort out the PHPCS 'installed_paths' automatically."
+		"dealerdirect/phpcodesniffer-composer-installer": "^0.7 || This Composer plugin will manage the PHPCS 'installed_paths' automatically."
 	},
 	"minimum-stability": "RC",
 	"scripts": {


### PR DESCRIPTION
[WPCS 2.3.0](https://github.com/WordPress/WordPress-Coding-Standards/releases/tag/2.3.0) and [PHPCS 3.5.5](https://github.com/squizlabs/PHP_CodeSniffer/releases/tag/3.5.5) have been out for a little while.

The Composer plugin has only been out a week, but has tested fine, and is a development dependency only anyway (until WPCS 3.0.0 is pulled in).