### PR TITLE
WordPressVIPMinimum: fix the failing ruleset test & let Travis show failures

### DIFF
--- a/WordPressVIPMinimum/ruleset-test.inc
+++ b/WordPressVIPMinimum/ruleset-test.inc
@@ -2,9 +2,9 @@
 
 
 <?php // Error - Squiz.WhiteSpace.SuperfluousWhitespace.
-$hello = ''; $posts_not_in = ''; $listofthings = ''; $cachedlistofthings = ''; $title = ''; $ch = ''; $thing = ''; $descriptorspec = ''; $pipes = ''; $cwd = ''; $env = ''; $page_title = ''; $menu_title = ''; $capability = ''; $function = ''; $icon_url = ''; $position = ''; $wpdb = ''; $file = ''; $fp = ''; $dir = ''; $test = ''; $post = ''; $bar = ''; $array = []; $query_args = []; $url = ''; $query = ''; $page_title = ''; $true = true; $some_nasty_var = ''; $data = ''; $group = ''; $testing = ''; $this = new stdClass(); $needle = ''; $some_var = ''; $blogid = 1; $text = ''; $category_id = 123; $foo = ''; $bar = ''; $var = ''; $wp_rewrite = ''; $count = 1; $loop = 1; $a = ''; $b = ''; $obj = ''; // phpcs:ignore WordPress.WP.GlobalVariablesOverride.Prohibited -- All set for VariableAnalysis checks.
+$hello = ''; $posts_not_in = ''; $listofthings = ''; $cachedlistofthings = ''; $title = ''; $ch = ''; $thing = ''; $descriptorspec = ''; $pipes = ''; $cwd = ''; $env = ''; $page_title = ''; $menu_title = ''; $capability = ''; $function = ''; $icon_url = ''; $position = ''; $wpdb = ''; $file = ''; $fp = ''; $dir = ''; $test = ''; $post = ''; $bar = ''; $array = []; $query_args = []; $url = ''; $query = ''; $page_title = ''; $true = true; $some_nasty_var = ''; $data = ''; $group = ''; $testing = ''; $stdClass = new stdClass(); $needle = ''; $some_var = ''; $blogid = 1; $text = ''; $category_id = 123; $foo = ''; $bar = ''; $var = ''; $wp_rewrite = ''; $count = 1; $loop = 1; $a = ''; $b = ''; $obj = ''; // phpcs:ignore WordPress.WP.GlobalVariablesOverride.Prohibited -- All set for VariableAnalysis checks.
 // Generic.PHP.Syntax
-while { // Error.
+foreach() { // Error.
 }
 
 // Generic.PHP.NoSilencedErrors
@@ -486,12 +486,12 @@ $query_args = [
 ];
 
 // WordPressVIPMinimum.Performance.RemoteRequestTimeout
-wp_remote_post( $this->endpoint, array(
+wp_remote_post( $stdClass->endpoint, array(
         'method'      => 'POST',
         'timeout'     => 45, // Error.
         'httpversion' => '1.1',
         'blocking'    => false,
-        'body'        => wp_json_encode( $this->logs, JSON_UNESCAPED_SLASHES ),
+        'body'        => wp_json_encode( $stdClass->logs, JSON_UNESCAPED_SLASHES ),
     )
 );
 

--- a/bin/ruleset-tests
+++ b/bin/ruleset-tests
@@ -17,5 +17,4 @@
 PHPCS_BIN="$(pwd)/vendor/bin/phpcs"
 export PHPCS_BIN
 
-php ./WordPressVIPMinimum/ruleset-test.php
-php ./WordPress-VIP-Go/ruleset-test.php
+php ./WordPressVIPMinimum/ruleset-test.php && php ./WordPress-VIP-Go/ruleset-test.php

--- a/tests/RulesetTest.php
+++ b/tests/RulesetTest.php
@@ -230,6 +230,10 @@ class RulesetTest {
 			}
 
 			foreach ( $lines as $line_number => $expected_count_of_type_violations ) {
+				if ( 0 === $expected_count_of_type_violations ) {
+					continue;
+				}
+
 				if ( ! isset( $this->{$type}[ $line_number ] ) ) {
 					$this->error_warning_message( $expected_count_of_type_violations, $type, 0, $line_number );
 				} elseif ( $this->{$type}[ $line_number ] !== $expected_count_of_type_violations ) {
@@ -247,6 +251,10 @@ class RulesetTest {
 	private function check_unexpected_values() {
 		foreach ( [ 'errors', 'warnings' ] as $type ) {
 			foreach ( $this->$type as $line_number => $actual_count_of_type_violations ) {
+				if ( 0 === $actual_count_of_type_violations ) {
+					continue;
+				}
+
 				if ( ! isset( $this->expected[ $type ][ $line_number ] ) ) {
 					$this->error_warning_message( 0, $type, $actual_count_of_type_violations, $line_number );
 				} elseif ( $actual_count_of_type_violations !== $this->expected[ $type ][ $line_number ] ) {


### PR DESCRIPTION
### Ruleset test script: fail the build on failing ruleset tests

The builds on PHP 5.4, 5.5 and 5.6 should have been failing on the ruleset test for a while now, but aren't.

Example: https://travis-ci.org/github/Automattic/VIP-Coding-Standards/jobs/710513865#L311-L315

What is happening here is that when several commands are run via a script, Travis will only look at the exit code of the _last_ script to decide whether the build should be failed or not.

This means that failures from the `WordPressVIPMinimum` ruleset test were never failing the build as they were hidden by a passing ruleset test for the `WordPress-VIP-Go` ruleset.

By chaining the commands together, the exit codes of both commands are taken into account when determining whether the build should be failed or not.

### WordPressVIPMinimum: fix the failing ruleset test

Ok, this is a fun one.

Line 5 of the ruleset-test is not supposed to error. It is just setting up the variables for the VariableAnalysis test.

Line 7, however, is supposed to error on a PHP parse error (`Generic.PHP.Syntax`).

The above is true and working for PHP 7.

However on PHP 5, line 7 will not throw a parse error, while line 5 actually will - `Cannot re-assign $this`.

As the test on line 7 is about checking that the parse error sniff is correctly triggered and the error on line 5 on PHP 5 _is_ a parse error, I deem this sufficiently covered and have fixed the build failure by making the expected errors on line 5 and 7 conditional on the PHP version on which the tests are being run.

Includes annotating these findings in the inline documentation of the test case file.

Fun times ;-)

### RulesetTest: fix the test script to be able to handle 0 values

Turns out the test script was not set up to be able to deal with `0` values and would throw a very informative "_Expected 0 errors, found 0 on line 7._" error in such a case.

Fixed now.