### PR TITLE
RestrictedFunctions: fix false negative - functions in `config_settings` would never match

### DIFF
--- a/WordPress-VIP-Go/ruleset-test.inc
+++ b/WordPress-VIP-Go/ruleset-test.inc
@@ -350,9 +350,9 @@ wp_cache_get_multi(); // Error.
 opcache_reset(); // Error.
 opcache_invalidate( 'test_script.php' ); // Error.
 opcache_compile_file( $var ); // Error.
-opcache_​is_​script_​cached( 'test_script.php' ); // Error.
-opcache_​get_​status(); // Error.
-opcache_​get_​configuration(); // Error.
+opcache_is_script_cached( 'test_script.php' ); // Error.
+opcache_get_status(); // Error.
+opcache_get_configuration(); // Error.
 get_super_admins(); // OK.
 wpcom_vip_irc(); // Error.
 flush_rewrite_rules(); // Error.

--- a/WordPressVIPMinimum/Sniffs/Functions/RestrictedFunctionsSniff.php
+++ b/WordPressVIPMinimum/Sniffs/Functions/RestrictedFunctionsSniff.php
@@ -45,9 +45,9 @@ class RestrictedFunctionsSniff extends AbstractFunctionRestrictionsSniff {
 				'type'      => 'error',
 				'message'   => '`%s` is not recommended for use on the WordPress VIP platform due to potential setting changes.',
 				'functions' => [
-					'opcache_​is_​script_​cached',
-					'opcache_​get_​status',
-					'opcache_​get_​configuration',
+					'opcache_is_script_cached',
+					'opcache_get_status',
+					'opcache_get_configuration',
 				],
 			],
 			'get_super_admins' => [

--- a/WordPressVIPMinimum/Tests/Functions/RestrictedFunctionsUnitTest.inc
+++ b/WordPressVIPMinimum/Tests/Functions/RestrictedFunctionsUnitTest.inc
@@ -21,17 +21,17 @@ wp_cache_get_multi(); // Error.
 opcache_resets(); // Ok - similarly-named custom function to opcache_reset().
 opcach_invalidate ( $test_script ); // Ok - similarly-named custom function to opcache_invalidate().
 opcache_compil_file(); // Ok - similarly-named custom function to opcache_compile_file().
-okcache_is_​script_​cached( 'test_script.php' ); // Ok - similarly-named custom function to opcache_is_script_cached().
+okcache_is_script_cached( 'test_script.php' ); // Ok - similarly-named custom function to opcache_is_script_cached().
 foo_opcache_get_status( $test_script ); // Ok - similarly-named custom function to opcache_get_status().
 opcache_get_config( $test_script ); // Ok - similary-named custom function to opcache_get_configuration().
 opcache_reset(); // Error.
 opcache_invalidate( 'test_script.php' ); // Error - one parameter.
 opcache_invalidate( $test_script, true ); // Error - two parameters.
 opcache_compile_file( $test_script ); // Error - one parameter.
-opcache_​is_​script_​cached( 'test_script.php' ); // Error - one parameter.
-opcache_​get_​status(); // Error.
-opcache_​get_​status( false ); // Error.
-opcache_​get_​configuration(); // Error.
+opcache_is_script_cached( 'test_script.php' ); // Error - one parameter.
+opcache_get_status(); // Error.
+opcache_get_status( false ); // Error.
+opcache_get_configuration(); // Error.
 
 get_super_admin(); // Ok - similarly-named function to get_super_admins().
 get_super_admins(); // Error.

--- a/WordPressVIPMinimum/ruleset-test.inc
+++ b/WordPressVIPMinimum/ruleset-test.inc
@@ -312,9 +312,9 @@ wp_cache_get_multi(); // Error.
 opcache_reset(); // Error.
 opcache_invalidate( 'test_script.php' ); // Error.
 opcache_compile_file( $var ); // Error.
-opcache_​is_​script_​cached( 'test_script.php' ); // Error.
-opcache_​get_​status(); // Error.
-opcache_​get_​configuration(); // Error.
+opcache_is_script_cached( 'test_script.php' ); // Error.
+opcache_get_status(); // Error.
+opcache_get_configuration(); // Error.
 get_super_admins(); // Error.
 wpcom_vip_irc(); // Error.
 flush_rewrite_rules(); // Error.


### PR DESCRIPTION
The functions in the `config_settings` group were using a unicode `_`, not the ascii `_`, so these would never match the PHP native `opcache_*` functions they were intended to match.

As the same unicode character was used in the applicable unit tests and ruleset tests, the bug was never reported as a test failure.

Related to #518 (sniff review)