### PR TITLE
Travis: Use PHPUnit 7 with PHP 8

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -62,7 +62,7 @@ jobs:
       php: 7.3
       env: PHPCS_BRANCH="dev-master"
       before_install: phpenv config-rm xdebug.ini || echo 'No xdebug config.'
-      install: composer install --dev --no-suggest
+      install: composer install --no-suggest
       script:
         # Run PHPCS against VIPCS.
         - ./bin/phpcs
@@ -82,11 +82,14 @@ before_install:
     fi
 
 install:
-  - composer require squizlabs/php_codesniffer:"$PHPCS_BRANCH" --update-no-dev --no-suggest --no-scripts
+  - composer require squizlabs/php_codesniffer:"$PHPCS_BRANCH" --no-update --no-suggest --no-scripts
   - |
-    # Don't need dev dependencies for running `php -l`.
-    if [[ "$TRAVIS_BUILD_STAGE_NAME" != "Lint" ]]; then
-      composer install --dev --no-suggest
+    if [[ $TRAVIS_PHP_VERSION == "nightly" ]]; then
+        # PHPUnit 7.x does not allow for installation on PHP 8, so ignore platform
+        # requirements to get PHPUnit 7.x to install on nightly.
+        composer install --ignore-platform-reqs --no-suggest
+    else
+      composer install --no-suggest
     fi
 
 script:


### PR DESCRIPTION
By default, our tests on PHP 8 nightly use PHPUnit 5.2.7, which includes calls to `each()`, which was removed in PHP 8, and therefore fails.

By ignoring the platform requirements, then PHPUnit 7 should be installed, as that's the highest version supported in the `composer.json` constraints.

All credit to @jrfnl for the same work she did on WPCS.