### PR TITLE
CS ruleset: minor tweaks

### DIFF
--- a/.phpcs.xml.dist
+++ b/.phpcs.xml.dist
@@ -16,6 +16,7 @@
 	<rule ref="WordPress-Extra">
 		<exclude name="WordPress.Files.FileName"/>
 		<exclude name="WordPress.NamingConventions.ValidVariableName"/>
+		<exclude name="Generic.Arrays.DisallowShortArraySyntax"/>
 	</rule>
 
 	<rule ref="WordPress-Docs"/>
@@ -34,13 +35,8 @@
 	<!-- Disallow long array syntax -->
 	<rule ref="Generic.Arrays.DisallowLongArraySyntax"/>
 
-	<!-- Allow short array syntax -->
-	<rule ref="Generic.Arrays.DisallowShortArraySyntax.Found">
-		<exclude name="Generic.Arrays.DisallowShortArraySyntax.Found"/>
-	</rule>
-
 	<!-- Check code for cross-version PHP compatibility. -->
-	<config name="testVersion" value="5.6-"/>
+	<config name="testVersion" value="5.4-"/>
 	<rule ref="PHPCompatibility">
 		<!-- Exclude PHP constants back-filled by PHPCS. -->
 		<exclude name="PHPCompatibility.PHP.NewConstants.t_finallyFound"/>


### PR DESCRIPTION
1. According to the `composer.json` file, the minimum supported PHP version is PHP 5.4, so PHPCompatibility should be set to check for that, not for PHP 5.6 and up.
2. Excluding a complete sniff instead of including it twice and excluding the single errorcode.
    This is more efficient as it prevents the sniff from running completely instead of letting the sniff run and silencing the error at the moment it is being thrown.