### PR TITLE
Hooks/PreGetPosts: add support for hook-ins using short arrays

### DIFF
--- a/WordPressVIPMinimum/Sniffs/Hooks/PreGetPostsSniff.php
+++ b/WordPressVIPMinimum/Sniffs/Hooks/PreGetPostsSniff.php
@@ -79,7 +79,9 @@ class PreGetPostsSniff extends Sniff {
 
 		if ( 'PHPCS_T_CLOSURE' === $this->tokens[ $callbackPtr ]['code'] ) {
 			$this->processClosure( $callbackPtr );
-		} elseif ( 'T_ARRAY' === $this->tokens[ $callbackPtr ]['type'] ) {
+		} elseif ( T_ARRAY === $this->tokens[ $callbackPtr ]['code']
+			|| T_OPEN_SHORT_ARRAY === $this->tokens[ $callbackPtr ]['code']
+		) {
 			$this->processArray( $callbackPtr );
 		} elseif ( true === in_array( $this->tokens[ $callbackPtr ]['code'], Tokens::$stringTokens, true ) ) {
 			$this->processString( $callbackPtr );
@@ -93,9 +95,14 @@ class PreGetPostsSniff extends Sniff {
 	 */
 	private function processArray( $stackPtr ) {
 
+		$open_close = $this->find_array_open_close( $stackPtr );
+		if ( false === $open_close ) {
+			return;
+		}
+
 		$previous = $this->phpcsFile->findPrevious(
 			Tokens::$emptyTokens,
-			$this->tokens[ $stackPtr ]['parenthesis_closer'] - 1,
+			$open_close['closer'] - 1,
 			null,
 			true
 		);

--- a/WordPressVIPMinimum/Tests/Hooks/PreGetPostsUnitTest.inc
+++ b/WordPressVIPMinimum/Tests/Hooks/PreGetPostsUnitTest.inc
@@ -116,3 +116,33 @@ function inline_control_structures( $query ) {
 	$query->set('meta_query', 'foo');
 	return $query;
 }
+
+class short_array_hook_in {
+
+	public function __construct() {
+		add_action( 'pre_get_posts', [ $this, 'short_pre_get_posts' ] );
+	}
+
+	public function short_pre_get_posts( $wp_query ) {
+
+		$wp_query->set( 'cat', '-5' );
+
+		if ( $wp_query->is_main_query() ) {
+			$wp_query->set( 'cat', '-5' );
+		} else if ( $wp_query->is_search() ) {
+			$wp_query->set( 'cat', '-5' );
+		}
+
+		if ( ( ! $wp_query->is_main_query() ) ) {
+			return;
+		}
+
+		$wp_query->set( 'cat', '-5' );
+
+		if ( $wp_query->is_main_query() ) {
+			$wp_query->set( 'cat', '-5' );
+		} else if ( $wp_query->is_search() ) {
+			$wp_query->set( 'cat', '-5' );
+		}
+	}
+}

--- a/WordPressVIPMinimum/Tests/Hooks/PreGetPostsUnitTest.php
+++ b/WordPressVIPMinimum/Tests/Hooks/PreGetPostsUnitTest.php
@@ -32,13 +32,15 @@ class PreGetPostsUnitTest extends AbstractSniffUnitTest {
 	 */
 	public function getWarningList() {
 		return [
-			8  => 1,
-			11 => 1,
-			29 => 1,
-			32 => 1,
-			52 => 1,
-			57 => 1,
-			87 => 1,
+			8   => 1,
+			11  => 1,
+			29  => 1,
+			32  => 1,
+			52  => 1,
+			57  => 1,
+			87  => 1,
+			128 => 1,
+			133 => 1,
 		];
 	}
 


### PR DESCRIPTION
As VIPCS is currently using WPCS 2.x, we can use the WPCS `Sniff::find_array_open_close()` method to get the opener/closer for an array independently of the type of array (long/short).

Once VIPCS implements PHPCSUtils, this method call should be swopped out for the PHPCSUtils `Arrays::getOpenClose()` method.

Addresses #358 for the `PreGetPosts` sniff.

Includes unit tests.