### PR TITLE
DeclarationCompatibility: fix incorrect signature check for `Walker::walk()`

### DIFF
--- a/WordPressVIPMinimum/Sniffs/Classes/DeclarationCompatibilitySniff.php
+++ b/WordPressVIPMinimum/Sniffs/Classes/DeclarationCompatibilitySniff.php
@@ -148,12 +148,18 @@ class DeclarationCompatibilitySniff extends AbstractScopeSniff {
 			'walk'                        => [
 				'elements',
 				'max_depth',
+				'args' => [
+					'variable_length' => true,
+				],
 			],
 			'paged_walk'                  => [
 				'elements',
 				'max_depth',
 				'page_num',
 				'per_page',
+				'args' => [
+					'variable_length' => true,
+				],
 			],
 			'get_number_of_root_elements' => [
 				'elements',
@@ -276,6 +282,9 @@ class DeclarationCompatibilitySniff extends AbstractScopeSniff {
 					) || (
 						true === array_key_exists( 'pass_by_reference', $param ) &&
 						$param['pass_by_reference'] !== $signatureParams[ $i ]['pass_by_reference']
+					) || (
+						true === array_key_exists( 'variable_length', $param ) &&
+						$param['variable_length'] !== $signatureParams[ $i ]['variable_length']
 					)
 				) {
 					$this->addError( $originalParentClassName, $methodName, $signatureParams, $parentSignature, $phpcsFile, $stackPtr );
@@ -329,6 +338,10 @@ class DeclarationCompatibilitySniff extends AbstractScopeSniff {
 				$paramName = $options['name'];
 			} else {
 				$paramName .= $param;
+			}
+
+			if ( true === array_key_exists( 'variable_length', $options ) && true === $options['variable_length'] ) {
+				$paramName = '...' . $paramName;
 			}
 
 			if ( true === array_key_exists( 'pass_by_reference', $options ) && true === $options['pass_by_reference'] ) {

--- a/WordPressVIPMinimum/Tests/Classes/DeclarationCompatibilityUnitTest.inc
+++ b/WordPressVIPMinimum/Tests/Classes/DeclarationCompatibilityUnitTest.inc
@@ -127,4 +127,13 @@ class MyWalker extends Walker {
 
 	function unset_children( $el, $children_elements ) {
 	} // Bad. $children_elements should be passed by reference
+	
+	function walk( $elements, $max_depth, ...$args ) {
+	} // Ok.
+	
+	function paged_walk( $elements, $max_depth, $page_num, $per_page ) {
+	} // Bad. Missing $args.
+
+	function paged_walk( $elements, $max_depth, $page_num, $per_page, $args ) {
+	} // Bad. $args is not variadic.
 }

--- a/WordPressVIPMinimum/Tests/Classes/DeclarationCompatibilityUnitTest.php
+++ b/WordPressVIPMinimum/Tests/Classes/DeclarationCompatibilityUnitTest.php
@@ -45,6 +45,8 @@ class DeclarationCompatibilityUnitTest extends AbstractSniffUnitTest {
 			112 => 1,
 			119 => 1,
 			128 => 1,
+			134 => 1,
+			137 => 1,
 		];
 	}
 


### PR DESCRIPTION
... and `Walker::paged_walk()`.

The method signature of both the `Walker::walk()` method as well as the `Walker::paged_walk()` method were changed in WordPress 5.3 to make the variadic nature of the allowed arguments explicit.

This change updates the sniff to verify the signature of these methods in child classes against the new method signature as it is in WordPress Core.

Refs:
* https://make.wordpress.org/core/2019/10/09/wp-5-3-introducing-the-spread-operator/
* https://core.trac.wordpress.org/changeset/46442

Fixes #448

Note: I've pointedly ignored everything else which could be improved in this sniff and just focused on getting this particular issue fixed for now.