### PR TITLE
Variables/RestrictedVariables: fix namespace of unit test file + fix test

### DIFF
--- a/WordPressVIPMinimum/Tests/Variables/RestrictedVariablesUnitTest.inc
+++ b/WordPressVIPMinimum/Tests/Variables/RestrictedVariablesUnitTest.inc
@@ -28,10 +28,10 @@ $phrase = <<<EOD
 Your user-agent is {$_SERVER['HTTP_USER_AGENT']}
 EOD;
 
-// phpcs:set WordPressVIPMinimum.Variables.RestrictedVariables exclude user_meta
-$query = "SELECT * FROM $wpdb->usermeta"; // Error.
+// phpcs:set WordPressVIPMinimum.Variables.RestrictedVariables exclude[] user_meta
+$query = "SELECT * FROM $wpdb->usermeta"; // Ok, excluded.
 
-// phpcs:set WordPressVIPMinimum.Functions.RestrictedFunctions exclude false
+// phpcs:set WordPressVIPMinimum.Functions.RestrictedFunctions exclude[]
 
 foo( $_SESSION ); // Error.
 foo( $_SESSION['bar'] ); // Error.

--- a/WordPressVIPMinimum/Tests/Variables/RestrictedVariablesUnitTest.php
+++ b/WordPressVIPMinimum/Tests/Variables/RestrictedVariablesUnitTest.php
@@ -5,7 +5,7 @@
  * @package VIPCS\WordPressVIPMinimum
  */
 
-namespace WordPress\Tests\Variables;
+namespace WordPressVIPMinimum\Tests\Variables;
 
 use PHP_CodeSniffer\Tests\Standards\AbstractSniffUnitTest;
 


### PR DESCRIPTION
* The namespace of the test file was not for VIPCS.
* Update the inline `exclude` property setting syntax.
