### PR TITLE
Allow for checking test code coverage

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
+build/
 vendor/
 composer.lock
 phpcs.xml

--- a/WordPressVIPMinimum/Tests/Classes/DeclarationCompatibilityUnitTest.php
+++ b/WordPressVIPMinimum/Tests/Classes/DeclarationCompatibilityUnitTest.php
@@ -13,6 +13,8 @@ use PHP_CodeSniffer\Tests\Standards\AbstractSniffUnitTest;
  * Unit test class for the DeclarationCompatibility sniff.
  *
  * @package VIPCS\WordPressVIPMinimum
+ *
+ * @covers \WordPressVIPMinimum\Sniffs\Classes\DeclarationCompatibilitySniff
  */
 class DeclarationCompatibilityUnitTest extends AbstractSniffUnitTest {
 

--- a/WordPressVIPMinimum/Tests/Classes/RestrictedExtendClassesUnitTest.php
+++ b/WordPressVIPMinimum/Tests/Classes/RestrictedExtendClassesUnitTest.php
@@ -13,6 +13,8 @@ use PHP_CodeSniffer\Tests\Standards\AbstractSniffUnitTest;
  * Unit test class for the RestrictedExtendClasses sniff.
  *
  * @package VIPCS\WordPressVIPMinimum
+ *
+ * @covers \WordPressVIPMinimum\Sniffs\Classes\RestrictedExtendClassesSniff
  */
 class RestrictedExtendClassesUnitTest extends AbstractSniffUnitTest {
 

--- a/WordPressVIPMinimum/Tests/Compatibility/ZoninatorUnitTest.php
+++ b/WordPressVIPMinimum/Tests/Compatibility/ZoninatorUnitTest.php
@@ -13,6 +13,8 @@ use PHP_CodeSniffer\Tests\Standards\AbstractSniffUnitTest;
  * Unit test class for the CheckReturnValue sniff.
  *
  * @package VIPCS\WordPressVIPMinimum
+ *
+ * @covers \WordPressVIPMinimum\Sniffs\Compatibility\ZoninatorSniff
  */
 class ZoninatorUnitTest extends AbstractSniffUnitTest {
 

--- a/WordPressVIPMinimum/Tests/Constants/ConstantStringUnitTest.php
+++ b/WordPressVIPMinimum/Tests/Constants/ConstantStringUnitTest.php
@@ -13,6 +13,8 @@ use PHP_CodeSniffer\Tests\Standards\AbstractSniffUnitTest;
  * Unit test class for the ConstantString sniff.
  *
  * @package VIPCS\WordPressVIPMinimum
+ *
+ * @covers \WordPressVIPMinimum\Sniffs\Constants\ConstantStringSniff
  */
 class ConstantStringUnitTest extends AbstractSniffUnitTest {
 

--- a/WordPressVIPMinimum/Tests/Constants/RestrictedConstantsUnitTest.php
+++ b/WordPressVIPMinimum/Tests/Constants/RestrictedConstantsUnitTest.php
@@ -13,6 +13,8 @@ use PHP_CodeSniffer\Tests\Standards\AbstractSniffUnitTest;
  * Unit test class for the ConstantRestrictions sniff.
  *
  * @package VIPCS\WordPressVIPMinimum
+ *
+ * @covers \WordPressVIPMinimum\Sniffs\Constants\RestrictedConstantsSniff
  */
 class RestrictedConstantsUnitTest extends AbstractSniffUnitTest {
 

--- a/WordPressVIPMinimum/Tests/Files/IncludingFileUnitTest.php
+++ b/WordPressVIPMinimum/Tests/Files/IncludingFileUnitTest.php
@@ -12,6 +12,8 @@ use PHP_CodeSniffer\Tests\Standards\AbstractSniffUnitTest;
  * Unit test class for the IncludingFile sniff.
  *
  * @package VIPCS\WordPressVIPMinimum
+ *
+ * @covers \WordPressVIPMinimum\Sniffs\Files\IncludingFileSniff
  */
 class IncludingFileUnitTest extends AbstractSniffUnitTest {
 

--- a/WordPressVIPMinimum/Tests/Files/IncludingNonPHPFileUnitTest.php
+++ b/WordPressVIPMinimum/Tests/Files/IncludingNonPHPFileUnitTest.php
@@ -12,6 +12,8 @@ use PHP_CodeSniffer\Tests\Standards\AbstractSniffUnitTest;
  * Unit test class for the IncludingFile sniff.
  *
  * @package VIPCS\WordPressVIPMinimum
+ *
+ * @covers \WordPressVIPMinimum\Sniffs\Files\IncludingNonPHPFileSniff
  */
 class IncludingNonPHPFileUnitTest extends AbstractSniffUnitTest {
 

--- a/WordPressVIPMinimum/Tests/Functions/CheckReturnValueUnitTest.php
+++ b/WordPressVIPMinimum/Tests/Functions/CheckReturnValueUnitTest.php
@@ -13,6 +13,8 @@ use PHP_CodeSniffer\Tests\Standards\AbstractSniffUnitTest;
  * Unit test class for the CheckReturnValue sniff.
  *
  * @package VIPCS\WordPressVIPMinimum
+ *
+ * @covers \WordPressVIPMinimum\Sniffs\Functions\CheckReturnValueSniff
  */
 class CheckReturnValueUnitTest extends AbstractSniffUnitTest {
 

--- a/WordPressVIPMinimum/Tests/Functions/DynamicCallsUnitTest.php
+++ b/WordPressVIPMinimum/Tests/Functions/DynamicCallsUnitTest.php
@@ -13,6 +13,8 @@ use PHP_CodeSniffer\Tests\Standards\AbstractSniffUnitTest;
  * Unit test class for the DynamicCalls sniff.
  *
  * @package VIPCS\WordPressVIPMinimum
+ *
+ * @covers \WordPressVIPMinimum\Sniffs\Functions\DynamicCallsSniff
  */
 class DynamicCallsUnitTest extends AbstractSniffUnitTest {
 

--- a/WordPressVIPMinimum/Tests/Functions/RestrictedFunctionsUnitTest.php
+++ b/WordPressVIPMinimum/Tests/Functions/RestrictedFunctionsUnitTest.php
@@ -13,6 +13,8 @@ use PHP_CodeSniffer\Tests\Standards\AbstractSniffUnitTest;
  * Unit test class for the RestrictedFunctions sniff.
  *
  * @package VIPCS\WordPressVIPMinimum
+ *
+ * @covers \WordPressVIPMinimum\Sniffs\Functions\RestrictedFunctionsSniff
  */
 class RestrictedFunctionsUnitTest extends AbstractSniffUnitTest {
 

--- a/WordPressVIPMinimum/Tests/Functions/StripTagsUnitTest.php
+++ b/WordPressVIPMinimum/Tests/Functions/StripTagsUnitTest.php
@@ -13,6 +13,8 @@ use PHP_CodeSniffer\Tests\Standards\AbstractSniffUnitTest;
  * Unit test class for the StripTags sniff.
  *
  * @package VIPCS\WordPressVIPMinimum
+ *
+ * @covers \WordPressVIPMinimum\Sniffs\Functions\StripTagsSniff
  */
 class StripTagsUnitTest extends AbstractSniffUnitTest {
 

--- a/WordPressVIPMinimum/Tests/Hooks/AlwaysReturnInFilterUnitTest.php
+++ b/WordPressVIPMinimum/Tests/Hooks/AlwaysReturnInFilterUnitTest.php
@@ -12,6 +12,8 @@ use PHP_CodeSniffer\Tests\Standards\AbstractSniffUnitTest;
  * Unit test class for the Hooks/AlwaysReturn sniff.
  *
  * @package VIPCS\WordPressVIPMinimum
+ *
+ * @covers \WordPressVIPMinimum\Sniffs\Hooks\AlwaysReturnInFilterSniff
  */
 class AlwaysReturnInFilterUnitTest extends AbstractSniffUnitTest {
 

--- a/WordPressVIPMinimum/Tests/Hooks/PreGetPostsUnitTest.php
+++ b/WordPressVIPMinimum/Tests/Hooks/PreGetPostsUnitTest.php
@@ -13,6 +13,8 @@ use PHP_CodeSniffer\Tests\Standards\AbstractSniffUnitTest;
  * Unit test class for the PreGetPosts sniff.
  *
  * @package VIPCS\WordPressVIPMinimum
+ *
+ * @covers \WordPressVIPMinimum\Sniffs\Hooks\PreGetPostsSniff
  */
 class PreGetPostsUnitTest extends AbstractSniffUnitTest {
 

--- a/WordPressVIPMinimum/Tests/Hooks/RestrictedHooksUnitTest.php
+++ b/WordPressVIPMinimum/Tests/Hooks/RestrictedHooksUnitTest.php
@@ -14,6 +14,8 @@ use PHP_CodeSniffer\Tests\Standards\AbstractSniffUnitTest;
  * @package VIPCS\WordPressVIPMinimum
  *
  * @since 0.4.0
+ *
+ * @covers \WordPressVIPMinimum\Sniffs\Hooks\RestrictedHooksSniff
  */
 class RestrictedHooksUnitTest extends AbstractSniffUnitTest {
 

--- a/WordPressVIPMinimum/Tests/JS/DangerouslySetInnerHTMLUnitTest.php
+++ b/WordPressVIPMinimum/Tests/JS/DangerouslySetInnerHTMLUnitTest.php
@@ -13,6 +13,8 @@ use PHP_CodeSniffer\Tests\Standards\AbstractSniffUnitTest;
  * Unit test class for the HTML String concatenation in JS sniff.
  *
  * @package VIPCS\WordPressVIPMinimum
+ *
+ * @covers \WordPressVIPMinimum\Sniffs\JS\DangerouslySetInnerHTMLSniff
  */
 class DangerouslySetInnerHTMLUnitTest extends AbstractSniffUnitTest {
 

--- a/WordPressVIPMinimum/Tests/JS/HTMLExecutingFunctionsUnitTest.php
+++ b/WordPressVIPMinimum/Tests/JS/HTMLExecutingFunctionsUnitTest.php
@@ -13,6 +13,8 @@ use PHP_CodeSniffer\Tests\Standards\AbstractSniffUnitTest;
  * Unit test class for the HTML executing JS functions sniff.
  *
  * @package VIPCS\WordPressVIPMinimum
+ *
+ * @covers \WordPressVIPMinimum\Sniffs\JS\HTMLExecutingFunctionsSniff
  */
 class HTMLExecutingFunctionsUnitTest extends AbstractSniffUnitTest {
 

--- a/WordPressVIPMinimum/Tests/JS/InnerHTMLUnitTest.php
+++ b/WordPressVIPMinimum/Tests/JS/InnerHTMLUnitTest.php
@@ -13,6 +13,8 @@ use PHP_CodeSniffer\Tests\Standards\AbstractSniffUnitTest;
  * Unit test class for the HTML String concatenation in JS sniff.
  *
  * @package VIPCS\WordPressVIPMinimum
+ *
+ * @covers \WordPressVIPMinimum\Sniffs\JS\InnerHTMLSniff
  */
 class InnerHTMLUnitTest extends AbstractSniffUnitTest {
 

--- a/WordPressVIPMinimum/Tests/JS/StringConcatUnitTest.php
+++ b/WordPressVIPMinimum/Tests/JS/StringConcatUnitTest.php
@@ -13,6 +13,8 @@ use PHP_CodeSniffer\Tests\Standards\AbstractSniffUnitTest;
  * Unit test class for the HTML String concatenation in JS sniff.
  *
  * @package VIPCS\WordPressVIPMinimum
+ *
+ * @covers \WordPressVIPMinimum\Sniffs\JS\StringConcatSniff
  */
 class StringConcatUnitTest extends AbstractSniffUnitTest {
 

--- a/WordPressVIPMinimum/Tests/JS/StrippingTagsUnitTest.php
+++ b/WordPressVIPMinimum/Tests/JS/StrippingTagsUnitTest.php
@@ -13,6 +13,8 @@ use PHP_CodeSniffer\Tests\Standards\AbstractSniffUnitTest;
  * Unit test class for incorrect HTML tags stripping approach in JS sniff.
  *
  * @package VIPCS\WordPressVIPMinimum
+ *
+ * @covers \WordPressVIPMinimum\Sniffs\JS\StrippingTagsSniff
  */
 class StrippingTagsUnitTest extends AbstractSniffUnitTest {
 

--- a/WordPressVIPMinimum/Tests/JS/WindowUnitTest.php
+++ b/WordPressVIPMinimum/Tests/JS/WindowUnitTest.php
@@ -13,6 +13,8 @@ use PHP_CodeSniffer\Tests\Standards\AbstractSniffUnitTest;
  * Unit test class for the HTML String concatenation in JS sniff.
  *
  * @package VIPCS\WordPressVIPMinimum
+ *
+ * @covers \WordPressVIPMinimum\Sniffs\JS\WindowSniff
  */
 class WindowUnitTest extends AbstractSniffUnitTest {
 

--- a/WordPressVIPMinimum/Tests/Performance/BatcacheWhitelistedParamsUnitTest.php
+++ b/WordPressVIPMinimum/Tests/Performance/BatcacheWhitelistedParamsUnitTest.php
@@ -13,6 +13,8 @@ use PHP_CodeSniffer\Tests\Standards\AbstractSniffUnitTest;
  * Unit test class for the BatcacheWhitelistedParams sniff.
  *
  * @package VIPCS\WordPressVIPMinimum
+ *
+ * @covers \WordPressVIPMinimum\Sniffs\Performance\BatcacheWhitelistedParamsSniff
  */
 class BatcacheWhitelistedParamsUnitTest extends AbstractSniffUnitTest {
 

--- a/WordPressVIPMinimum/Tests/Performance/CacheValueOverrideUnitTest.php
+++ b/WordPressVIPMinimum/Tests/Performance/CacheValueOverrideUnitTest.php
@@ -13,6 +13,8 @@ use PHP_CodeSniffer\Tests\Standards\AbstractSniffUnitTest;
  * Unit test class for the CacheValueOverride sniff.
  *
  * @package VIPCS\WordPressVIPMinimum
+ *
+ * @covers \WordPressVIPMinimum\Sniffs\Performance\CacheValueOverrideSniff
  */
 class CacheValueOverrideUnitTest extends AbstractSniffUnitTest {
 

--- a/WordPressVIPMinimum/Tests/Performance/FetchingRemoteDataUnitTest.php
+++ b/WordPressVIPMinimum/Tests/Performance/FetchingRemoteDataUnitTest.php
@@ -13,6 +13,8 @@ use PHP_CodeSniffer\Tests\Standards\AbstractSniffUnitTest;
  * Unit test class for the ExitAfterRedirect sniff.
  *
  * @package VIPCS\WordPressVIPMinimum
+ *
+ * @covers \WordPressVIPMinimum\Sniffs\Performance\FetchingRemoteDataSniff
  */
 class FetchingRemoteDataUnitTest extends AbstractSniffUnitTest {
 

--- a/WordPressVIPMinimum/Tests/Performance/LowExpiryCacheTimeUnitTest.php
+++ b/WordPressVIPMinimum/Tests/Performance/LowExpiryCacheTimeUnitTest.php
@@ -13,6 +13,8 @@ use PHP_CodeSniffer\Tests\Standards\AbstractSniffUnitTest;
  * Unit test class for the LowExpiryCacheTime sniff.
  *
  * @package VIPCS\WordPressVIPMinimum
+ *
+ * @covers \WordPressVIPMinimum\Sniffs\Performance\LowExpiryCacheTimeSniff
  */
 class LowExpiryCacheTimeUnitTest extends AbstractSniffUnitTest {
 

--- a/WordPressVIPMinimum/Tests/Performance/NoPagingUnitTest.php
+++ b/WordPressVIPMinimum/Tests/Performance/NoPagingUnitTest.php
@@ -15,6 +15,8 @@ use PHP_CodeSniffer\Tests\Standards\AbstractSniffUnitTest;
  * @package VIPCS\WordPressVIPMinimum
  *
  * @since   0.5.0
+ *
+ * @covers \WordPressVIPMinimum\Sniffs\Performance\NoPagingSniff
  */
 class NoPagingUnitTest extends AbstractSniffUnitTest {
 

--- a/WordPressVIPMinimum/Tests/Performance/OrderByRandUnitTest.php
+++ b/WordPressVIPMinimum/Tests/Performance/OrderByRandUnitTest.php
@@ -15,6 +15,8 @@ use PHP_CodeSniffer\Tests\Standards\AbstractSniffUnitTest;
  * @package VIPCS\WordPressVIPMinimum
  *
  * @since   0.5.0
+ *
+ * @covers \WordPressVIPMinimum\Sniffs\Performance\OrderByRandSniff
  */
 class OrderByRandUnitTest extends AbstractSniffUnitTest {
 

--- a/WordPressVIPMinimum/Tests/Performance/RegexpCompareUnitTest.php
+++ b/WordPressVIPMinimum/Tests/Performance/RegexpCompareUnitTest.php
@@ -13,6 +13,8 @@ use PHP_CodeSniffer\Tests\Standards\AbstractSniffUnitTest;
  * Unit test class for the RegexpCompare sniff.
  *
  * @package VIPCS\WordPressVIPMinimum
+ *
+ * @covers \WordPressVIPMinimum\Sniffs\Performance\RegexpCompareSniff
  */
 class RegexpCompareUnitTest extends AbstractSniffUnitTest {
 

--- a/WordPressVIPMinimum/Tests/Performance/RemoteRequestTimeoutUnitTest.php
+++ b/WordPressVIPMinimum/Tests/Performance/RemoteRequestTimeoutUnitTest.php
@@ -13,6 +13,8 @@ use PHP_CodeSniffer\Tests\Standards\AbstractSniffUnitTest;
  * Unit test class for the RemoteRequestTimeout sniff.
  *
  * @package VIPCS\WordPressVIPMinimum
+ *
+ * @covers \WordPressVIPMinimum\Sniffs\Performance\RemoteRequestTimeoutSniff
  */
 class RemoteRequestTimeoutUnitTest extends AbstractSniffUnitTest {
 

--- a/WordPressVIPMinimum/Tests/Performance/TaxonomyMetaInOptionsUnitTest.php
+++ b/WordPressVIPMinimum/Tests/Performance/TaxonomyMetaInOptionsUnitTest.php
@@ -13,6 +13,8 @@ use PHP_CodeSniffer\Tests\Standards\AbstractSniffUnitTest;
  * Unit test class for the TaxonomyMetaInOptions sniff.
  *
  * @package VIPCS\WordPressVIPMinimum
+ *
+ * @covers \WordPressVIPMinimum\Sniffs\Performance\TaxonomyMetaInOptionsSniff
  */
 class TaxonomyMetaInOptionsUnitTest extends AbstractSniffUnitTest {
 

--- a/WordPressVIPMinimum/Tests/Performance/WPQueryParamsUnitTest.php
+++ b/WordPressVIPMinimum/Tests/Performance/WPQueryParamsUnitTest.php
@@ -13,6 +13,8 @@ use PHP_CodeSniffer\Tests\Standards\AbstractSniffUnitTest;
  * Unit test class for the WP_Query params sniff.
  *
  * @package VIPCS\WordPressVIPMinimum
+ *
+ * @covers \WordPressVIPMinimum\Sniffs\Performance\WPQueryParamsSniff
  */
 class WPQueryParamsUnitTest extends AbstractSniffUnitTest {
 

--- a/WordPressVIPMinimum/Tests/Security/EscapingVoidReturnFunctionsUnitTest.php
+++ b/WordPressVIPMinimum/Tests/Security/EscapingVoidReturnFunctionsUnitTest.php
@@ -13,6 +13,8 @@ use PHP_CodeSniffer\Tests\Standards\AbstractSniffUnitTest;
  * Unit test class for the EscapingVoidReturnFunctions sniff.
  *
  * @package VIPCS\WordPressVIPMinimum
+ *
+ * @covers \WordPressVIPMinimum\Sniffs\Security\EscapingVoidReturnFunctionsSniff
  */
 class EscapingVoidReturnFunctionsUnitTest extends AbstractSniffUnitTest {
 

--- a/WordPressVIPMinimum/Tests/Security/ExitAfterRedirectUnitTest.php
+++ b/WordPressVIPMinimum/Tests/Security/ExitAfterRedirectUnitTest.php
@@ -13,6 +13,8 @@ use PHP_CodeSniffer\Tests\Standards\AbstractSniffUnitTest;
  * Unit test class for the ExitAfterRedirect sniff.
  *
  * @package VIPCS\WordPressVIPMinimum
+ *
+ * @covers \WordPressVIPMinimum\Sniffs\Security\ExitAfterRedirectSniff
  */
 class ExitAfterRedirectUnitTest extends AbstractSniffUnitTest {
 

--- a/WordPressVIPMinimum/Tests/Security/MustacheUnitTest.php
+++ b/WordPressVIPMinimum/Tests/Security/MustacheUnitTest.php
@@ -13,6 +13,8 @@ use PHP_CodeSniffer\Tests\Standards\AbstractSniffUnitTest;
  * Unit test class for the unescaped output in Mustache templating engine.
  *
  * @package VIPCS\WordPressVIPMinimum
+ *
+ * @covers \WordPressVIPMinimum\Sniffs\Security\MustacheSniff
  */
 class MustacheUnitTest extends AbstractSniffUnitTest {
 

--- a/WordPressVIPMinimum/Tests/Security/PHPFilterFunctionsUnitTest.php
+++ b/WordPressVIPMinimum/Tests/Security/PHPFilterFunctionsUnitTest.php
@@ -13,6 +13,8 @@ use PHP_CodeSniffer\Tests\Standards\AbstractSniffUnitTest;
  * Unit test class for the WP_Query params sniff.
  *
  * @package VIPCS\WordPressVIPMinimum
+ *
+ * @covers \WordPressVIPMinimum\Sniffs\Security\PHPFilterFunctionsSniff
  */
 class PHPFilterFunctionsUnitTest extends AbstractSniffUnitTest {
 

--- a/WordPressVIPMinimum/Tests/Security/ProperEscapingFunctionUnitTest.php
+++ b/WordPressVIPMinimum/Tests/Security/ProperEscapingFunctionUnitTest.php
@@ -13,6 +13,8 @@ use PHP_CodeSniffer\Tests\Standards\AbstractSniffUnitTest;
  * Unit test class for the ProperEscapingFunction sniff.
  *
  * @package VIPCS\WordPressVIPMinimum
+ *
+ * @covers \WordPressVIPMinimum\Sniffs\Security\ProperEscapingFunctionSniff
  */
 class ProperEscapingFunctionUnitTest extends AbstractSniffUnitTest {
 

--- a/WordPressVIPMinimum/Tests/Security/StaticStrreplaceUnitTest.php
+++ b/WordPressVIPMinimum/Tests/Security/StaticStrreplaceUnitTest.php
@@ -13,6 +13,8 @@ use PHP_CodeSniffer\Tests\Standards\AbstractSniffUnitTest;
  * Unit test class for the StaticStrreplace sniff.
  *
  * @package VIPCS\WordPressVIPMinimum
+ *
+ * @covers \WordPressVIPMinimum\Sniffs\Security\StaticStrreplaceSniff
  */
 class StaticStrreplaceUnitTest extends AbstractSniffUnitTest {
 

--- a/WordPressVIPMinimum/Tests/Security/TwigUnitTest.php
+++ b/WordPressVIPMinimum/Tests/Security/TwigUnitTest.php
@@ -13,6 +13,8 @@ use PHP_CodeSniffer\Tests\Standards\AbstractSniffUnitTest;
  * Unit test class for the unescaped output in Twig templating engine.
  *
  * @package VIPCS\WordPressVIPMinimum
+ *
+ * @covers \WordPressVIPMinimum\Sniffs\Security\TwigSniff
  */
 class TwigUnitTest extends AbstractSniffUnitTest {
 

--- a/WordPressVIPMinimum/Tests/Security/UnderscorejsUnitTest.php
+++ b/WordPressVIPMinimum/Tests/Security/UnderscorejsUnitTest.php
@@ -13,6 +13,8 @@ use PHP_CodeSniffer\Tests\Standards\AbstractSniffUnitTest;
  * Unit test class for the unescaped output in Underscore.js templating engine.
  *
  * @package VIPCS\WordPressVIPMinimum
+ *
+ * @covers \WordPressVIPMinimum\Sniffs\Security\UnderscorejsSniff
  */
 class UnderscorejsUnitTest extends AbstractSniffUnitTest {
 

--- a/WordPressVIPMinimum/Tests/Security/VuejsUnitTest.php
+++ b/WordPressVIPMinimum/Tests/Security/VuejsUnitTest.php
@@ -13,6 +13,8 @@ use PHP_CodeSniffer\Tests\Standards\AbstractSniffUnitTest;
  * Unit test class for the unescaped output in Vue.js templating engine.
  *
  * @package VIPCS\WordPressVIPMinimum
+ *
+ * @covers \WordPressVIPMinimum\Sniffs\Security\VuejsSniff
  */
 class VuejsUnitTest extends AbstractSniffUnitTest {
 

--- a/WordPressVIPMinimum/Tests/UserExperience/AdminBarRemovalUnitTest.php
+++ b/WordPressVIPMinimum/Tests/UserExperience/AdminBarRemovalUnitTest.php
@@ -15,6 +15,8 @@ use PHP_CodeSniffer\Tests\Standards\AbstractSniffUnitTest;
  * @package VIPCS\WordPressVIPMinimum
  *
  * @since   0.5.0
+ *
+ * @covers \WordPressVIPMinimum\Sniffs\UserExperience\AdminBarRemovalSniff
  */
 class AdminBarRemovalUnitTest extends AbstractSniffUnitTest {
 

--- a/WordPressVIPMinimum/Tests/Variables/RestrictedVariablesUnitTest.php
+++ b/WordPressVIPMinimum/Tests/Variables/RestrictedVariablesUnitTest.php
@@ -16,6 +16,8 @@ use PHP_CodeSniffer\Tests\Standards\AbstractSniffUnitTest;
  *
  * @since   0.3.0
  * @since   0.13.0 Class name changed: this class is now namespaced.
+ *
+ * @covers \WordPressVIPMinimum\Sniffs\Variables\RestrictedVariablesSniff
  */
 class RestrictedVariablesUnitTest extends AbstractSniffUnitTest {
 

--- a/WordPressVIPMinimum/Tests/Variables/ServerVariablesUnitTest.php
+++ b/WordPressVIPMinimum/Tests/Variables/ServerVariablesUnitTest.php
@@ -13,6 +13,8 @@ use PHP_CodeSniffer\Tests\Standards\AbstractSniffUnitTest;
  * Unit test class for the Variable Analysis sniff.
  *
  * @package VIPCS\WordPressVIPMinimum
+ *
+ * @covers \WordPressVIPMinimum\Sniffs\Variables\ServerVariablesSniff
  */
 class ServerVariablesUnitTest extends AbstractSniffUnitTest {
 

--- a/WordPressVIPMinimum/Tests/Variables/VariableAnalysisUnitTest.php
+++ b/WordPressVIPMinimum/Tests/Variables/VariableAnalysisUnitTest.php
@@ -13,6 +13,8 @@ use PHP_CodeSniffer\Tests\Standards\AbstractSniffUnitTest;
  * Unit test class for the Variable Analysis sniff.
  *
  * @package VIPCS\WordPressVIPMinimum
+ *
+ * @covers \WordPressVIPMinimum\Sniffs\Variables\VariableAnalysisSniff
  */
 class VariableAnalysisUnitTest extends AbstractSniffUnitTest {
 

--- a/bin/unit-tests
+++ b/bin/unit-tests
@@ -10,4 +10,4 @@
 #   ./bin/unit-tests
 #
 
-"$(pwd)/vendor/bin/phpunit" --filter WordPressVIPMinimum "$(pwd)/vendor/squizlabs/php_codesniffer/tests/AllTests.php"
+"$(pwd)/vendor/bin/phpunit" --filter WordPressVIPMinimum "$(pwd)/vendor/squizlabs/php_codesniffer/tests/AllTests.php" --no-coverage

--- a/bin/unit-tests
+++ b/bin/unit-tests
@@ -9,5 +9,11 @@
 #
 #   ./bin/unit-tests
 #
+# The script allows to pass additional PHPUnit CLI arguments.
+# For instance, if you only want to run the tests for one particular sniff,
+# use the following, replacing "SniffName" with the name of the target sniff:
+#
+#   ./bin/unit-tests --filter SniffName
+#
 
-"$(pwd)/vendor/bin/phpunit" --filter WordPressVIPMinimum "$(pwd)/vendor/squizlabs/php_codesniffer/tests/AllTests.php" --no-coverage
+"$(pwd)/vendor/bin/phpunit" --filter WordPressVIPMinimum "$(pwd)/vendor/squizlabs/php_codesniffer/tests/AllTests.php" --no-coverage $@

--- a/bin/unit-tests-coverage
+++ b/bin/unit-tests-coverage
@@ -1,0 +1,12 @@
+#!/usr/bin/env bash
+#
+# Run the unit tests with code coverage.
+#
+# This ensures that the logic in the VIP sniffs is covered by unit tests.
+#
+# EXAMPLE TO RUN LOCALLY:
+#
+#   ./bin/unit-tests-coverage
+#
+
+"$(pwd)/vendor/bin/phpunit" --filter WordPressVIPMinimum "$(pwd)/vendor/squizlabs/php_codesniffer/tests/AllTests.php"

--- a/bin/unit-tests-coverage
+++ b/bin/unit-tests-coverage
@@ -8,5 +8,12 @@
 #
 #   ./bin/unit-tests-coverage
 #
+# The script allows to pass additional PHPUnit CLI arguments.
+# For instance, if you only want to run the tests with code coverage for one
+# particular sniff, use the following, replacing "SniffName" with the name
+# of the target sniff:
+#
+#   ./bin/unit-tests-coverage --filter SniffName
+#
 
-"$(pwd)/vendor/bin/phpunit" --filter WordPressVIPMinimum "$(pwd)/vendor/squizlabs/php_codesniffer/tests/AllTests.php"
+"$(pwd)/vendor/bin/phpunit" --filter WordPressVIPMinimum "$(pwd)/vendor/squizlabs/php_codesniffer/tests/AllTests.php" $@

--- a/composer.json
+++ b/composer.json
@@ -38,6 +38,7 @@
 		],
 		"phpcs": "bin/phpcs",
 		"phpunit": "bin/unit-tests",
+		"coverage": "bin/unit-tests-coverage",
 		"test": [
 			"@lint",
 			"@ruleset",

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -5,6 +5,7 @@
 	backupGlobals="true"
 	bootstrap="./tests/bootstrap.php"
 	beStrictAboutTestsThatDoNotTestAnything="false"
+	forceCoversAnnotation="true"
 	colors="true"
 	>
 	<testsuites>

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -1,9 +1,26 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <phpunit
-		xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-		xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/7.2/phpunit.xsd"
-		backupGlobals="true"
-		bootstrap="./tests/bootstrap.php"
-		beStrictAboutTestsThatDoNotTestAnything="false"
-		colors="true">
+	xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+	xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/7.2/phpunit.xsd"
+	backupGlobals="true"
+	bootstrap="./tests/bootstrap.php"
+	beStrictAboutTestsThatDoNotTestAnything="false"
+	colors="true"
+	>
+	<testsuites>
+		<testsuite name="VIPCS_Sniffs">
+			<directory suffix="UnitTest.php">./WordPressVIPMinimum/Tests/</directory>
+		</testsuite>
+	</testsuites>
+
+	<filter>
+		<whitelist addUncoveredFilesFromWhitelist="true">
+			<directory suffix=".php">./WordPressVIPMinimum/Sniffs/</directory>
+		</whitelist>
+	</filter>
+
+	<logging>
+		<log type="coverage-html" target="./build/logs/"/>
+	</logging>
+
 </phpunit>


### PR DESCRIPTION
As part of the sniff reviews, I'll be checking that the sniffs are properly covered by unit tests.

Adding a code coverage configuration and `@covers` tags makes that simpler.

**Note**: this doesn't yet add code coverage checking to the Travis build/PR build checks. If so desired, that can be added separately.

The current code coverage results as is:
![image](https://user-images.githubusercontent.com/663378/88593601-179fae00-d060-11ea-9f9f-b51f4191435e.png)

## Commit details

###  Tests: add code coverage configuration

* PHPUnit config: add code coverage configuration.
    By default, when there is a code coverage configuration and Xdebug is enabled, code coverage will be generated.
    Note: generating code coverage is slow.
* Git ignore the `build` directory as created by PHPUnit to store the log files.
* Adjust the "normal" test script to not generate code coverage information.
* Add a `bin/unit-tests-coverage` to run the unit tests with code coverage enabled.
* Add a Composer script to call the `unit-tests-coverage` script.

### Code coverage recording: add @Covers tags

... to all unit test files, as well as enable strict coverage recording.

