### PR TITLE
Functions/RestrictedFunctions: fix false positive on class instantiation

### DIFF
--- a/WordPressVIPMinimum/Sniffs/Functions/RestrictedFunctionsSniff.php
+++ b/WordPressVIPMinimum/Sniffs/Functions/RestrictedFunctionsSniff.php
@@ -398,6 +398,7 @@ class RestrictedFunctionsSniff extends AbstractFunctionRestrictionsSniff {
 					\T_AS              => \T_AS, // Use declaration alias.
 					\T_DOUBLE_COLON    => \T_DOUBLE_COLON,
 					\T_OBJECT_OPERATOR => \T_OBJECT_OPERATOR,
+					\T_NEW             => \T_NEW,
 				];
 				if ( isset( $skipped[ $this->tokens[ $prev ]['code'] ] ) ) {
 					return false;

--- a/WordPressVIPMinimum/Tests/Functions/RestrictedFunctionsUnitTest.inc
+++ b/WordPressVIPMinimum/Tests/Functions/RestrictedFunctionsUnitTest.inc
@@ -227,3 +227,6 @@ get_page_by_path( $page_path ); // Warning.
 
 $popular = stats_get_csv( 'postviews', [ 'days'  => 2,   'limit' => 20 ] ); // Error.
 $popular = custom_stats_get_csv( 'postviews', [ 'days'  => 2,   'limit' => 20 ] ); // Ok.
+
+$foo = new Link; // OK, class, not function.
+$foo = new Mail(); // OK, class, not function.


### PR DESCRIPTION
Quick fix for false positives on class instantiation.

First new unit test was already ok, second unit test would previously fail.

Fixes #469

Notes:
* I've pointedly ignored everything else which could be improved in this sniff and just focused on getting this particular issue fixed for now.
* The parent `is_targetted_token()` method has diverged quite a bit from what is in the method in this class.
    Rather than address this now, I propose to address this once the improved/namespace and use context aware abstracts in PHPCSUtils are available as this sniff would benefit from switching over to such abstract.