### PR TITLE
chore: Add CODEOWNERS file

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,4 @@
+# The following teams will get auto-tagged for a review.
+# See https://docs.github.com/en/enterprise/2.15/user/articles/about-code-owners
+
+* @Automattic/vipcs


### PR DESCRIPTION
Helps to auto-tag the repo maintainers for reviews when PRs are created.