### PR TITLE
RulesetTest: don't use the system default version of PHP

### DIFF
--- a/tests/RulesetTest.php
+++ b/tests/RulesetTest.php
@@ -138,7 +138,17 @@ class RulesetTest {
 	 * @return array Returns an associative array with keys of `totals` and `files`.
 	 */
 	private function collect_phpcs_result() {
-		$shell = sprintf( '%1$s --severity=1 --standard=%2$s --report=json ./%2$s/ruleset-test.inc', $this->phpcs_bin, $this->ruleset );
+		$php = '';
+		if ( \PHP_BINARY && in_array( \PHP_SAPI, [ 'cgi-fcgi', 'cli', 'cli-server', 'phpdbg' ], true ) ) {
+			$php = \PHP_BINARY . ' ';
+		}
+
+		$shell = sprintf(
+			'%1$s%2$s --severity=1 --standard=%3$s --report=json ./%3$s/ruleset-test.inc',
+			$php, // Current PHP executable if avaiable.
+			$this->phpcs_bin,
+			$this->ruleset
+		);
 		// phpcs:ignore
 		$output = shell_exec( $shell );
 


### PR DESCRIPTION
... instead use the PHP version used when this script was called.

`shell_exec()` opens a new process and that process does not inherit the PHP executable which was used to run the tests, but uses the system default PHP version instead, which means that the PHPCS command may run on a different PHP version than the tests.

The current solution is a simple one and not exhaustive, but should suffice in most cases.

If a more complex/more comprehensive solution is desired, I'd recommend using the `PhpExecutableFinder` from the `Symfony\Process` package.

_Context: I needed this fix to be able to properly investigate #485 _