### PR TITLE
Travis: change from "trusty" to "xenial"

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,6 @@
 language: php
 os: linux
-dist: trusty
+dist: xenial
 
 env:
   # `master` is now 3.x.
@@ -13,8 +13,6 @@ cache:
     - $HOME/.cache/composer/files
 
 php:
-  - 5.4
-  - 5.5
   - 5.6
   - 7.0
   - 7.1
@@ -69,6 +67,20 @@ jobs:
         # Run PHPCS against VIPCS.
         - ./bin/phpcs
 
+    # Builds which need a different distro.
+    - stage: test
+    - php: 5.5
+      dist: trusty
+      env: PHPCS_BRANCH="dev-master"
+    - php: 5.5
+      dist: trusty
+      env: PHPCS_BRANCH="3.5.5"
+    - php: 5.4
+      dist: trusty
+      env: PHPCS_BRANCH="dev-master"
+    - php: 5.4
+      dist: trusty
+      env: PHPCS_BRANCH="3.5.5"
 
 before_install:
   # Speed up build time by disabling Xdebug.


### PR DESCRIPTION
As the "trusty" environment is no longer officially supported by Travis, they decided in their wisdom to silently stop updating the PHP "nightly" image, which makes it next to useless as the last image apparently is from January....

This updates the Travis config to:
* Use the `xenial` distro, which at this time is the default.
* Sets the distro for low PHP versions explicitly to `trusty`.