### PR TITLE
RestrictedVariables: don't report on "use" in `isset()`

### DIFF
--- a/WordPress-VIP-Go/ruleset-test.inc
+++ b/WordPress-VIP-Go/ruleset-test.inc
@@ -53,7 +53,7 @@ setcookie( 'cookie[three]', 'cookiethree' ); // Error + Message.
 $x = sanitize_key( $_COOKIE['bar'] ); // phpcs:ignore WordPress.Security.ValidatedSanitizedInput.InputNotValidated -- Error + Message.
 
 // WordPressVIPMinimum.Variables.RestrictedVariables.cache_constraints___SERVER__HTTP_USER_AGENT__
-if ( ! isset( $_SERVER['HTTP_USER_AGENT'] ) ) { // Error + Message.
+if ( isset( $_SERVER['HTTP_USER_AGENT'] ) && $_SERVER['HTTP_USER_AGENT'] === 'some_value' ) { // Error + Message.
 }
 
 // WordPress.WP.AlternativeFunctions.file_system_read_fclose

--- a/WordPressVIPMinimum/Sniffs/AbstractVariableRestrictionsSniff.php
+++ b/WordPressVIPMinimum/Sniffs/AbstractVariableRestrictionsSniff.php
@@ -143,6 +143,11 @@ abstract class AbstractVariableRestrictionsSniff extends Sniff {
 			}
 		}
 
+		if ( $this->is_in_isset_or_empty( $stackPtr ) === true ) {
+			// Checking whether a variable exists is not the same as using it.
+			return;
+		}
+
 		foreach ( $this->groups_cache as $groupName => $group ) {
 
 			if ( isset( $this->excluded_groups[ $groupName ] ) ) {

--- a/WordPressVIPMinimum/Tests/Variables/RestrictedVariablesUnitTest.inc
+++ b/WordPressVIPMinimum/Tests/Variables/RestrictedVariablesUnitTest.inc
@@ -10,8 +10,8 @@ $wp_db->update( $wpdb->usermeta, array( 'meta_value' => 'bar!' ), array( 'user_i
 
 $query = "SELECT * FROM $wpdb->posts"; // Ok.
 
-if ( isset( $_SERVER['REMOTE_ADDR'] ) ) { // Warning.
-	foo( $_SERVER['HTTP_USER_AGENT'] ); // Warning.
+if ( isset( $_SERVER['REMOTE_ADDR'] ) ) { // OK.
+	foo( $_SERVER['REMOTE_ADDR'] ); // Warning.
 }
 
 $x = $_COOKIE['bar']; // Warning.
@@ -35,3 +35,7 @@ $query = "SELECT * FROM $wpdb->usermeta"; // Ok, excluded.
 
 foo( $_SESSION ); // Error.
 foo( $_SESSION['bar'] ); // Error.
+
+if ( isset( $_SESSION ) ) { // OK.
+	$cache = false;
+}

--- a/WordPressVIPMinimum/Tests/Variables/RestrictedVariablesUnitTest.php
+++ b/WordPressVIPMinimum/Tests/Variables/RestrictedVariablesUnitTest.php
@@ -43,7 +43,6 @@ class RestrictedVariablesUnitTest extends AbstractSniffUnitTest {
 	 */
 	public function getWarningList() {
 		return [
-			13 => 1,
 			14 => 1,
 			17 => 1,
 			28 => 1,


### PR DESCRIPTION
Disregard when the existence of a restricted variable is being checked. This uses the upstream WPCS `Sniff::is_in_isset_or_empty()` method.

This means that variables will not be reported as "used" when they are wrapped in a call to:
* `isset()`
* `empty()`
* `array_key_exists()`

This also means that the `if ( isset( $_SERVER['REMOTE_ADDR'] ) ) {` test on line 13 will no longer report a warning.

As `$_SERVER['REMOTE_ADDR']` was then no longer tested for and `$_SERVER['HTTP_USER_AGENT']` was being tested twice (line 14 and line 28), I've changed the occurrence on line 14 to use `$_SERVER['REMOTE_ADDR']` to make sure both are still tested.

Includes additional unit test for the case as reported by the op.

Fixes #568