### PR TITLE
Hooks/AlwaysReturnInFilter: add support for hook-ins using short arrays

### DIFF
--- a/WordPressVIPMinimum/Sniffs/Hooks/AlwaysReturnInFilterSniff.php
+++ b/WordPressVIPMinimum/Sniffs/Hooks/AlwaysReturnInFilterSniff.php
@@ -78,7 +78,9 @@ class AlwaysReturnInFilterSniff extends Sniff {
 
 		if ( 'PHPCS_T_CLOSURE' === $this->tokens[ $callbackPtr ]['code'] ) {
 			$this->processFunctionBody( $callbackPtr );
-		} elseif ( 'T_ARRAY' === $this->tokens[ $callbackPtr ]['type'] ) {
+		} elseif ( T_ARRAY === $this->tokens[ $callbackPtr ]['code']
+			|| T_OPEN_SHORT_ARRAY === $this->tokens[ $callbackPtr ]['code']
+		) {
 			$this->processArray( $callbackPtr );
 		} elseif ( true === in_array( $this->tokens[ $callbackPtr ]['code'], Tokens::$stringTokens, true ) ) {
 			$this->processString( $callbackPtr );
@@ -92,9 +94,14 @@ class AlwaysReturnInFilterSniff extends Sniff {
 	 */
 	private function processArray( $stackPtr ) {
 
+		$open_close = $this->find_array_open_close( $stackPtr );
+		if ( false === $open_close ) {
+			return;
+		}
+
 		$previous = $this->phpcsFile->findPrevious(
 			Tokens::$emptyTokens,
-			$this->tokens[ $stackPtr ]['parenthesis_closer'] - 1,
+			$open_close['closer'] - 1,
 			null,
 			true
 		);

--- a/WordPressVIPMinimum/Tests/Hooks/AlwaysReturnInFilterUnitTest.inc
+++ b/WordPressVIPMinimum/Tests/Hooks/AlwaysReturnInFilterUnitTest.inc
@@ -137,3 +137,38 @@ function bad_example_arg( $test ) { // Error.
 	// Missing universal return.
 }
 add_filter( 'bad_example_filter', 'bad_example_arg' );
+
+class good_example_class_short_array { // Ok.
+	public function __construct() {
+		add_filter( 'good_example_class_filter', [ $this, 'class_filter' ] );
+	}
+
+	public function class_filter( $param ) {
+		if ( 1 === 1 ) {
+			if ( 1 === 0 ) {
+				return 'whoops';
+			} else {
+				return 'here!';
+			}
+		}
+		return 'This is Okay';
+	}
+}
+
+class bad_example_class_short_array { // Error.
+	public function __construct() {
+		add_filter( 'bad_example_class_filter', [ $this, 'class_filter' ] );
+	}
+
+	public function class_filter( $param ) {
+		if ( 1 === 1 ) {
+			if ( 1 === 0 ) {
+				return 'whoops';
+			} else {
+				return 'here!';
+			}
+		}
+		// Missing universal return.
+	}
+}
+

--- a/WordPressVIPMinimum/Tests/Hooks/AlwaysReturnInFilterUnitTest.php
+++ b/WordPressVIPMinimum/Tests/Hooks/AlwaysReturnInFilterUnitTest.php
@@ -28,6 +28,7 @@ class AlwaysReturnInFilterUnitTest extends AbstractSniffUnitTest {
 			95  => 1,
 			105 => 1,
 			129 => 1,
+			163 => 1,
 		];
 	}
 


### PR DESCRIPTION
As VIPCS is currently using WPCS 2.x, we can use the WPCS `Sniff::find_array_open_close()` method to get the opener/closer for an array independently of the type of array (long/short).

Once VIPCS implements PHPCSUtils, this method call should be swopped out for the PHPCSUtils `Arrays::getOpenClose()` method.

Addresses #358 for the `AlwaysReturnInFilter` sniff.

Includes unit tests.