### PR TITLE
chore: Add `.gitattributes` file

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,29 @@
+#
+# Exclude files from release archives.
+# This will also make them unavailable when using Composer with `--prefer-dist`.
+# If you develop for VIPCS using Composer, use `--prefer-source`.
+# https://blog.madewithlove.be/post/gitattributes/
+#
+/.editorconfig export-ignore
+/.gitattributes export-ignore
+/.gitignore export-ignore
+/.phpcs.xml.dist export-ignore
+/.travis.yml export-ignore
+/phpunit.xml.dist export-ignore
+/.github export-ignore
+/bin export-ignore
+/tests export-ignore
+/WordPressVIPMinimum/Tests export-ignore
+
+#
+# Auto detect text files and perform LF normalization
+# http://davidlaing.com/2012/09/19/customise-your-gitattributes-to-become-a-git-ninja/
+#
+* text=auto
+
+#
+# The above will handle all files NOT found below
+#
+*.md text
+*.php text
+*.inc text


### PR DESCRIPTION
Exclude files from release archives.

This will also make them unavailable when using Composer with `--prefer-dist`.

If you develop for VIPCS using Composer, use `--prefer-source`.

See https://blog.madewithlove.be/post/gitattributes/