### PR TITLE
Travis: Expand supported PHP down to 5.4

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,6 @@
 language: php
 os: linux
-dist: xenial
+dist: trusty
 
 env:
   # `master` is now 3.x.
@@ -13,6 +13,8 @@ cache:
     - $HOME/.cache/composer/files
 
 php:
+  - 5.4
+  - 5.5
   - 5.6
   - 7.0
   - 7.1
@@ -36,7 +38,7 @@ jobs:
   include:
 
     - stage: lint
-      php: 7.3
+      php: 7.4
       env: PHPCS_BRANCH="dev-master"
       before_install: phpenv config-rm xdebug.ini || echo 'No xdebug config.'
       install: skip
@@ -59,7 +61,7 @@ jobs:
             - libxml2-utils
 
     - stage: sniff
-      php: 7.3
+      php: 7.4
       env: PHPCS_BRANCH="dev-master"
       before_install: phpenv config-rm xdebug.ini || echo 'No xdebug config.'
       install: composer install --dev --no-suggest

--- a/README.md
+++ b/README.md
@@ -15,6 +15,7 @@ Go to https://wpvip.com/documentation/phpcs-review-feedback/ to learn about why 
 
 ## Minimal requirements
 
+* PHP 5.4+
 * [PHPCS 3.3.1+](https://github.com/squizlabs/PHP_CodeSniffer/releases)
 * [WPCS 2.*](https://github.com/WordPress-Coding-Standards/WordPress-Coding-Standards/releases)
 

--- a/composer.json
+++ b/composer.json
@@ -15,14 +15,14 @@
 		}
 	],
 	"require": {
-		"php": ">=5.6",
+		"php": ">=5.4",
 		"squizlabs/php_codesniffer": "^3.5.5",
 		"wp-coding-standards/wpcs": "^2.3"
 	},
 	"require-dev": {
 		"dealerdirect/phpcodesniffer-composer-installer": "^0.7",
 		"phpcompatibility/php-compatibility": "^9",
-		"phpunit/phpunit": "^5 || ^6 || ^7"
+		"phpunit/phpunit": "^4 || ^5 || ^6 || ^7"
 	},
 	"suggest": {
 		"dealerdirect/phpcodesniffer-composer-installer": "^0.7 || This Composer plugin will manage the PHPCS 'installed_paths' automatically."


### PR DESCRIPTION
PHP 5.4 is the minimum that PHPCS and WPCS support, so it would be nice to be able to say VIPCS supports the same minimum version of PHP.

As much as I'd love to use some PHP 7-only syntax in sniffs, that doesn't seem like a good enough reason to limit what versions of PHP we support for using this tool (it doesn't affect what versions of PHP that themes and plugins use of course).