### PR TITLE
CS: remove yoda conditions from VIPCS codebase

### DIFF
--- a/.phpcs.xml.dist
+++ b/.phpcs.xml.dist
@@ -17,6 +17,7 @@
 		<exclude name="WordPress.Files.FileName"/>
 		<exclude name="WordPress.NamingConventions.ValidVariableName"/>
 		<exclude name="Generic.Arrays.DisallowShortArraySyntax"/>
+		<exclude name="WordPress.PHP.YodaConditions"/>
 	</rule>
 
 	<rule ref="WordPress-Docs"/>
@@ -32,8 +33,11 @@
 
 	<rule ref="PSR2.Methods.FunctionClosingBrace"/>
 
-	<!-- Disallow long array syntax -->
+	<!-- Disallow long array syntax. -->
 	<rule ref="Generic.Arrays.DisallowLongArraySyntax"/>
+
+	<!-- Disallow Yoda conditions. -->
+	<rule ref="Generic.ControlStructures.DisallowYodaConditions"/>
 
 	<!-- Check code for cross-version PHP compatibility. -->
 	<config name="testVersion" value="5.4-"/>

--- a/WordPressVIPMinimum/Sniffs/AbstractVariableRestrictionsSniff.php
+++ b/WordPressVIPMinimum/Sniffs/AbstractVariableRestrictionsSniff.php
@@ -61,7 +61,7 @@ abstract class AbstractVariableRestrictionsSniff extends Sniff {
 	 */
 	public function register() {
 		// Retrieve the groups only once and don't set up a listener if there are no groups.
-		if ( false === $this->setup_groups() ) {
+		if ( $this->setup_groups() === false ) {
 			return [];
 		}
 
@@ -138,7 +138,7 @@ abstract class AbstractVariableRestrictionsSniff extends Sniff {
 		if ( \in_array( $token['code'], [ \T_OBJECT_OPERATOR, \T_DOUBLE_COLON ], true ) ) { // This only works for object vars and array members.
 			$method               = $this->phpcsFile->findNext( \T_WHITESPACE, $stackPtr + 1, null, true );
 			$possible_parenthesis = $this->phpcsFile->findNext( \T_WHITESPACE, $method + 1, null, true );
-			if ( \T_OPEN_PARENTHESIS === $this->tokens[ $possible_parenthesis ]['code'] ) {
+			if ( $this->tokens[ $possible_parenthesis ]['code'] === \T_OPEN_PARENTHESIS ) {
 				return; // So .. it is a function after all !
 			}
 		}
@@ -185,9 +185,9 @@ abstract class AbstractVariableRestrictionsSniff extends Sniff {
 
 			$patterns = array_map( [ $this, 'test_patterns' ], $patterns );
 			$pattern  = implode( '|', $patterns );
-			$delim    = ( \T_OPEN_SQUARE_BRACKET !== $token['code'] && \T_HEREDOC !== $token['code'] ) ? '\b' : '';
+			$delim    = ( $token['code'] !== \T_OPEN_SQUARE_BRACKET && $token['code'] !== \T_HEREDOC ) ? '\b' : '';
 
-			if ( \T_DOUBLE_QUOTED_STRING === $token['code'] || \T_HEREDOC === $token['code'] ) {
+			if ( $token['code'] === \T_DOUBLE_QUOTED_STRING || $token['code'] === \T_HEREDOC ) {
 				$var = $token['content'];
 			}
 
@@ -198,7 +198,7 @@ abstract class AbstractVariableRestrictionsSniff extends Sniff {
 			$this->addMessage(
 				$group['message'],
 				$stackPtr,
-				'error' === $group['type'],
+				$group['type'] === 'error',
 				$this->string_to_errorcode( $groupName . '_' . $match[1] ),
 				[ $var ]
 			);

--- a/WordPressVIPMinimum/Sniffs/Classes/DeclarationCompatibilitySniff.php
+++ b/WordPressVIPMinimum/Sniffs/Classes/DeclarationCompatibilitySniff.php
@@ -218,7 +218,7 @@ class DeclarationCompatibilitySniff extends AbstractScopeSniff {
 		$methodName = $phpcsFile->getDeclarationName( $stackPtr );
 
 		$parentClassName = $phpcsFile->findExtendedClassName( $currScope );
-		if ( false === $parentClassName ) {
+		if ( $parentClassName === false ) {
 			// This class does not extend any other class.
 			return;
 		}
@@ -226,7 +226,7 @@ class DeclarationCompatibilitySniff extends AbstractScopeSniff {
 		// Meed to define the originalParentClassName since we might override the parentClassName due to signature notations grouping.
 		$originalParentClassName = $parentClassName;
 
-		if ( false === array_key_exists( $parentClassName, $this->checkClasses ) ) {
+		if ( array_key_exists( $parentClassName, $this->checkClasses ) === false ) {
 			// This class does not extend a class we are interested in.
 			foreach ( $this->checkClassesGroups as $parent => $children ) {
 				// But it might be one of the grouped classes.
@@ -237,14 +237,14 @@ class DeclarationCompatibilitySniff extends AbstractScopeSniff {
 					}
 				}
 			}
-			if ( false === array_key_exists( $parentClassName, $this->checkClasses ) ) {
+			if ( array_key_exists( $parentClassName, $this->checkClasses ) === false ) {
 				// This class really does not extend a class we are interested in.
 				return;
 			}
 		}
 
-		if ( false === array_key_exists( $methodName, $this->checkClasses[ $parentClassName ] ) &&
-			false === in_array( $methodName, $this->checkClasses[ $parentClassName ], true )
+		if ( array_key_exists( $methodName, $this->checkClasses[ $parentClassName ] ) === false &&
+			in_array( $methodName, $this->checkClasses[ $parentClassName ], true ) === false
 		) {
 			// This method is not a one we are interested in.
 			return;
@@ -258,11 +258,11 @@ class DeclarationCompatibilitySniff extends AbstractScopeSniff {
 			$extra_params                  = array_slice( $signatureParams, count( $parentSignature ) - count( $signatureParams ) );
 			$all_extra_params_have_default = true;
 			foreach ( $extra_params as $extra_param ) {
-				if ( false === array_key_exists( 'default', $extra_param ) || 'true' !== $extra_param['default'] ) {
+				if ( array_key_exists( 'default', $extra_param ) === false || $extra_param['default'] !== 'true' ) {
 					$all_extra_params_have_default = false;
 				}
 			}
-			if ( true === $all_extra_params_have_default ) {
+			if ( $all_extra_params_have_default === true ) {
 				return; // We're good.
 			}
 		}
@@ -274,16 +274,16 @@ class DeclarationCompatibilitySniff extends AbstractScopeSniff {
 
 		$i = 0;
 		foreach ( $parentSignature as $key => $param ) {
-			if ( true === is_array( $param ) ) {
+			if ( is_array( $param ) === true ) {
 				if (
 					(
-						true === array_key_exists( 'default', $param ) &&
-						false === array_key_exists( 'default', $signatureParams[ $i ] )
+						array_key_exists( 'default', $param ) === true &&
+						array_key_exists( 'default', $signatureParams[ $i ] ) === false
 					) || (
-						true === array_key_exists( 'pass_by_reference', $param ) &&
+						array_key_exists( 'pass_by_reference', $param ) === true &&
 						$param['pass_by_reference'] !== $signatureParams[ $i ]['pass_by_reference']
 					) || (
-						true === array_key_exists( 'variable_length', $param ) &&
+						array_key_exists( 'variable_length', $param ) === true &&
 						$param['variable_length'] !== $signatureParams[ $i ]['variable_length']
 					)
 				) {
@@ -329,26 +329,26 @@ class DeclarationCompatibilitySniff extends AbstractScopeSniff {
 		$paramList = [];
 		foreach ( $methodSignature as $param => $options ) {
 			$paramName = '$';
-			if ( false === is_array( $options ) ) {
+			if ( is_array( $options ) === false ) {
 				$paramList[] = '$' . $options;
 				continue;
 			}
 
-			if ( true === array_key_exists( 'name', $options ) ) {
+			if ( array_key_exists( 'name', $options ) === true ) {
 				$paramName = $options['name'];
 			} else {
 				$paramName .= $param;
 			}
 
-			if ( true === array_key_exists( 'variable_length', $options ) && true === $options['variable_length'] ) {
+			if ( array_key_exists( 'variable_length', $options ) === true && $options['variable_length'] === true ) {
 				$paramName = '...' . $paramName;
 			}
 
-			if ( true === array_key_exists( 'pass_by_reference', $options ) && true === $options['pass_by_reference'] ) {
+			if ( array_key_exists( 'pass_by_reference', $options ) === true && $options['pass_by_reference'] === true ) {
 				$paramName = '&' . $paramName;
 			}
 
-			if ( true === array_key_exists( 'default', $options ) && false === empty( $options['default'] ) ) {
+			if ( array_key_exists( 'default', $options ) === true && empty( $options['default'] ) === false ) {
 				$paramName .= ' = ' . trim( $options['default'] );
 			}
 
@@ -371,7 +371,7 @@ class DeclarationCompatibilitySniff extends AbstractScopeSniff {
 		$tokens             = $phpcsFile->getTokens();
 
 		for ( $i = ( $tokens[ $currScope ]['scope_opener'] + 1 ); $i < $tokens[ $currScope ]['scope_closer']; $i++ ) {
-			if ( T_FUNCTION !== $tokens[ $i ]['code'] ) {
+			if ( $tokens[ $i ]['code'] !== T_FUNCTION ) {
 				continue;
 			}
 

--- a/WordPressVIPMinimum/Sniffs/Classes/RestrictedExtendClassesSniff.php
+++ b/WordPressVIPMinimum/Sniffs/Classes/RestrictedExtendClassesSniff.php
@@ -47,7 +47,7 @@ class RestrictedExtendClassesSniff extends AbstractClassRestrictionsSniff {
 	public function process_matched_token( $stackPtr, $group_name, $matched_content ) {
 		$tokens = $this->phpcsFile->getTokens();
 
-		if ( T_EXTENDS !== $tokens[ $stackPtr ]['code'] ) {
+		if ( $tokens[ $stackPtr ]['code'] !== T_EXTENDS ) {
 			// If not extending, bail.
 			return;
 		}

--- a/WordPressVIPMinimum/Sniffs/Compatibility/ZoninatorSniff.php
+++ b/WordPressVIPMinimum/Sniffs/Compatibility/ZoninatorSniff.php
@@ -35,26 +35,26 @@ class ZoninatorSniff extends Sniff {
 	 */
 	public function process_token( $stackPtr ) {
 
-		if ( 'wpcom_vip_load_plugin' !== $this->tokens[ $stackPtr ]['content'] ) {
+		if ( $this->tokens[ $stackPtr ]['content'] !== 'wpcom_vip_load_plugin' ) {
 			return;
 		}
 
 		$openBracket = $this->phpcsFile->findNext( Tokens::$emptyTokens, $stackPtr + 1, null, true );
 
-		if ( T_OPEN_PARENTHESIS !== $this->tokens[ $openBracket ]['code'] ) {
+		if ( $this->tokens[ $openBracket ]['code'] !== T_OPEN_PARENTHESIS ) {
 			// Not a function call.
 			return;
 		}
 
 		$plugin_name = $this->phpcsFile->findNext( Tokens::$emptyTokens, $openBracket + 1, null, true );
 
-		if ( 'zoninator' !== $this->remove_wrapping_quotation_marks( $this->tokens[ $plugin_name ]['content'] ) ) {
+		if ( $this->remove_wrapping_quotation_marks( $this->tokens[ $plugin_name ]['content'] ) !== 'zoninator' ) {
 			return;
 		}
 
 		$comma = $this->phpcsFile->findNext( Tokens::$emptyTokens, $plugin_name + 1, null, true );
 
-		if ( ! $comma || 'PHPCS_T_COMMA' !== $this->tokens[ $comma ]['code'] ) {
+		if ( ! $comma || $this->tokens[ $comma ]['code'] !== 'PHPCS_T_COMMA' ) {
 			// We are loading the default version.
 			return;
 		}
@@ -63,7 +63,7 @@ class ZoninatorSniff extends Sniff {
 
 		$comma = $this->phpcsFile->findNext( Tokens::$emptyTokens, $folder + 1, null, true );
 
-		if ( ! $comma || 'PHPCS_T_COMMA' !== $this->tokens[ $comma ]['code'] ) {
+		if ( ! $comma || $this->tokens[ $comma ]['code'] !== 'PHPCS_T_COMMA' ) {
 			// We are loading the default version.
 			return;
 		}
@@ -71,7 +71,7 @@ class ZoninatorSniff extends Sniff {
 		$version = $this->phpcsFile->findNext( Tokens::$emptyTokens, $comma + 1, null, true );
 		$version = $this->remove_wrapping_quotation_marks( $this->tokens[ $version ]['content'] );
 
-		if ( true === version_compare( $version, '0.8', '>=' ) ) {
+		if ( version_compare( $version, '0.8', '>=' ) === true ) {
 			$message = 'Zoninator of version >= v0.8 requires WordPress core REST API. Please, make sure the `wpcom_vip_load_wp_rest_api()` is being called on all sites loading this file.';
 			$this->phpcsFile->addWarning( $message, $stackPtr, 'RequiresRESTAPI' );
 		}

--- a/WordPressVIPMinimum/Sniffs/Constants/ConstantStringSniff.php
+++ b/WordPressVIPMinimum/Sniffs/Constants/ConstantStringSniff.php
@@ -38,26 +38,26 @@ class ConstantStringSniff extends Sniff {
 	 */
 	public function process_token( $stackPtr ) {
 
-		if ( false === in_array( $this->tokens[ $stackPtr ]['content'], [ 'define', 'defined' ], true ) ) {
+		if ( in_array( $this->tokens[ $stackPtr ]['content'], [ 'define', 'defined' ], true ) === false ) {
 			return;
 		}
 
 		// Find the next non-empty token.
 		$nextToken = $this->phpcsFile->findNext( Tokens::$emptyTokens, $stackPtr + 1, null, true, null, true );
 
-		if ( T_OPEN_PARENTHESIS !== $this->tokens[ $nextToken ]['code'] ) {
+		if ( $this->tokens[ $nextToken ]['code'] !== T_OPEN_PARENTHESIS ) {
 			// Not a function call.
 			return;
 		}
 
-		if ( false === isset( $this->tokens[ $nextToken ]['parenthesis_closer'] ) ) {
+		if ( isset( $this->tokens[ $nextToken ]['parenthesis_closer'] ) === false ) {
 			// Not a function call.
 			return;
 		}
 
 		$nextToken = $this->phpcsFile->findNext( Tokens::$emptyTokens, $nextToken + 1, null, true, null, true );
 
-		if ( T_CONSTANT_ENCAPSED_STRING !== $this->tokens[ $nextToken ]['code'] ) {
+		if ( $this->tokens[ $nextToken ]['code'] !== T_CONSTANT_ENCAPSED_STRING ) {
 			$message = 'Constant name, as a string, should be used along with `%s()`.';
 			$data    = [ $this->tokens[ $stackPtr ]['content'] ];
 			$this->phpcsFile->addError( $message, $nextToken, 'NotCheckingConstantName', $data );

--- a/WordPressVIPMinimum/Sniffs/Constants/RestrictedConstantsSniff.php
+++ b/WordPressVIPMinimum/Sniffs/Constants/RestrictedConstantsSniff.php
@@ -58,18 +58,18 @@ class RestrictedConstantsSniff extends Sniff {
 	 */
 	public function process_token( $stackPtr ) {
 
-		if ( T_STRING === $this->tokens[ $stackPtr ]['code'] ) {
+		if ( $this->tokens[ $stackPtr ]['code'] === T_STRING ) {
 			$constantName = $this->tokens[ $stackPtr ]['content'];
 		} else {
 			$constantName = trim( $this->tokens[ $stackPtr ]['content'], "\"'" );
 		}
 
-		if ( false === in_array( $constantName, $this->restrictedConstantNames, true ) && false === in_array( $constantName, $this->restrictedConstantDeclaration, true ) ) {
+		if ( in_array( $constantName, $this->restrictedConstantNames, true ) === false && in_array( $constantName, $this->restrictedConstantDeclaration, true ) === false ) {
 			// Not the constant we are looking for.
 			return;
 		}
 
-		if ( T_STRING === $this->tokens[ $stackPtr ]['code'] && true === in_array( $constantName, $this->restrictedConstantNames, true ) ) {
+		if ( $this->tokens[ $stackPtr ]['code'] === T_STRING && in_array( $constantName, $this->restrictedConstantNames, true ) === true ) {
 			$message = 'Code is touching the `%s` constant. Make sure it\'s used appropriately.';
 			$data    = [ $constantName ];
 			$this->phpcsFile->addWarning( $message, $stackPtr, 'UsingRestrictedConstant', $data );
@@ -79,12 +79,12 @@ class RestrictedConstantsSniff extends Sniff {
 		// Find the previous non-empty token.
 		$openBracket = $this->phpcsFile->findPrevious( Tokens::$emptyTokens, $stackPtr - 1, null, true, null, true );
 
-		if ( T_OPEN_PARENTHESIS !== $this->tokens[ $openBracket ]['code'] ) {
+		if ( $this->tokens[ $openBracket ]['code'] !== T_OPEN_PARENTHESIS ) {
 			// Not a function call.
 			return;
 		}
 
-		if ( false === isset( $this->tokens[ $openBracket ]['parenthesis_closer'] ) ) {
+		if ( isset( $this->tokens[ $openBracket ]['parenthesis_closer'] ) === false ) {
 			// Not a function call.
 			return;
 		}
@@ -93,17 +93,17 @@ class RestrictedConstantsSniff extends Sniff {
 		$search   = Tokens::$emptyTokens;
 		$search[] = T_BITWISE_AND;
 		$previous = $this->phpcsFile->findPrevious( $search, $openBracket - 1, null, true );
-		if ( T_FUNCTION === $this->tokens[ $previous ]['code'] ) {
+		if ( $this->tokens[ $previous ]['code'] === T_FUNCTION ) {
 			// It's a function definition, not a function call.
 			return;
 		}
 
-		if ( true === in_array( $this->tokens[ $previous ]['code'], Tokens::$functionNameTokens, true ) ) {
+		if ( in_array( $this->tokens[ $previous ]['code'], Tokens::$functionNameTokens, true ) === true ) {
 			$data = [ $constantName ];
-			if ( 'define' === $this->tokens[ $previous ]['content'] ) {
+			if ( $this->tokens[ $previous ]['content'] === 'define' ) {
 				$message = 'The definition of `%s` constant is prohibited. Please use a different name.';
 				$this->phpcsFile->addError( $message, $previous, 'DefiningRestrictedConstant', $data );
-			} elseif ( true === in_array( $constantName, $this->restrictedConstantNames, true ) ) {
+			} elseif ( in_array( $constantName, $this->restrictedConstantNames, true ) === true ) {
 				$message = 'Code is touching the `%s` constant. Make sure it\'s used appropriately.';
 				$this->phpcsFile->addWarning( $message, $previous, 'UsingRestrictedConstant', $data );
 			}

--- a/WordPressVIPMinimum/Sniffs/Files/IncludingFileSniff.php
+++ b/WordPressVIPMinimum/Sniffs/Files/IncludingFileSniff.php
@@ -94,35 +94,35 @@ class IncludingFileSniff extends AbstractFunctionRestrictionsSniff {
 	public function process_token( $stackPtr ) {
 		$nextToken = $this->phpcsFile->findNext( Tokens::$emptyTokens, $stackPtr + 1, null, true, null, true );
 
-		if ( T_OPEN_PARENTHESIS === $this->tokens[ $nextToken ]['code'] ) {
+		if ( $this->tokens[ $nextToken ]['code'] === T_OPEN_PARENTHESIS ) {
 			// The construct is using parenthesis, grab the next non empty token.
 			$nextToken = $this->phpcsFile->findNext( Tokens::$emptyTokens, $nextToken + 1, null, true, null, true );
 		}
 
-		if ( T_DIR === $this->tokens[ $nextToken ]['code'] || '__DIR__' === $this->tokens[ $nextToken ]['content'] ) {
+		if ( $this->tokens[ $nextToken ]['code'] === T_DIR || $this->tokens[ $nextToken ]['content'] === '__DIR__' ) {
 			// The construct is using __DIR__ which is fine.
 			return;
 		}
 
-		if ( T_VARIABLE === $this->tokens[ $nextToken ]['code'] ) {
+		if ( $this->tokens[ $nextToken ]['code'] === T_VARIABLE ) {
 			$message = 'File inclusion using variable (`%s`). Probably needs manual inspection.';
 			$data    = [ $this->tokens[ $nextToken ]['content'] ];
 			$this->phpcsFile->addWarning( $message, $nextToken, 'UsingVariable', $data );
 			return;
 		}
 
-		if ( T_STRING === $this->tokens[ $nextToken ]['code'] ) {
-			if ( true === in_array( $this->tokens[ $nextToken ]['content'], $this->getPathFunctions, true ) ) {
+		if ( $this->tokens[ $nextToken ]['code'] === T_STRING ) {
+			if ( in_array( $this->tokens[ $nextToken ]['content'], $this->getPathFunctions, true ) === true ) {
 				// The construct is using one of the function for getting correct path which is fine.
 				return;
 			}
 
-			if ( true === in_array( $this->tokens[ $nextToken ]['content'], $this->allowedConstants, true ) ) {
+			if ( in_array( $this->tokens[ $nextToken ]['content'], $this->allowedConstants, true ) === true ) {
 				// The construct is using one of the allowed constants which is fine.
 				return;
 			}
 
-			if ( true === array_key_exists( $this->tokens[ $nextToken ]['content'], $this->restrictedConstants ) ) {
+			if ( array_key_exists( $this->tokens[ $nextToken ]['content'], $this->restrictedConstants ) === true ) {
 				// The construct is using one of the restricted constants.
 				$message = '`%s` constant might not be defined or available. Use `%s()` instead.';
 				$data    = [ $this->tokens[ $nextToken ]['content'], $this->restrictedConstants[ $this->tokens[ $nextToken ]['content'] ] ];
@@ -131,7 +131,7 @@ class IncludingFileSniff extends AbstractFunctionRestrictionsSniff {
 			}
 
 			$nextNextToken = $this->phpcsFile->findNext( array_merge( Tokens::$emptyTokens, [ T_COMMENT ] ), $nextToken + 1, null, true, null, true );
-			if ( 1 === preg_match( '/^[a-zA-Z_\x7f-\xff][a-zA-Z0-9_\x7f-\xff]*$/', $this->tokens[ $nextToken ]['content'] ) && T_OPEN_PARENTHESIS !== $this->tokens[ $nextNextToken ]['code'] ) {
+			if ( preg_match( '/^[a-zA-Z_\x7f-\xff][a-zA-Z0-9_\x7f-\xff]*$/', $this->tokens[ $nextToken ]['content'] ) === 1 && $this->tokens[ $nextNextToken ]['code'] !== T_OPEN_PARENTHESIS ) {
 				// The construct is using custom constant, which needs manual inspection.
 				$message = 'File inclusion using custom constant (`%s`). Probably needs manual inspection.';
 				$data    = [ $this->tokens[ $nextToken ]['content'] ];
@@ -139,14 +139,14 @@ class IncludingFileSniff extends AbstractFunctionRestrictionsSniff {
 				return;
 			}
 
-			if ( 0 === strpos( $this->tokens[ $nextToken ]['content'], '$' ) ) {
+			if ( strpos( $this->tokens[ $nextToken ]['content'], '$' ) === 0 ) {
 				$message = 'File inclusion using variable (`%s`). Probably needs manual inspection.';
 				$data    = [ $this->tokens[ $nextToken ]['content'] ];
 				$this->phpcsFile->addWarning( $message, $nextToken, 'UsingVariable', $data );
 				return;
 			}
 
-			if ( true === in_array( $this->tokens[ $nextToken ]['content'], $this->slashingFunctions, true ) ) {
+			if ( in_array( $this->tokens[ $nextToken ]['content'], $this->slashingFunctions, true ) === true ) {
 				// The construct is using one of the slashing functions, it's probably correct.
 				return;
 			}
@@ -163,7 +163,7 @@ class IncludingFileSniff extends AbstractFunctionRestrictionsSniff {
 			return;
 		}
 
-		if ( T_CONSTANT_ENCAPSED_STRING === $this->tokens[ $nextToken ]['code'] && filter_var( str_replace( [ '"', "'" ], '', $this->tokens[ $nextToken ]['content'] ), FILTER_VALIDATE_URL ) ) {
+		if ( $this->tokens[ $nextToken ]['code'] === T_CONSTANT_ENCAPSED_STRING && filter_var( str_replace( [ '"', "'" ], '', $this->tokens[ $nextToken ]['content'] ), FILTER_VALIDATE_URL ) ) {
 			$message = 'Include path must be local file source, external URLs are prohibited on WordPress VIP.';
 			$this->phpcsFile->addError( $message, $nextToken, 'ExternalURL' );
 			return;

--- a/WordPressVIPMinimum/Sniffs/Files/IncludingNonPHPFileSniff.php
+++ b/WordPressVIPMinimum/Sniffs/Files/IncludingNonPHPFileSniff.php
@@ -40,10 +40,10 @@ class IncludingNonPHPFileSniff extends Sniff {
 	 */
 	public function process_token( $stackPtr ) {
 		$curStackPtr = $stackPtr;
-		while ( false !== $this->phpcsFile->findNext( Tokens::$stringTokens, $curStackPtr + 1, null, false, null, true ) ) {
+		while ( $this->phpcsFile->findNext( Tokens::$stringTokens, $curStackPtr + 1, null, false, null, true ) !== false ) {
 			$curStackPtr = $this->phpcsFile->findNext( Tokens::$stringTokens, $curStackPtr + 1, null, false, null, true );
 
-			if ( T_CONSTANT_ENCAPSED_STRING === $this->tokens[ $curStackPtr ]['code'] ) {
+			if ( $this->tokens[ $curStackPtr ]['code'] === T_CONSTANT_ENCAPSED_STRING ) {
 				$stringWithoutEnclosingQuotationMarks = trim( $this->tokens[ $curStackPtr ]['content'], "\"'" );
 			} else {
 				$stringWithoutEnclosingQuotationMarks = $this->tokens[ $curStackPtr ]['content'];
@@ -51,12 +51,12 @@ class IncludingNonPHPFileSniff extends Sniff {
 
 			$isFileName = preg_match( '/.*(\.[a-z]{2,})$/i', $stringWithoutEnclosingQuotationMarks, $regexMatches );
 
-			if ( false === $isFileName || 0 === $isFileName ) {
+			if ( $isFileName === false || $isFileName === 0 ) {
 				continue;
 			}
 
 			$extension = $regexMatches[1];
-			if ( true === in_array( $extension, [ '.php', '.inc' ], true ) ) {
+			if ( in_array( $extension, [ '.php', '.inc' ], true ) === true ) {
 				return;
 			}
 
@@ -64,7 +64,7 @@ class IncludingNonPHPFileSniff extends Sniff {
 			$data    = [ $this->tokens[ $stackPtr ]['content'] ];
 			$code    = 'IncludingNonPHPFile';
 
-			if ( true === in_array( $extension, [ '.svg', '.css' ], true ) ) {
+			if ( in_array( $extension, [ '.svg', '.css' ], true ) === true ) {
 				// Be more specific for SVG and CSS files.
 				$message = 'Local SVG and CSS files should be loaded via `file_get_contents` rather than via `%s`.';
 				$code    = 'IncludingSVGCSSFile';

--- a/WordPressVIPMinimum/Sniffs/Functions/CheckReturnValueSniff.php
+++ b/WordPressVIPMinimum/Sniffs/Functions/CheckReturnValueSniff.php
@@ -86,14 +86,14 @@ class CheckReturnValueSniff extends Sniff {
 	 */
 	private function isFunctionCall( $stackPtr ) {
 
-		if ( false === in_array( $this->tokens[ $stackPtr ]['code'], Tokens::$functionNameTokens, true ) ) {
+		if ( in_array( $this->tokens[ $stackPtr ]['code'], Tokens::$functionNameTokens, true ) === false ) {
 			return false;
 		}
 
 		// Find the next non-empty token.
 		$openBracket = $this->phpcsFile->findNext( Tokens::$emptyTokens, $stackPtr + 1, null, true );
 
-		if ( T_OPEN_PARENTHESIS !== $this->tokens[ $openBracket ]['code'] ) {
+		if ( $this->tokens[ $openBracket ]['code'] !== T_OPEN_PARENTHESIS ) {
 			// Not a function call.
 			return false;
 		}
@@ -104,7 +104,7 @@ class CheckReturnValueSniff extends Sniff {
 		$previous = $this->phpcsFile->findPrevious( $search, $stackPtr - 1, null, true );
 
 		// It's a function definition, not a function call, so return false.
-		return ! ( T_FUNCTION === $this->tokens[ $previous ]['code'] );
+		return ! ( $this->tokens[ $previous ]['code'] === T_FUNCTION );
 	}
 
 	/**
@@ -121,14 +121,14 @@ class CheckReturnValueSniff extends Sniff {
 		$search[] = T_BITWISE_AND;
 		$previous = $this->phpcsFile->findPrevious( $search, $stackPtr - 1, null, true );
 
-		if ( T_EQUAL !== $this->tokens[ $previous ]['code'] ) {
+		if ( $this->tokens[ $previous ]['code'] !== T_EQUAL ) {
 			// It's not a variable assignment.
 			return false;
 		}
 
 		$previous = $this->phpcsFile->findPrevious( $search, $previous - 1, null, true );
 
-		if ( T_VARIABLE !== $this->tokens[ $previous ]['code'] ) {
+		if ( $this->tokens[ $previous ]['code'] !== T_VARIABLE ) {
 			// It's not a variable assignment.
 			return false;
 		}
@@ -145,12 +145,12 @@ class CheckReturnValueSniff extends Sniff {
 
 		$functionName = $this->tokens[ $stackPtr ]['content'];
 
-		if ( false === array_key_exists( $functionName, $this->catch ) ) {
+		if ( array_key_exists( $functionName, $this->catch ) === false ) {
 			// Not a function we are looking for.
 			return;
 		}
 
-		if ( false === $this->isFunctionCall( $stackPtr ) ) {
+		if ( $this->isFunctionCall( $stackPtr ) === false ) {
 			// Not a function call.
 			return;
 		}
@@ -164,7 +164,7 @@ class CheckReturnValueSniff extends Sniff {
 		$startNext = $openBracket + 1;
 		$next      = $this->phpcsFile->findNext( Tokens::$functionNameTokens, $startNext, $closeBracket, false, null, true );
 		while ( $next ) {
-			if ( true === in_array( $this->tokens[ $next ]['content'], $this->catch[ $functionName ], true ) ) {
+			if ( in_array( $this->tokens[ $next ]['content'], $this->catch[ $functionName ], true ) === true ) {
 				$message = "`%s`'s return type must be checked before calling `%s` using that value.";
 				$data    = [ $this->tokens[ $next ]['content'], $functionName ];
 				$this->phpcsFile->addError( $message, $next, 'DirectFunctionCall', $data );
@@ -192,25 +192,25 @@ class CheckReturnValueSniff extends Sniff {
 		$callees = [];
 
 		foreach ( $this->catch as $callee => $checkReturnArray ) {
-			if ( true === in_array( $functionName, $checkReturnArray, true ) ) {
+			if ( in_array( $functionName, $checkReturnArray, true ) === true ) {
 				$isFunctionWeLookFor = true;
 				$callees[]           = $callee;
 			}
 		}
 
-		if ( false === $isFunctionWeLookFor ) {
+		if ( $isFunctionWeLookFor === false ) {
 			// Not a function we are looking for.
 			return;
 		}
 
-		if ( false === $this->isFunctionCall( $stackPtr ) ) {
+		if ( $this->isFunctionCall( $stackPtr ) === false ) {
 			// Not a function call.
 			return;
 		}
 
 		$variablePos = $this->isVariableAssignment( $stackPtr );
 
-		if ( false === $variablePos ) {
+		if ( $variablePos === false ) {
 			// Not a variable assignment.
 			return;
 		}
@@ -224,7 +224,7 @@ class CheckReturnValueSniff extends Sniff {
 		// Find the closing bracket.
 		$closeBracket = $this->tokens[ $openBracket ]['parenthesis_closer'];
 
-		if ( true === in_array( $functionName, [ 'get_post_meta', 'get_term_meta' ], true ) ) {
+		if ( in_array( $functionName, [ 'get_post_meta', 'get_term_meta' ], true ) === true ) {
 			// Since the get_post_meta and get_term_meta always returns an array if $single is set to `true` we need to check for the value of it's third param before proceeding.
 			$params       = [];
 			$paramNo      = 1;
@@ -232,11 +232,11 @@ class CheckReturnValueSniff extends Sniff {
 
 			for ( $i = $openBracket + 1; $i <= $closeBracket; $i++ ) {
 
-				if ( T_OPEN_PARENTHESIS === $this->tokens[ $i ]['code'] ) {
+				if ( $this->tokens[ $i ]['code'] === T_OPEN_PARENTHESIS ) {
 					$i = $this->tokens[ $i ]['parenthesis_closer'];
 				}
 
-				if ( T_COMMA === $this->tokens[ $i ]['code'] ) {
+				if ( $this->tokens[ $i ]['code'] === T_COMMA ) {
 					$params[ $paramNo++ ] = trim( array_reduce( array_slice( $this->tokens, $prevCommaPos, $i - $prevCommaPos ), [ $this, 'reduce_array' ] ) );
 					$prevCommaPos         = $i + 1;
 				}
@@ -247,7 +247,7 @@ class CheckReturnValueSniff extends Sniff {
 				}
 			}
 
-			if ( false === array_key_exists( 3, $params ) || 'false' === $params[3] ) {
+			if ( array_key_exists( 3, $params ) === false || $params[3] === 'false' ) {
 				// Third param of get_post_meta is not set (default to false) or is set to false.
 				// Means the function returns an array. We are good then.
 				return;
@@ -269,7 +269,7 @@ class CheckReturnValueSniff extends Sniff {
 		foreach ( $callees as $callee ) {
 			$notFunctionsCallee = array_key_exists( $callee, $this->notFunctions ) ? (array) $this->notFunctions[ $callee ] : [];
 			// Check whether the found token is one of the function calls (or foreach call) we are interested in.
-			if ( true === in_array( $this->tokens[ $nextFunctionCallWithVariable ]['code'], array_merge( Tokens::$functionNameTokens, $notFunctionsCallee ), true )
+			if ( in_array( $this->tokens[ $nextFunctionCallWithVariable ]['code'], array_merge( Tokens::$functionNameTokens, $notFunctionsCallee ), true ) === true
 				&& $this->tokens[ $nextFunctionCallWithVariable ]['content'] === $callee
 			) {
 				$this->addNonCheckedVariableError( $nextFunctionCallWithVariable, $variableName, $callee );
@@ -278,7 +278,7 @@ class CheckReturnValueSniff extends Sniff {
 
 			$search = array_merge( Tokens::$emptyTokens, [ T_EQUAL ] );
 			$next   = $this->phpcsFile->findNext( $search, $nextVariableOccurrence + 1, null, true );
-			if ( true === in_array( $this->tokens[ $next ]['code'], Tokens::$functionNameTokens, true )
+			if ( in_array( $this->tokens[ $next ]['code'], Tokens::$functionNameTokens, true ) === true
 				&& $this->tokens[ $next ]['content'] === $callee
 			) {
 				$this->addNonCheckedVariableError( $next, $variableName, $callee );

--- a/WordPressVIPMinimum/Sniffs/Functions/DynamicCallsSniff.php
+++ b/WordPressVIPMinimum/Sniffs/Functions/DynamicCallsSniff.php
@@ -100,8 +100,8 @@ class DynamicCallsSniff extends Sniff {
 		 */
 
 		if (
-			'T_VARIABLE' !==
-				$this->tokens[ $this->stackPtr ]['type']
+			$this->tokens[ $this->stackPtr ]['type'] !==
+				'T_VARIABLE'
 		) {
 			return;
 		}
@@ -123,15 +123,15 @@ class DynamicCallsSniff extends Sniff {
 			true
 		);
 
-		if ( false === $t_item_key ) {
+		if ( $t_item_key === false ) {
 			return;
 		}
 
-		if ( 'T_EQUAL' !== $this->tokens[ $t_item_key ]['type'] ) {
+		if ( $this->tokens[ $t_item_key ]['type'] !== 'T_EQUAL' ) {
 			return;
 		}
 
-		if ( 1 !== $this->tokens[ $t_item_key ]['length'] ) {
+		if ( $this->tokens[ $t_item_key ]['length'] !== 1 ) {
 			return;
 		}
 
@@ -147,7 +147,7 @@ class DynamicCallsSniff extends Sniff {
 			true
 		);
 
-		if ( false === $t_item_key ) {
+		if ( $t_item_key === false ) {
 			return;
 		}
 
@@ -186,8 +186,8 @@ class DynamicCallsSniff extends Sniff {
 		 */
 
 		if (
-			'T_VARIABLE' !==
-				$this->tokens[ $this->stackPtr ]['type']
+			$this->tokens[ $this->stackPtr ]['type'] !==
+				'T_VARIABLE'
 		) {
 			return;
 		}
@@ -215,13 +215,13 @@ class DynamicCallsSniff extends Sniff {
 		do {
 			$i++;
 		} while (
-			'T_WHITESPACE' ===
-				$this->tokens[ $this->stackPtr + $i ]['type']
+			$this->tokens[ $this->stackPtr + $i ]['type'] ===
+				'T_WHITESPACE'
 		);
 
 		if (
-			'T_OPEN_PARENTHESIS' !==
-				$this->tokens[ $this->stackPtr + $i ]['type']
+			$this->tokens[ $this->stackPtr + $i ]['type'] !==
+				'T_OPEN_PARENTHESIS'
 		) {
 			return;
 		}

--- a/WordPressVIPMinimum/Sniffs/Functions/RestrictedFunctionsSniff.php
+++ b/WordPressVIPMinimum/Sniffs/Functions/RestrictedFunctionsSniff.php
@@ -373,22 +373,22 @@ class RestrictedFunctionsSniff extends AbstractFunctionRestrictionsSniff {
 	 */
 	public function is_targetted_token( $stackPtr ) {
 		// Exclude function definitions, class methods, and namespaced calls.
-		if ( \T_STRING === $this->tokens[ $stackPtr ]['code'] && isset( $this->tokens[ $stackPtr - 1 ] ) ) {
+		if ( $this->tokens[ $stackPtr ]['code'] === \T_STRING && isset( $this->tokens[ $stackPtr - 1 ] ) ) {
 			// Check if this is really a function.
 			$next = $this->phpcsFile->findNext( Tokens::$emptyTokens, $stackPtr + 1, null, true );
-			if ( false !== $next && T_OPEN_PARENTHESIS !== $this->tokens[ $next ]['code'] ) {
+			if ( $next !== false && $this->tokens[ $next ]['code'] !== T_OPEN_PARENTHESIS ) {
 				return false;
 			}
 
 			$prev = $this->phpcsFile->findPrevious( Tokens::$emptyTokens, $stackPtr - 1, null, true );
-			if ( false !== $prev ) {
+			if ( $prev !== false ) {
 
 				// Start difference to parent class method.
 				// Check to see if function is a method on a specific object variable.
 				if ( ! empty( $this->groups[ $this->tokens[ $stackPtr ]['content'] ]['object_var'] ) ) {
 					$prevPrev = $this->phpcsFile->findPrevious( Tokens::$emptyTokens, $stackPtr - 2, null, true );
 
-					return \T_OBJECT_OPERATOR === $this->tokens[ $prev ]['code'] && isset( $this->groups[ $this->tokens[ $stackPtr ]['content'] ]['object_var'][ $this->tokens[ $prevPrev ]['content'] ] );
+					return $this->tokens[ $prev ]['code'] === \T_OBJECT_OPERATOR && isset( $this->groups[ $this->tokens[ $stackPtr ]['content'] ]['object_var'][ $this->tokens[ $prevPrev ]['content'] ] );
 				} // End difference to parent class method.
 
 				// Skip sniffing if calling a same-named method, or on function definitions.
@@ -404,9 +404,9 @@ class RestrictedFunctionsSniff extends AbstractFunctionRestrictionsSniff {
 					return false;
 				}
 				// Skip namespaced functions, ie: \foo\bar() not \bar().
-				if ( \T_NS_SEPARATOR === $this->tokens[ $prev ]['code'] ) {
+				if ( $this->tokens[ $prev ]['code'] === \T_NS_SEPARATOR ) {
 					$pprev = $this->phpcsFile->findPrevious( Tokens::$emptyTokens, $prev - 1, null, true );
-					if ( false !== $pprev && \T_STRING === $this->tokens[ $pprev ]['code'] ) {
+					if ( $pprev !== false && $this->tokens[ $pprev ]['code'] === \T_STRING ) {
 						return false;
 					}
 				}

--- a/WordPressVIPMinimum/Sniffs/Functions/StripTagsSniff.php
+++ b/WordPressVIPMinimum/Sniffs/Functions/StripTagsSniff.php
@@ -48,7 +48,7 @@ class StripTagsSniff extends AbstractFunctionParameterSniff {
 	 *                  normal file processing.
 	 */
 	public function process_parameters( $stackPtr, $group_name, $matched_content, $parameters ) {
-		if ( 1 === count( $parameters ) ) {
+		if ( count( $parameters ) === 1 ) {
 			$message = '`strip_tags()` does not strip CSS and JS in between the script and style tags. Use `wp_strip_all_tags()` to strip all tags.';
 			$this->phpcsFile->addWarning( $message, $stackPtr, 'StripTagsOneParameter' );
 		} elseif ( isset( $parameters[2] ) ) {

--- a/WordPressVIPMinimum/Sniffs/Hooks/AlwaysReturnInFilterSniff.php
+++ b/WordPressVIPMinimum/Sniffs/Hooks/AlwaysReturnInFilterSniff.php
@@ -44,7 +44,7 @@ class AlwaysReturnInFilterSniff extends Sniff {
 
 		$functionName = $this->tokens[ $stackPtr ]['content'];
 
-		if ( 'add_filter' !== $functionName ) {
+		if ( $functionName !== 'add_filter' ) {
 			return;
 		}
 
@@ -76,13 +76,13 @@ class AlwaysReturnInFilterSniff extends Sniff {
 			return;
 		}
 
-		if ( 'PHPCS_T_CLOSURE' === $this->tokens[ $callbackPtr ]['code'] ) {
+		if ( $this->tokens[ $callbackPtr ]['code'] === 'PHPCS_T_CLOSURE' ) {
 			$this->processFunctionBody( $callbackPtr );
-		} elseif ( T_ARRAY === $this->tokens[ $callbackPtr ]['code']
-			|| T_OPEN_SHORT_ARRAY === $this->tokens[ $callbackPtr ]['code']
+		} elseif ( $this->tokens[ $callbackPtr ]['code'] === T_ARRAY
+			|| $this->tokens[ $callbackPtr ]['code'] === T_OPEN_SHORT_ARRAY
 		) {
 			$this->processArray( $callbackPtr );
-		} elseif ( true === in_array( $this->tokens[ $callbackPtr ]['code'], Tokens::$stringTokens, true ) ) {
+		} elseif ( in_array( $this->tokens[ $callbackPtr ]['code'], Tokens::$stringTokens, true ) === true ) {
 			$this->processString( $callbackPtr );
 		}
 	}
@@ -95,7 +95,7 @@ class AlwaysReturnInFilterSniff extends Sniff {
 	private function processArray( $stackPtr ) {
 
 		$open_close = $this->find_array_open_close( $stackPtr );
-		if ( false === $open_close ) {
+		if ( $open_close === false ) {
 			return;
 		}
 
@@ -106,7 +106,7 @@ class AlwaysReturnInFilterSniff extends Sniff {
 			true
 		);
 
-		if ( true === in_array( T_CLASS, $this->tokens[ $stackPtr ]['conditions'], true ) ) {
+		if ( in_array( T_CLASS, $this->tokens[ $stackPtr ]['conditions'], true ) === true ) {
 			$classPtr = array_search( T_CLASS, $this->tokens[ $stackPtr ]['conditions'], true );
 			if ( $classPtr ) {
 				$classToken = $this->tokens[ $classPtr ];
@@ -157,10 +157,10 @@ class AlwaysReturnInFilterSniff extends Sniff {
 		$functionName = $this->tokens[ $stackPtr ]['content'];
 
 		$offset = $start;
-		while ( false !== $this->phpcsFile->findNext( [ T_FUNCTION ], $offset, $end ) ) {
+		while ( $this->phpcsFile->findNext( [ T_FUNCTION ], $offset, $end ) !== false ) {
 			$functionStackPtr = $this->phpcsFile->findNext( [ T_FUNCTION ], $offset, $end );
 			$functionNamePtr  = $this->phpcsFile->findNext( Tokens::$emptyTokens, $functionStackPtr + 1, null, true, null, true );
-			if ( T_STRING === $this->tokens[ $functionNamePtr ]['code'] && $this->tokens[ $functionNamePtr ]['content'] === $functionName ) {
+			if ( $this->tokens[ $functionNamePtr ]['code'] === T_STRING && $this->tokens[ $functionNamePtr ]['content'] === $functionName ) {
 				$this->processFunctionBody( $functionStackPtr );
 				return;
 			}
@@ -185,7 +185,7 @@ class AlwaysReturnInFilterSniff extends Sniff {
 		);
 
 		// If arg is being passed by reference, we can skip.
-		if ( T_BITWISE_AND === $this->tokens[ $argPtr ]['code'] ) {
+		if ( $this->tokens[ $argPtr ]['code'] === T_BITWISE_AND ) {
 			return;
 		}
 
@@ -221,7 +221,7 @@ class AlwaysReturnInFilterSniff extends Sniff {
 			);
 		}
 
-		if ( 0 <= $insideIfConditionalReturn && 0 === $outsideConditionalReturn ) {
+		if ( $insideIfConditionalReturn >= 0 && $outsideConditionalReturn === 0 ) {
 			$message = 'Please, make sure that a callback to `%s` filter is always returning some value.';
 			$data    = [ $filterName ];
 			$this->phpcsFile->addError( $message, $functionBodyScopeStart, 'MissingReturnStatement', $data );
@@ -240,24 +240,24 @@ class AlwaysReturnInFilterSniff extends Sniff {
 
 		// This check helps us in situations a class or a function is wrapped
 		// inside a conditional as a whole. Eg.: inside `class_exists`.
-		if ( T_FUNCTION === end( $this->tokens[ $stackPtr ]['conditions'] ) ) {
+		if ( end( $this->tokens[ $stackPtr ]['conditions'] ) === T_FUNCTION ) {
 			return false;
 		}
 
 		// Similar case may be a conditional closure.
-		if ( 'PHPCS_T_CLOSURE' === end( $this->tokens[ $stackPtr ]['conditions'] ) ) {
+		if ( end( $this->tokens[ $stackPtr ]['conditions'] ) === 'PHPCS_T_CLOSURE' ) {
 			return false;
 		}
 
 		// Loop over the array of conditions and look for an IF.
 		reset( $this->tokens[ $stackPtr ]['conditions'] );
 
-		if ( true === array_key_exists( 'conditions', $this->tokens[ $stackPtr ] )
-			&& true === is_array( $this->tokens[ $stackPtr ]['conditions'] )
-			&& false === empty( $this->tokens[ $stackPtr ]['conditions'] )
+		if ( array_key_exists( 'conditions', $this->tokens[ $stackPtr ] ) === true
+			&& is_array( $this->tokens[ $stackPtr ]['conditions'] ) === true
+			&& empty( $this->tokens[ $stackPtr ]['conditions'] ) === false
 		) {
 			foreach ( $this->tokens[ $stackPtr ]['conditions'] as $tokenPtr => $tokenCode ) {
-				if ( T_IF === $this->tokens[ $stackPtr ]['conditions'][ $tokenPtr ] ) {
+				if ( $this->tokens[ $stackPtr ]['conditions'][ $tokenPtr ] === T_IF ) {
 					return true;
 				}
 			}
@@ -281,6 +281,6 @@ class AlwaysReturnInFilterSniff extends Sniff {
 			true
 		);
 
-		return T_SEMICOLON === $this->tokens[ $nextToReturnTokenPtr ]['code'];
+		return $this->tokens[ $nextToReturnTokenPtr ]['code'] === T_SEMICOLON;
 	}
 }

--- a/WordPressVIPMinimum/Sniffs/Hooks/PreGetPostsSniff.php
+++ b/WordPressVIPMinimum/Sniffs/Hooks/PreGetPostsSniff.php
@@ -39,7 +39,7 @@ class PreGetPostsSniff extends Sniff {
 
 		$functionName = $this->tokens[ $stackPtr ]['content'];
 
-		if ( 'add_action' !== $functionName ) {
+		if ( $functionName !== 'add_action' ) {
 			// We are interested in add_action calls only.
 			return;
 		}
@@ -58,7 +58,7 @@ class PreGetPostsSniff extends Sniff {
 			return;
 		}
 
-		if ( 'pre_get_posts' !== substr( $this->tokens[ $actionNamePtr ]['content'], 1, -1 ) ) {
+		if ( substr( $this->tokens[ $actionNamePtr ]['content'], 1, -1 ) !== 'pre_get_posts' ) {
 			// This is not setting a callback for pre_get_posts action.
 			return;
 		}
@@ -77,13 +77,13 @@ class PreGetPostsSniff extends Sniff {
 			return;
 		}
 
-		if ( 'PHPCS_T_CLOSURE' === $this->tokens[ $callbackPtr ]['code'] ) {
+		if ( $this->tokens[ $callbackPtr ]['code'] === 'PHPCS_T_CLOSURE' ) {
 			$this->processClosure( $callbackPtr );
-		} elseif ( T_ARRAY === $this->tokens[ $callbackPtr ]['code']
-			|| T_OPEN_SHORT_ARRAY === $this->tokens[ $callbackPtr ]['code']
+		} elseif ( $this->tokens[ $callbackPtr ]['code'] === T_ARRAY
+			|| $this->tokens[ $callbackPtr ]['code'] === T_OPEN_SHORT_ARRAY
 		) {
 			$this->processArray( $callbackPtr );
-		} elseif ( true === in_array( $this->tokens[ $callbackPtr ]['code'], Tokens::$stringTokens, true ) ) {
+		} elseif ( in_array( $this->tokens[ $callbackPtr ]['code'], Tokens::$stringTokens, true ) === true ) {
 			$this->processString( $callbackPtr );
 		}
 	}
@@ -96,7 +96,7 @@ class PreGetPostsSniff extends Sniff {
 	private function processArray( $stackPtr ) {
 
 		$open_close = $this->find_array_open_close( $stackPtr );
-		if ( false === $open_close ) {
+		if ( $open_close === false ) {
 			return;
 		}
 
@@ -251,9 +251,9 @@ class PreGetPostsSniff extends Sniff {
 	 */
 	private function isParentConditionalCheckingMainQuery( $stackPtr ) {
 
-		if ( false === array_key_exists( 'conditions', $this->tokens[ $stackPtr ] )
-			|| false === is_array( $this->tokens[ $stackPtr ]['conditions'] )
-			|| true === empty( $this->tokens[ $stackPtr ]['conditions'] )
+		if ( array_key_exists( 'conditions', $this->tokens[ $stackPtr ] ) === false
+			|| is_array( $this->tokens[ $stackPtr ]['conditions'] ) === false
+			|| empty( $this->tokens[ $stackPtr ]['conditions'] ) === true
 		) {
 			return false;
 		}
@@ -261,7 +261,7 @@ class PreGetPostsSniff extends Sniff {
 		$conditionStackPtrs    = array_keys( $this->tokens[ $stackPtr ]['conditions'] );
 		$lastConditionStackPtr = array_pop( $conditionStackPtrs );
 
-		while ( T_IF === $this->tokens[ $stackPtr ]['conditions'][ $lastConditionStackPtr ] ) {
+		while ( $this->tokens[ $stackPtr ]['conditions'][ $lastConditionStackPtr ] === T_IF ) {
 
 			$next = $this->phpcsFile->findNext(
 				[ T_VARIABLE ],
@@ -272,7 +272,7 @@ class PreGetPostsSniff extends Sniff {
 				true
 			);
 			while ( $next ) {
-				if ( true === $this->isWPQueryMethodCall( $next, 'is_main_query' ) ) {
+				if ( $this->isWPQueryMethodCall( $next, 'is_main_query' ) === true ) {
 					return true;
 				}
 				$next = $this->phpcsFile->findNext(
@@ -305,8 +305,8 @@ class PreGetPostsSniff extends Sniff {
 			return false;
 		}
 
-		if ( false === array_key_exists( 'nested_parenthesis', $this->tokens[ $stackPtr ] )
-			|| true === empty( $this->tokens[ $stackPtr ]['nested_parenthesis'] )
+		if ( array_key_exists( 'nested_parenthesis', $this->tokens[ $stackPtr ] ) === false
+			|| empty( $this->tokens[ $stackPtr ]['nested_parenthesis'] ) === true
 		) {
 			return false;
 		}
@@ -314,13 +314,13 @@ class PreGetPostsSniff extends Sniff {
 		$parentheses = $this->tokens[ $stackPtr ]['nested_parenthesis'];
 		do {
 			$nestedParenthesisEnd = array_shift( $parentheses );
-			if ( null === $nestedParenthesisEnd ) {
+			if ( $nestedParenthesisEnd === null ) {
 				// Nothing left in the array. No parenthesis found with a non-closure owner.
 				return false;
 			}
 
 			if ( isset( $this->tokens[ $nestedParenthesisEnd ]['parenthesis_owner'] )
-				&& T_CLOSURE !== $this->tokens[ $this->tokens[ $nestedParenthesisEnd ]['parenthesis_owner'] ]['code']
+				&& $this->tokens[ $this->tokens[ $nestedParenthesisEnd ]['parenthesis_owner'] ]['code'] !== T_CLOSURE
 			) {
 				break;
 			}
@@ -336,7 +336,7 @@ class PreGetPostsSniff extends Sniff {
 				true
 			);
 
-			if ( false !== $next && T_RETURN === $this->tokens[ $next ]['code'] ) {
+			if ( $next !== false && $this->tokens[ $next ]['code'] === T_RETURN ) {
 				return true;
 			}
 
@@ -377,11 +377,11 @@ class PreGetPostsSniff extends Sniff {
 			true
 		);
 
-		if ( ! $next || 'T_OBJECT_OPERATOR' !== $this->tokens[ $next ]['type'] ) {
+		if ( ! $next || $this->tokens[ $next ]['type'] !== 'T_OBJECT_OPERATOR' ) {
 			return false;
 		}
 
-		if ( null === $method ) {
+		if ( $method === null ) {
 			return true;
 		}
 
@@ -394,7 +394,7 @@ class PreGetPostsSniff extends Sniff {
 			true
 		);
 
-		return $next && true === in_array( $this->tokens[ $next ]['code'], Tokens::$functionNameTokens, true ) && $method === $this->tokens[ $next ]['content'];
+		return $next && in_array( $this->tokens[ $next ]['code'], Tokens::$functionNameTokens, true ) === true && $method === $this->tokens[ $next ]['content'];
 	}
 
 	/**
@@ -406,9 +406,9 @@ class PreGetPostsSniff extends Sniff {
 	 */
 	private function isPartOfIfConditional( $stackPtr ) {
 
-		if ( true === array_key_exists( 'nested_parenthesis', $this->tokens[ $stackPtr ] )
-			&& true === is_array( $this->tokens[ $stackPtr ]['nested_parenthesis'] )
-			&& false === empty( $this->tokens[ $stackPtr ]['nested_parenthesis'] )
+		if ( array_key_exists( 'nested_parenthesis', $this->tokens[ $stackPtr ] ) === true
+			&& is_array( $this->tokens[ $stackPtr ]['nested_parenthesis'] ) === true
+			&& empty( $this->tokens[ $stackPtr ]['nested_parenthesis'] ) === false
 		) {
 			$previousLocalIf = $this->phpcsFile->findPrevious(
 				[ T_IF ],
@@ -418,7 +418,7 @@ class PreGetPostsSniff extends Sniff {
 				null,
 				true
 			);
-			if ( false !== $previousLocalIf
+			if ( $previousLocalIf !== false
 				&& $this->tokens[ $previousLocalIf ]['parenthesis_opener'] < $stackPtr
 				&& $this->tokens[ $previousLocalIf ]['parenthesis_closer'] > $stackPtr
 			) {
@@ -437,13 +437,13 @@ class PreGetPostsSniff extends Sniff {
 	 */
 	private function isInsideIfConditonal( $stackPtr ) {
 
-		if ( true === array_key_exists( 'conditions', $this->tokens[ $stackPtr ] )
-			&& true === is_array( $this->tokens[ $stackPtr ]['conditions'] )
-			&& false === empty( $this->tokens[ $stackPtr ]['conditions'] )
+		if ( array_key_exists( 'conditions', $this->tokens[ $stackPtr ] ) === true
+			&& is_array( $this->tokens[ $stackPtr ]['conditions'] ) === true
+			&& empty( $this->tokens[ $stackPtr ]['conditions'] ) === false
 		) {
 			$conditionStackPtrs    = array_keys( $this->tokens[ $stackPtr ]['conditions'] );
 			$lastConditionStackPtr = array_pop( $conditionStackPtrs );
-			return T_IF === $this->tokens[ $stackPtr ]['conditions'][ $lastConditionStackPtr ];
+			return $this->tokens[ $stackPtr ]['conditions'][ $lastConditionStackPtr ] === T_IF;
 		}
 		return false;
 	}

--- a/WordPressVIPMinimum/Sniffs/Hooks/RestrictedHooksSniff.php
+++ b/WordPressVIPMinimum/Sniffs/Hooks/RestrictedHooksSniff.php
@@ -114,7 +114,7 @@ class RestrictedHooksSniff extends AbstractFunctionParameterSniff {
 		if ( $concat_ptr ) {
 			$hook_name = '';
 			for ( $i = $parameter['start'] + 1; $i < $parameter['end']; $i++ ) {
-				if ( T_CONSTANT_ENCAPSED_STRING === $this->tokens[ $i ]['code'] ) {
+				if ( $this->tokens[ $i ]['code'] === T_CONSTANT_ENCAPSED_STRING ) {
 					$hook_name .= str_replace( [ "'", '"' ], '', $this->tokens[ $i ]['content'] );
 				}
 			}

--- a/WordPressVIPMinimum/Sniffs/JS/DangerouslySetInnerHTMLSniff.php
+++ b/WordPressVIPMinimum/Sniffs/JS/DangerouslySetInnerHTMLSniff.php
@@ -46,21 +46,21 @@ class DangerouslySetInnerHTMLSniff extends Sniff {
 	 */
 	public function process_token( $stackPtr ) {
 
-		if ( 'dangerouslySetInnerHTML' !== $this->tokens[ $stackPtr ]['content'] ) {
+		if ( $this->tokens[ $stackPtr ]['content'] !== 'dangerouslySetInnerHTML' ) {
 			// Looking for dangerouslySetInnerHTML only.
 			return;
 		}
 
 		$nextToken = $this->phpcsFile->findNext( Tokens::$emptyTokens, $stackPtr + 1, null, true, null, true );
 
-		if ( T_EQUAL !== $this->tokens[ $nextToken ]['code'] ) {
+		if ( $this->tokens[ $nextToken ]['code'] !== T_EQUAL ) {
 			// Not an assignment.
 			return;
 		}
 
 		$nextNextToken = $this->phpcsFile->findNext( Tokens::$emptyTokens, $nextToken + 1, null, true, null, true );
 
-		if ( T_OBJECT !== $this->tokens[ $nextNextToken ]['code'] ) {
+		if ( $this->tokens[ $nextNextToken ]['code'] !== T_OBJECT ) {
 			// Not react syntax.
 			return;
 		}

--- a/WordPressVIPMinimum/Sniffs/JS/HTMLExecutingFunctionsSniff.php
+++ b/WordPressVIPMinimum/Sniffs/JS/HTMLExecutingFunctionsSniff.php
@@ -76,10 +76,10 @@ class HTMLExecutingFunctionsSniff extends Sniff {
 			return;
 		}
 
-		if ( 'content' === $this->HTMLExecutingFunctions[ $this->tokens[ $stackPtr ]['content'] ] ) {
+		if ( $this->HTMLExecutingFunctions[ $this->tokens[ $stackPtr ]['content'] ] === 'content' ) {
 			$nextToken = $this->phpcsFile->findNext( Tokens::$emptyTokens, $stackPtr + 1, null, true, null, true );
 
-			if ( T_OPEN_PARENTHESIS !== $this->tokens[ $nextToken ]['code'] ) {
+			if ( $this->tokens[ $nextToken ]['code'] !== T_OPEN_PARENTHESIS ) {
 				// Not a function.
 				return;
 			}
@@ -88,7 +88,7 @@ class HTMLExecutingFunctionsSniff extends Sniff {
 
 			while ( $nextToken < $parenthesis_closer ) {
 				$nextToken = $this->phpcsFile->findNext( Tokens::$emptyTokens, $nextToken + 1, null, true, null, true );
-				if ( T_STRING === $this->tokens[ $nextToken ]['code'] ) { // Contains a variable, function call or something else dynamic.
+				if ( $this->tokens[ $nextToken ]['code'] === T_STRING ) { // Contains a variable, function call or something else dynamic.
 					$message = 'Any HTML passed to `%s` gets executed. Make sure it\'s properly escaped.';
 					$data    = [ $this->tokens[ $stackPtr ]['content'] ];
 					$this->phpcsFile->addWarning( $message, $stackPtr, $this->tokens[ $stackPtr ]['content'], $data );
@@ -96,16 +96,16 @@ class HTMLExecutingFunctionsSniff extends Sniff {
 					return;
 				}
 			}
-		} elseif ( 'target' === $this->HTMLExecutingFunctions[ $this->tokens[ $stackPtr ]['content'] ] ) {
+		} elseif ( $this->HTMLExecutingFunctions[ $this->tokens[ $stackPtr ]['content'] ] === 'target' ) {
 			$prevToken = $this->phpcsFile->findPrevious( Tokens::$emptyTokens, $stackPtr - 1, null, true, null, true );
 
-			if ( T_OBJECT_OPERATOR !== $this->tokens[ $prevToken ]['code'] ) {
+			if ( $this->tokens[ $prevToken ]['code'] !== T_OBJECT_OPERATOR ) {
 				return;
 			}
 
 			$prevPrevToken = $this->phpcsFile->findPrevious( Tokens::$emptyTokens, $prevToken - 1, null, true, null, true );
 
-			if ( T_CLOSE_PARENTHESIS !== $this->tokens[ $prevPrevToken ]['code'] ) {
+			if ( $this->tokens[ $prevPrevToken ]['code'] !== T_CLOSE_PARENTHESIS ) {
 				// Not a function call, but may be a variable containing an element reference, so just
 				// flag all remaining instances of these target HTML executing functions.
 				$message = 'Any HTML used with `%s` gets executed. Make sure it\'s properly escaped.';
@@ -120,7 +120,7 @@ class HTMLExecutingFunctionsSniff extends Sniff {
 
 			while ( $prevPrevToken > $parenthesis_opener ) {
 				$prevPrevToken = $this->phpcsFile->findPrevious( Tokens::$emptyTokens, $prevPrevToken - 1, null, true, null, true );
-				if ( T_STRING === $this->tokens[ $prevPrevToken ]['code'] ) { // Contains a variable, function call or something else dynamic.
+				if ( $this->tokens[ $prevPrevToken ]['code'] === T_STRING ) { // Contains a variable, function call or something else dynamic.
 					$message = 'Any HTML used with `%s` gets executed. Make sure it\'s properly escaped.';
 					$data    = [ $this->tokens[ $stackPtr ]['content'] ];
 					$this->phpcsFile->addWarning( $message, $stackPtr, $this->tokens[ $stackPtr ]['content'], $data );

--- a/WordPressVIPMinimum/Sniffs/JS/InnerHTMLSniff.php
+++ b/WordPressVIPMinimum/Sniffs/JS/InnerHTMLSniff.php
@@ -46,20 +46,20 @@ class InnerHTMLSniff extends Sniff {
 	 */
 	public function process_token( $stackPtr ) {
 
-		if ( 'innerHTML' !== $this->tokens[ $stackPtr ]['content'] ) {
+		if ( $this->tokens[ $stackPtr ]['content'] !== 'innerHTML' ) {
 			// Looking for .innerHTML only.
 			return;
 		}
 
 		$prevToken = $this->phpcsFile->findPrevious( Tokens::$emptyTokens, $stackPtr - 1, null, true, null, true );
 
-		if ( T_OBJECT_OPERATOR !== $this->tokens[ $prevToken ]['code'] ) {
+		if ( $this->tokens[ $prevToken ]['code'] !== T_OBJECT_OPERATOR ) {
 				return;
 		}
 
 		$nextToken = $this->phpcsFile->findNext( Tokens::$emptyTokens, $stackPtr + 1, null, true, null, true );
 
-		if ( T_EQUAL !== $this->tokens[ $nextToken ]['code'] ) {
+		if ( $this->tokens[ $nextToken ]['code'] !== T_EQUAL ) {
 			// Not an assignment.
 			return;
 		}
@@ -67,9 +67,9 @@ class InnerHTMLSniff extends Sniff {
 		$nextToken     = $this->phpcsFile->findNext( Tokens::$emptyTokens, $nextToken + 1, null, true, null, true );
 		$foundVariable = false;
 
-		while ( false !== $nextToken && T_SEMICOLON !== $this->tokens[ $nextToken ]['code'] ) {
+		while ( $nextToken !== false && $this->tokens[ $nextToken ]['code'] !== T_SEMICOLON ) {
 
-			if ( T_STRING === $this->tokens[ $nextToken ]['code'] ) {
+			if ( $this->tokens[ $nextToken ]['code'] === T_STRING ) {
 				$foundVariable = true;
 				break;
 			}
@@ -77,7 +77,7 @@ class InnerHTMLSniff extends Sniff {
 			$nextToken = $this->phpcsFile->findNext( Tokens::$emptyTokens, $nextToken + 1, null, true, null, true );
 		}
 
-		if ( true === $foundVariable ) {
+		if ( $foundVariable === true ) {
 			$message = 'Any HTML passed to `%s` gets executed. Consider using `.textContent` or make sure that used variables are properly escaped.';
 			$data    = [ $this->tokens[ $stackPtr ]['content'] ];
 			$this->phpcsFile->addWarning( $message, $stackPtr, 'Found', $data );

--- a/WordPressVIPMinimum/Sniffs/JS/StringConcatSniff.php
+++ b/WordPressVIPMinimum/Sniffs/JS/StringConcatSniff.php
@@ -49,14 +49,14 @@ class StringConcatSniff extends Sniff {
 
 		$nextToken = $this->phpcsFile->findNext( Tokens::$emptyTokens, $stackPtr + 1, null, true, null, true );
 
-		if ( T_CONSTANT_ENCAPSED_STRING === $this->tokens[ $nextToken ]['code'] && false !== strpos( $this->tokens[ $nextToken ]['content'], '<' ) && 1 === preg_match( '/\<\/[a-zA-Z]+/', $this->tokens[ $nextToken ]['content'] ) ) {
+		if ( $this->tokens[ $nextToken ]['code'] === T_CONSTANT_ENCAPSED_STRING && strpos( $this->tokens[ $nextToken ]['content'], '<' ) !== false && preg_match( '/\<\/[a-zA-Z]+/', $this->tokens[ $nextToken ]['content'] ) === 1 ) {
 			$data = [ '+' . $this->tokens[ $nextToken ]['content'] ];
 			$this->addFoundError( $stackPtr, $data );
 		}
 
 		$prevToken = $this->phpcsFile->findPrevious( Tokens::$emptyTokens, $stackPtr - 1, null, true, null, true );
 
-		if ( T_CONSTANT_ENCAPSED_STRING === $this->tokens[ $prevToken ]['code'] && false !== strpos( $this->tokens[ $prevToken ]['content'], '<' ) && 1 === preg_match( '/\<[a-zA-Z]+/', $this->tokens[ $prevToken ]['content'] ) ) {
+		if ( $this->tokens[ $prevToken ]['code'] === T_CONSTANT_ENCAPSED_STRING && strpos( $this->tokens[ $prevToken ]['content'], '<' ) !== false && preg_match( '/\<[a-zA-Z]+/', $this->tokens[ $prevToken ]['content'] ) === 1 ) {
 			$data = [ $this->tokens[ $nextToken ]['content'] . '+' ];
 			$this->addFoundError( $stackPtr, $data );
 		}

--- a/WordPressVIPMinimum/Sniffs/JS/StrippingTagsSniff.php
+++ b/WordPressVIPMinimum/Sniffs/JS/StrippingTagsSniff.php
@@ -48,27 +48,27 @@ class StrippingTagsSniff extends Sniff {
 	 */
 	public function process_token( $stackPtr ) {
 
-		if ( 'html' !== $this->tokens[ $stackPtr ]['content'] ) {
+		if ( $this->tokens[ $stackPtr ]['content'] !== 'html' ) {
 			// Looking for html() only.
 			return;
 		}
 
 		$nextToken = $this->phpcsFile->findNext( Tokens::$emptyTokens, $stackPtr + 1, null, true, null, true );
 
-		if ( T_OPEN_PARENTHESIS !== $this->tokens[ $nextToken ]['code'] ) {
+		if ( $this->tokens[ $nextToken ]['code'] !== T_OPEN_PARENTHESIS ) {
 			// Not a function.
 			return;
 		}
 
 		$afterFunctionCall = $this->phpcsFile->findNext( Tokens::$emptyTokens, $this->tokens[ $nextToken ]['parenthesis_closer'] + 1, null, true, null, true );
 
-		if ( T_OBJECT_OPERATOR !== $this->tokens[ $afterFunctionCall ]['code'] ) {
+		if ( $this->tokens[ $afterFunctionCall ]['code'] !== T_OBJECT_OPERATOR ) {
 			return;
 		}
 
 		$nextToken = $this->phpcsFile->findNext( Tokens::$emptyTokens, $afterFunctionCall + 1, null, true, null, true );
 
-		if ( T_STRING === $this->tokens[ $nextToken ]['code'] && 'text' === $this->tokens[ $nextToken ]['content'] ) {
+		if ( $this->tokens[ $nextToken ]['code'] === T_STRING && $this->tokens[ $nextToken ]['content'] === 'text' ) {
 			$message = 'Vulnerable tag stripping approach detected.';
 			$this->phpcsFile->addError( $message, $stackPtr, 'VulnerableTagStripping' );
 		}

--- a/WordPressVIPMinimum/Sniffs/JS/WindowSniff.php
+++ b/WordPressVIPMinimum/Sniffs/JS/WindowSniff.php
@@ -69,20 +69,20 @@ class WindowSniff extends Sniff {
 	 */
 	public function process_token( $stackPtr ) {
 
-		if ( 'window' !== $this->tokens[ $stackPtr ]['content'] ) {
+		if ( $this->tokens[ $stackPtr ]['content'] !== 'window' ) {
 			// Doesn't begin with 'window', bail.
 			return;
 		}
 
 		$nextTokenPtr = $this->phpcsFile->findNext( Tokens::$emptyTokens, $stackPtr + 1, null, true, null, true );
 		$nextToken    = $this->tokens[ $nextTokenPtr ]['code'];
-		if ( T_OBJECT_OPERATOR !== $nextToken && T_OPEN_SQUARE_BRACKET !== $nextToken ) {
+		if ( $nextToken !== T_OBJECT_OPERATOR && $nextToken !== T_OPEN_SQUARE_BRACKET ) {
 			// No . or [' next, bail.
 			return;
 		}
 
 		$nextNextTokenPtr = $this->phpcsFile->findNext( Tokens::$emptyTokens, $nextTokenPtr + 1, null, true, null, true );
-		if ( false === $nextNextTokenPtr ) {
+		if ( $nextNextTokenPtr === false ) {
 			// Something went wrong, bail.
 			return;
 		}
@@ -97,9 +97,9 @@ class WindowSniff extends Sniff {
 		$nextNextNextToken    = $this->tokens[ $nextNextNextTokenPtr ]['code'];
 
 		$nextNextNextNextToken = false;
-		if ( T_OBJECT_OPERATOR === $nextNextNextToken || T_OPEN_SQUARE_BRACKET === $nextNextNextToken ) {
+		if ( $nextNextNextToken === T_OBJECT_OPERATOR || $nextNextNextToken === T_OPEN_SQUARE_BRACKET ) {
 			$nextNextNextNextTokenPtr = $this->phpcsFile->findNext( Tokens::$emptyTokens, $nextNextNextTokenPtr + 1, null, true, null, true );
-			if ( false === $nextNextNextNextTokenPtr ) {
+			if ( $nextNextNextNextTokenPtr === false ) {
 				// Something went wrong, bail.
 				return;
 			}
@@ -117,7 +117,7 @@ class WindowSniff extends Sniff {
 
 		$prevTokenPtr = $this->phpcsFile->findPrevious( Tokens::$emptyTokens, $stackPtr - 1, null, true, null, true );
 
-		if ( T_EQUAL === $this->tokens[ $prevTokenPtr ]['code'] ) {
+		if ( $this->tokens[ $prevTokenPtr ]['code'] === T_EQUAL ) {
 			// Variable assignment.
 			$message = 'Data from JS global "%s" may contain user-supplied values and should be checked.';
 			$this->phpcsFile->addWarning( $message, $stackPtr, 'VarAssignment', $data );

--- a/WordPressVIPMinimum/Sniffs/Performance/BatcacheWhitelistedParamsSniff.php
+++ b/WordPressVIPMinimum/Sniffs/Performance/BatcacheWhitelistedParamsSniff.php
@@ -88,13 +88,13 @@ class BatcacheWhitelistedParamsSniff extends Sniff {
 	 */
 	public function process_token( $stackPtr ) {
 
-		if ( '$_GET' !== $this->tokens[ $stackPtr ]['content'] ) {
+		if ( $this->tokens[ $stackPtr ]['content'] !== '$_GET' ) {
 			return;
 		}
 
 		$key = $this->phpcsFile->findNext( array_merge( Tokens::$emptyTokens, [ T_OPEN_SQUARE_BRACKET ] ), $stackPtr + 1, null, true );
 
-		if ( T_CONSTANT_ENCAPSED_STRING !== $this->tokens[ $key ]['code'] ) {
+		if ( $this->tokens[ $key ]['code'] !== T_CONSTANT_ENCAPSED_STRING ) {
 			return;
 		}
 
@@ -102,7 +102,7 @@ class BatcacheWhitelistedParamsSniff extends Sniff {
 
 		$variable_name = substr( $variable_name, 1, -1 );
 
-		if ( true === in_array( $variable_name, $this->whitelistes_batcache_params, true ) ) {
+		if ( in_array( $variable_name, $this->whitelistes_batcache_params, true ) === true ) {
 			$message = 'Batcache whitelisted GET param, `%s`, found. Batcache whitelisted parameters get stripped and are not available in PHP.';
 			$data    = [ $variable_name ];
 			$this->phpcsFile->addWarning( $message, $stackPtr, 'StrippedGetParam', $data );

--- a/WordPressVIPMinimum/Sniffs/Performance/CacheValueOverrideSniff.php
+++ b/WordPressVIPMinimum/Sniffs/Performance/CacheValueOverrideSniff.php
@@ -44,19 +44,19 @@ class CacheValueOverrideSniff extends Sniff {
 
 		$functionName = $this->tokens[ $stackPtr ]['content'];
 
-		if ( 'wp_cache_get' !== $functionName ) {
+		if ( $functionName !== 'wp_cache_get' ) {
 			// Not a function we are looking for.
 			return;
 		}
 
-		if ( false === $this->isFunctionCall( $stackPtr ) ) {
+		if ( $this->isFunctionCall( $stackPtr ) === false ) {
 			// Not a function call.
 			return;
 		}
 
 		$variablePos = $this->isVariableAssignment( $stackPtr );
 
-		if ( false === $variablePos ) {
+		if ( $variablePos === false ) {
 			// Not a variable assignment.
 			return;
 		}
@@ -74,14 +74,14 @@ class CacheValueOverrideSniff extends Sniff {
 
 		$rightAfterNextVariableOccurence = $this->phpcsFile->findNext( Tokens::$emptyTokens, $nextVariableOccurrence + 1, null, true, null, true );
 
-		if ( T_EQUAL !== $this->tokens[ $rightAfterNextVariableOccurence ]['code'] ) {
+		if ( $this->tokens[ $rightAfterNextVariableOccurence ]['code'] !== T_EQUAL ) {
 			// Not a value override.
 			return;
 		}
 
 		$valueAfterEqualSign = $this->phpcsFile->findNext( Tokens::$emptyTokens, $rightAfterNextVariableOccurence + 1, null, true, null, true );
 
-		if ( T_FALSE === $this->tokens[ $valueAfterEqualSign ]['code'] ) {
+		if ( $this->tokens[ $valueAfterEqualSign ]['code'] === T_FALSE ) {
 			$message = 'Obtained cached value in `%s` is being overridden. Disabling caching?';
 			$data    = [ $variableName ];
 			$this->phpcsFile->addError( $message, $nextVariableOccurrence, 'CacheValueOverride', $data );
@@ -97,14 +97,14 @@ class CacheValueOverrideSniff extends Sniff {
 	 */
 	private function isFunctionCall( $stackPtr ) {
 
-		if ( false === in_array( $this->tokens[ $stackPtr ]['code'], Tokens::$functionNameTokens, true ) ) {
+		if ( in_array( $this->tokens[ $stackPtr ]['code'], Tokens::$functionNameTokens, true ) === false ) {
 			return false;
 		}
 
 		// Find the next non-empty token.
 		$openBracket = $this->phpcsFile->findNext( Tokens::$emptyTokens, $stackPtr + 1, null, true );
 
-		if ( T_OPEN_PARENTHESIS !== $this->tokens[ $openBracket ]['code'] ) {
+		if ( $this->tokens[ $openBracket ]['code'] !== T_OPEN_PARENTHESIS ) {
 			// Not a function call.
 			return false;
 		}
@@ -115,7 +115,7 @@ class CacheValueOverrideSniff extends Sniff {
 		$previous = $this->phpcsFile->findPrevious( $search, $stackPtr - 1, null, true );
 
 		// It's a function definition, not a function call, so return false.
-		return ! ( T_FUNCTION === $this->tokens[ $previous ]['code'] );
+		return ! ( $this->tokens[ $previous ]['code'] === T_FUNCTION );
 	}
 
 	/**
@@ -132,14 +132,14 @@ class CacheValueOverrideSniff extends Sniff {
 		$search[] = T_BITWISE_AND;
 		$previous = $this->phpcsFile->findPrevious( $search, $stackPtr - 1, null, true );
 
-		if ( T_EQUAL !== $this->tokens[ $previous ]['code'] ) {
+		if ( $this->tokens[ $previous ]['code'] !== T_EQUAL ) {
 			// It's not a variable assignment.
 			return false;
 		}
 
 		$previous = $this->phpcsFile->findPrevious( $search, $previous - 1, null, true );
 
-		if ( T_VARIABLE !== $this->tokens[ $previous ]['code'] ) {
+		if ( $this->tokens[ $previous ]['code'] !== T_VARIABLE ) {
 			// It's not a variable assignment.
 			return false;
 		}

--- a/WordPressVIPMinimum/Sniffs/Performance/FetchingRemoteDataSniff.php
+++ b/WordPressVIPMinimum/Sniffs/Performance/FetchingRemoteDataSniff.php
@@ -37,22 +37,22 @@ class FetchingRemoteDataSniff extends Sniff {
 	public function process_token( $stackPtr ) {
 
 		$functionName = $this->tokens[ $stackPtr ]['content'];
-		if ( 'file_get_contents' !== $functionName ) {
+		if ( $functionName !== 'file_get_contents' ) {
 			return;
 		}
 
 		$data = [ $this->tokens[ $stackPtr ]['content'] ];
 
 		$fileNameStackPtr = $this->phpcsFile->findNext( Tokens::$stringTokens, $stackPtr + 1, null, false, null, true );
-		if ( false === $fileNameStackPtr ) {
+		if ( $fileNameStackPtr === false ) {
 			$message = '`%s()` is highly discouraged for remote requests, please use `wpcom_vip_file_get_contents()` or `vip_safe_wp_remote_get()` instead. If it\'s for a local file please use WP_Filesystem instead.';
 			$this->phpcsFile->addWarning( $message, $stackPtr, 'FileGetContentsUnknown', $data );
 		}
 
 		$fileName = $this->tokens[ $fileNameStackPtr ]['content'];
 
-		$isRemoteFile = ( false !== strpos( $fileName, '://' ) );
-		if ( true === $isRemoteFile ) {
+		$isRemoteFile = ( strpos( $fileName, '://' ) !== false );
+		if ( $isRemoteFile === true ) {
 			$message = '`%s()` is highly discouraged for remote requests, please use `wpcom_vip_file_get_contents()` or `vip_safe_wp_remote_get()` instead.';
 			$this->phpcsFile->addWarning( $message, $stackPtr, 'FileGetContentsRemoteFile', $data );
 		}

--- a/WordPressVIPMinimum/Sniffs/Performance/LowExpiryCacheTimeSniff.php
+++ b/WordPressVIPMinimum/Sniffs/Performance/LowExpiryCacheTimeSniff.php
@@ -64,14 +64,14 @@ class LowExpiryCacheTimeSniff extends AbstractFunctionParameterSniff {
 	 *                  normal file processing.
 	 */
 	public function process_parameters( $stackPtr, $group_name, $matched_content, $parameters ) {
-		if ( false === isset( $parameters[4] ) ) {
+		if ( isset( $parameters[4] ) === false ) {
 			// If no cache expiry time, bail (i.e. we don't want to flag for something like feeds where it is cached indefinitely until a hook runs).
 			return;
 		}
 
 		$time = $parameters[4]['raw'];
 
-		if ( false === is_numeric( $time ) ) {
+		if ( is_numeric( $time ) === false ) {
 			// If using time constants, we need to convert to a number.
 			$time = str_replace( array_keys( $this->wp_time_constants ), $this->wp_time_constants, $time );
 

--- a/WordPressVIPMinimum/Sniffs/Performance/NoPagingSniff.php
+++ b/WordPressVIPMinimum/Sniffs/Performance/NoPagingSniff.php
@@ -51,7 +51,7 @@ class NoPagingSniff extends AbstractArrayAssignmentRestrictionsSniff {
 	public function callback( $key, $val, $line, $group ) {
 		$key = strtolower( $key );
 
-		if ( 'nopaging' === $key && ( 'true' === $val || 1 === $val ) ) {
+		if ( $key === 'nopaging' && ( $val === 'true' || $val === 1 ) ) {
 			return 'Disabling pagination is prohibited in VIP context, do not set `%s` to `%s` ever.';
 		}
 

--- a/WordPressVIPMinimum/Sniffs/Performance/OrderByRandSniff.php
+++ b/WordPressVIPMinimum/Sniffs/Performance/OrderByRandSniff.php
@@ -49,7 +49,7 @@ class OrderByRandSniff extends AbstractArrayAssignmentRestrictionsSniff {
 	 * @return mixed         FALSE if no match, TRUE if matches, STRING if matches with custom error message passed to ->process().
 	 */
 	public function callback( $key, $val, $line, $group ) {
-		if ( 'rand' === strtolower( $val ) ) {
+		if ( strtolower( $val ) === 'rand' ) {
 			return 'Detected forbidden query_var "%s" of "%s". Use vip_get_random_posts() instead.';
 		}
 

--- a/WordPressVIPMinimum/Sniffs/Performance/RegexpCompareSniff.php
+++ b/WordPressVIPMinimum/Sniffs/Performance/RegexpCompareSniff.php
@@ -56,9 +56,9 @@ class RegexpCompareSniff extends AbstractArrayAssignmentRestrictionsSniff {
 	 *                       with custom error message passed to ->process().
 	 */
 	public function callback( $key, $val, $line, $group ) {
-		if ( 0 === strpos( $val, 'NOT REGEXP' )
-			|| 0 === strpos( $val, 'REGEXP' )
-			|| true === in_array( $val, [ 'REGEXP', 'NOT REGEXP' ], true )
+		if ( strpos( $val, 'NOT REGEXP' ) === 0
+			|| strpos( $val, 'REGEXP' ) === 0
+			|| in_array( $val, [ 'REGEXP', 'NOT REGEXP' ], true ) === true
 		) {
 			return 'Detected regular expression comparison. `%s` is set to `%s`.';
 		}

--- a/WordPressVIPMinimum/Sniffs/Performance/TaxonomyMetaInOptionsSniff.php
+++ b/WordPressVIPMinimum/Sniffs/Performance/TaxonomyMetaInOptionsSniff.php
@@ -63,56 +63,56 @@ class TaxonomyMetaInOptionsSniff extends Sniff {
 	 */
 	public function process_token( $stackPtr ) {
 
-		if ( false === in_array( $this->tokens[ $stackPtr ]['content'], $this->option_functions, true ) ) {
+		if ( in_array( $this->tokens[ $stackPtr ]['content'], $this->option_functions, true ) === false ) {
 			return;
 		}
 
 		$openBracket = $this->phpcsFile->findNext( Tokens::$emptyTokens, $stackPtr + 1, null, true );
 
-		if ( T_OPEN_PARENTHESIS !== $this->tokens[ $openBracket ]['code'] ) {
+		if ( $this->tokens[ $openBracket ]['code'] !== T_OPEN_PARENTHESIS ) {
 			return;
 		}
 
 		$param_ptr = $this->phpcsFile->findNext( Tokens::$emptyTokens, $openBracket + 1, null, true );
 
-		if ( T_DOUBLE_QUOTED_STRING === $this->tokens[ $param_ptr ]['code'] ) {
+		if ( $this->tokens[ $param_ptr ]['code'] === T_DOUBLE_QUOTED_STRING ) {
 			foreach ( $this->taxonomy_term_patterns as $taxonomy_term_pattern ) {
-				if ( false !== strpos( $this->tokens[ $param_ptr ]['content'], $taxonomy_term_pattern ) ) {
+				if ( strpos( $this->tokens[ $param_ptr ]['content'], $taxonomy_term_pattern ) !== false ) {
 					$this->addPossibleTermMetaInOptionsWarning( $stackPtr );
 					return;
 				}
 			}
-		} elseif ( T_CONSTANT_ENCAPSED_STRING === $this->tokens[ $param_ptr ]['code'] ) {
+		} elseif ( $this->tokens[ $param_ptr ]['code'] === T_CONSTANT_ENCAPSED_STRING ) {
 
 			$string_concat = $this->phpcsFile->findNext( Tokens::$emptyTokens, $param_ptr + 1, null, true );
-			if ( T_STRING_CONCAT !== $this->tokens[ $string_concat ]['code'] ) {
+			if ( $this->tokens[ $string_concat ]['code'] !== T_STRING_CONCAT ) {
 				return;
 			}
 
 			$variable_name = $this->phpcsFile->findNext( Tokens::$emptyTokens, $string_concat + 1, null, true );
-			if ( T_VARIABLE !== $this->tokens[ $variable_name ]['code'] ) {
+			if ( $this->tokens[ $variable_name ]['code'] !== T_VARIABLE ) {
 				return;
 			}
 
 			foreach ( $this->taxonomy_term_patterns as $taxonomy_term_pattern ) {
-				if ( false !== strpos( $this->tokens[ $variable_name ]['content'], $taxonomy_term_pattern ) ) {
+				if ( strpos( $this->tokens[ $variable_name ]['content'], $taxonomy_term_pattern ) !== false ) {
 					$this->addPossibleTermMetaInOptionsWarning( $stackPtr );
 					return;
 				}
 			}
 
 			$object_operator = $this->phpcsFile->findNext( Tokens::$emptyTokens, $variable_name + 1, null, true );
-			if ( T_OBJECT_OPERATOR !== $this->tokens[ $object_operator ]['code'] ) {
+			if ( $this->tokens[ $object_operator ]['code'] !== T_OBJECT_OPERATOR ) {
 				return;
 			}
 
 			$object_property = $this->phpcsFile->findNext( Tokens::$emptyTokens, $object_operator + 1, null, true );
-			if ( T_STRING !== $this->tokens[ $object_property ]['code'] ) {
+			if ( $this->tokens[ $object_property ]['code'] !== T_STRING ) {
 				return;
 			}
 
 			foreach ( $this->taxonomy_term_patterns as $taxonomy_term_pattern ) {
-				if ( false !== strpos( $this->tokens[ $object_property ]['content'], $taxonomy_term_pattern ) ) {
+				if ( strpos( $this->tokens[ $object_property ]['content'], $taxonomy_term_pattern ) !== false ) {
 					$this->addPossibleTermMetaInOptionsWarning( $stackPtr );
 					return;
 				}

--- a/WordPressVIPMinimum/Sniffs/Performance/WPQueryParamsSniff.php
+++ b/WordPressVIPMinimum/Sniffs/Performance/WPQueryParamsSniff.php
@@ -38,11 +38,11 @@ class WPQueryParamsSniff extends Sniff {
 	 */
 	public function process_token( $stackPtr ) {
 
-		if ( 'suppress_filters' === trim( $this->tokens[ $stackPtr ]['content'], '\'' ) ) {
+		if ( trim( $this->tokens[ $stackPtr ]['content'], '\'' ) === 'suppress_filters' ) {
 
 			$next_token = $this->phpcsFile->findNext( array_merge( Tokens::$emptyTokens, [ T_EQUAL, T_CLOSE_SQUARE_BRACKET, T_DOUBLE_ARROW ] ), $stackPtr + 1, null, true );
 
-			if ( T_TRUE === $this->tokens[ $next_token ]['code'] ) {
+			if ( $this->tokens[ $next_token ]['code'] === T_TRUE ) {
 				// WordPress.com: https://lobby.vip.wordpress.com/wordpress-com-documentation/uncached-functions/.
 				// VIP Go: https://wpvip.com/documentation/vip-go/uncached-functions/.
 				$message = 'Setting `suppress_filters` to `true` is prohibited.';
@@ -50,7 +50,7 @@ class WPQueryParamsSniff extends Sniff {
 			}
 		}
 
-		if ( 'post__not_in' === trim( $this->tokens[ $stackPtr ]['content'], '\'' ) ) {
+		if ( trim( $this->tokens[ $stackPtr ]['content'], '\'' ) === 'post__not_in' ) {
 			$message = 'Using `post__not_in` should be done with caution, see https://wpvip.com/documentation/performance-improvements-by-removing-usage-of-post__not_in/ for more information.';
 			$this->phpcsFile->addWarning( $message, $stackPtr, 'PostNotIn' );
 		}

--- a/WordPressVIPMinimum/Sniffs/Security/EscapingVoidReturnFunctionsSniff.php
+++ b/WordPressVIPMinimum/Sniffs/Security/EscapingVoidReturnFunctionsSniff.php
@@ -40,21 +40,21 @@ class EscapingVoidReturnFunctionsSniff extends Sniff {
 	 */
 	public function process_token( $stackPtr ) {
 
-		if ( 0 !== strpos( $this->tokens[ $stackPtr ]['content'], 'esc_' ) && 0 !== strpos( $this->tokens[ $stackPtr ]['content'], 'wp_kses' ) ) {
+		if ( strpos( $this->tokens[ $stackPtr ]['content'], 'esc_' ) !== 0 && strpos( $this->tokens[ $stackPtr ]['content'], 'wp_kses' ) !== 0 ) {
 			// Not what we are looking for.
 			return;
 		}
 
 		$next_token = $this->phpcsFile->findNext( Tokens::$emptyTokens, $stackPtr + 1, null, true );
 
-		if ( T_OPEN_PARENTHESIS !== $this->tokens[ $next_token ]['code'] ) {
+		if ( $this->tokens[ $next_token ]['code'] !== T_OPEN_PARENTHESIS ) {
 			// Not a function call.
 			return;
 		}
 
 		$next_token = $this->phpcsFile->findNext( Tokens::$emptyTokens, $next_token + 1, null, true );
 
-		if ( T_STRING !== $this->tokens[ $next_token ]['code'] ) {
+		if ( $this->tokens[ $next_token ]['code'] !== T_STRING ) {
 			// Not what we are looking for.
 			return;
 		}

--- a/WordPressVIPMinimum/Sniffs/Security/ExitAfterRedirectSniff.php
+++ b/WordPressVIPMinimum/Sniffs/Security/ExitAfterRedirectSniff.php
@@ -36,13 +36,13 @@ class ExitAfterRedirectSniff extends Sniff {
 	 */
 	public function process_token( $stackPtr ) {
 
-		if ( 'wp_redirect' !== $this->tokens[ $stackPtr ]['content'] && 'wp_safe_redirect' !== $this->tokens[ $stackPtr ]['content'] ) {
+		if ( $this->tokens[ $stackPtr ]['content'] !== 'wp_redirect' && $this->tokens[ $stackPtr ]['content'] !== 'wp_safe_redirect' ) {
 			return;
 		}
 
 		$openBracket = $this->phpcsFile->findNext( Tokens::$emptyTokens, $stackPtr + 1, null, true );
 
-		if ( T_OPEN_PARENTHESIS !== $this->tokens[ $openBracket ]['code'] ) {
+		if ( $this->tokens[ $openBracket ]['code'] !== T_OPEN_PARENTHESIS ) {
 			return;
 		}
 
@@ -51,17 +51,17 @@ class ExitAfterRedirectSniff extends Sniff {
 		$message = '`%s()` should almost always be followed by a call to `exit;`.';
 		$data    = [ $this->tokens[ $stackPtr ]['content'] ];
 
-		if ( T_OPEN_CURLY_BRACKET === $this->tokens[ $next_token ]['code'] ) {
+		if ( $this->tokens[ $next_token ]['code'] === T_OPEN_CURLY_BRACKET ) {
 			$is_exit_in_scope = false;
 			for ( $i = $this->tokens[ $next_token ]['scope_opener']; $i <= $this->tokens[ $next_token ]['scope_closer']; $i++ ) {
-				if ( T_EXIT === $this->tokens[ $i ]['code'] ) {
+				if ( $this->tokens[ $i ]['code'] === T_EXIT ) {
 					$is_exit_in_scope = true;
 				}
 			}
-			if ( false === $is_exit_in_scope ) {
+			if ( $is_exit_in_scope === false ) {
 				$this->phpcsFile->addError( $message, $stackPtr, 'NoExitInConditional', $data );
 			}
-		} elseif ( T_EXIT !== $this->tokens[ $next_token ]['code'] ) {
+		} elseif ( $this->tokens[ $next_token ]['code'] !== T_EXIT ) {
 			$this->phpcsFile->addError( $message, $stackPtr, 'NoExit', $data );
 		}
 	}

--- a/WordPressVIPMinimum/Sniffs/Security/MustacheSniff.php
+++ b/WordPressVIPMinimum/Sniffs/Security/MustacheSniff.php
@@ -47,19 +47,19 @@ class MustacheSniff extends Sniff {
 	 */
 	public function process_token( $stackPtr ) {
 
-		if ( false !== strpos( $this->tokens[ $stackPtr ]['content'], '{{{' ) || false !== strpos( $this->tokens[ $stackPtr ]['content'], '}}}' ) ) {
+		if ( strpos( $this->tokens[ $stackPtr ]['content'], '{{{' ) !== false || strpos( $this->tokens[ $stackPtr ]['content'], '}}}' ) !== false ) {
 			// Mustache unescaped output notation.
 			$message = 'Found Mustache unescaped output notation: "{{{}}}".';
 			$this->phpcsFile->addWarning( $message, $stackPtr, 'OutputNotation' );
 		}
 
-		if ( false !== strpos( $this->tokens[ $stackPtr ]['content'], '{{&' ) ) {
+		if ( strpos( $this->tokens[ $stackPtr ]['content'], '{{&' ) !== false ) {
 			// Mustache unescaped variable notation.
 			$message = 'Found Mustache unescape variable notation: "{{&".';
 			$this->phpcsFile->addWarning( $message, $stackPtr, 'VariableNotation' );
 		}
 
-		if ( false !== strpos( $this->tokens[ $stackPtr ]['content'], '{{=' ) ) {
+		if ( strpos( $this->tokens[ $stackPtr ]['content'], '{{=' ) !== false ) {
 			// Mustache delimiter change.
 			$new_delimiter = trim( str_replace( [ '{{=', '=}}' ], '', substr( $this->tokens[ $stackPtr ]['content'], 0, strpos( $this->tokens[ $stackPtr ]['content'], '=}}' ) + 3 ) ) );
 			$message       = 'Found Mustache delimiter change notation. New delimiter is: %s.';
@@ -67,7 +67,7 @@ class MustacheSniff extends Sniff {
 			$this->phpcsFile->addWarning( $message, $stackPtr, 'DelimiterChange', $data );
 		}
 
-		if ( false !== strpos( $this->tokens[ $stackPtr ]['content'], 'SafeString' ) ) {
+		if ( strpos( $this->tokens[ $stackPtr ]['content'], 'SafeString' ) !== false ) {
 			// Handlebars.js Handlebars.SafeString does not get escaped.
 			$message = 'Found Handlebars.SafeString call which does not get escaped.';
 			$this->phpcsFile->addWarning( $message, $stackPtr, 'SafeString' );

--- a/WordPressVIPMinimum/Sniffs/Security/PHPFilterFunctionsSniff.php
+++ b/WordPressVIPMinimum/Sniffs/Security/PHPFilterFunctionsSniff.php
@@ -61,8 +61,8 @@ class PHPFilterFunctionsSniff extends AbstractFunctionParameterSniff {
 	 *                  normal file processing.
 	 */
 	public function process_parameters( $stackPtr, $group_name, $matched_content, $parameters ) {
-		if ( 'filter_input' === $matched_content ) {
-			if ( 2 === count( $parameters ) ) {
+		if ( $matched_content === 'filter_input' ) {
+			if ( count( $parameters ) === 2 ) {
 				$message = 'Missing third parameter for "%s".';
 				$data    = [ $matched_content ];
 				$this->phpcsFile->addWarning( $message, $stackPtr, 'MissingThirdParameter', $data );
@@ -74,7 +74,7 @@ class PHPFilterFunctionsSniff extends AbstractFunctionParameterSniff {
 				$this->phpcsFile->addWarning( $message, $stackPtr, 'RestrictedFilter', $data );
 			}
 		} else {
-			if ( 1 === count( $parameters ) ) {
+			if ( count( $parameters ) === 1 ) {
 				$message = 'Missing second parameter for "%s".';
 				$data    = [ $matched_content ];
 				$this->phpcsFile->addWarning( $message, $stackPtr, 'MissingSecondParameter', $data );

--- a/WordPressVIPMinimum/Sniffs/Security/ProperEscapingFunctionSniff.php
+++ b/WordPressVIPMinimum/Sniffs/Security/ProperEscapingFunctionSniff.php
@@ -47,7 +47,7 @@ class ProperEscapingFunctionSniff extends Sniff {
 	 */
 	public function process_token( $stackPtr ) {
 
-		if ( false === in_array( $this->tokens[ $stackPtr ]['content'], $this->escaping_functions, true ) ) {
+		if ( in_array( $this->tokens[ $stackPtr ]['content'], $this->escaping_functions, true ) === false ) {
 			return;
 		}
 
@@ -55,24 +55,24 @@ class ProperEscapingFunctionSniff extends Sniff {
 
 		$echo_or_string_concat = $this->phpcsFile->findPrevious( Tokens::$emptyTokens, $stackPtr - 1, null, true );
 
-		if ( T_ECHO === $this->tokens[ $echo_or_string_concat ]['code'] ) {
+		if ( $this->tokens[ $echo_or_string_concat ]['code'] === T_ECHO ) {
 			// Very likely inline HTML with <?php tag.
 			$php_open = $this->phpcsFile->findPrevious( Tokens::$emptyTokens, $echo_or_string_concat - 1, null, true );
 
-			if ( T_OPEN_TAG !== $this->tokens[ $php_open ]['code'] ) {
+			if ( $this->tokens[ $php_open ]['code'] !== T_OPEN_TAG ) {
 				return;
 			}
 
 			$html = $this->phpcsFile->findPrevious( Tokens::$emptyTokens, $php_open - 1, null, true );
 
-			if ( T_INLINE_HTML !== $this->tokens[ $html ]['code'] ) {
+			if ( $this->tokens[ $html ]['code'] !== T_INLINE_HTML ) {
 				return;
 			}
-		} elseif ( T_STRING_CONCAT === $this->tokens[ $echo_or_string_concat ]['code'] ) {
+		} elseif ( $this->tokens[ $echo_or_string_concat ]['code'] === T_STRING_CONCAT ) {
 			// Very likely string concatenation mixing strings and functions/variables.
 			$html = $this->phpcsFile->findPrevious( Tokens::$emptyTokens, $echo_or_string_concat - 1, null, true );
 
-			if ( T_CONSTANT_ENCAPSED_STRING !== $this->tokens[ $html ]['code'] ) {
+			if ( $this->tokens[ $html ]['code'] !== T_CONSTANT_ENCAPSED_STRING ) {
 				return;
 			}
 		} else {
@@ -82,12 +82,12 @@ class ProperEscapingFunctionSniff extends Sniff {
 
 		$data = [ $function_name ];
 
-		if ( 'esc_url' !== $function_name && $this->is_href_or_src( $this->tokens[ $html ]['content'] ) ) {
+		if ( $function_name !== 'esc_url' && $this->is_href_or_src( $this->tokens[ $html ]['content'] ) ) {
 			$message = 'Wrong escaping function. href and src attributes should be escaped by `esc_url()`, not by `%s()`.';
 			$this->phpcsFile->addError( $message, $stackPtr, 'hrefSrcEscUrl', $data );
 			return;
 		}
-		if ( 'esc_html' === $function_name && $this->is_html_attr( $this->tokens[ $html ]['content'] ) ) {
+		if ( $function_name === 'esc_html' && $this->is_html_attr( $this->tokens[ $html ]['content'] ) ) {
 			$message = 'Wrong escaping function. HTML attributes should be escaped by `esc_attr()`, not by `%s()`.';
 			$this->phpcsFile->addError( $message, $stackPtr, 'htmlAttrNotByEscHTML', $data );
 			return;
@@ -110,7 +110,7 @@ class ProperEscapingFunctionSniff extends Sniff {
 				'=\'"', // The tokenizer does some fun stuff when it comes to mixing double and single quotes.
 				'="\'', // The tokenizer does some fun stuff when it comes to mixing double and single quotes.
 			] as $ending ) {
-				if ( true === $this->endswith( $content, $attr . $ending ) ) {
+				if ( $this->endswith( $content, $attr . $ending ) === true ) {
 					$is_href_or_src = true;
 					break;
 				}
@@ -134,7 +134,7 @@ class ProperEscapingFunctionSniff extends Sniff {
 			'=\'"', // The tokenizer does some fun stuff when it comes to mixing double and single quotes.
 			'="\'', // The tokenizer does some fun stuff when it comes to mixing double and single quotes.
 		] as $ending ) {
-			if ( true === $this->endswith( $content, $ending ) ) {
+			if ( $this->endswith( $content, $ending ) === true ) {
 				$is_html_attr = true;
 				break;
 			}

--- a/WordPressVIPMinimum/Sniffs/Security/StaticStrreplaceSniff.php
+++ b/WordPressVIPMinimum/Sniffs/Security/StaticStrreplaceSniff.php
@@ -36,13 +36,13 @@ class StaticStrreplaceSniff extends Sniff {
 	 */
 	public function process_token( $stackPtr ) {
 
-		if ( 'str_replace' !== $this->tokens[ $stackPtr ]['content'] ) {
+		if ( $this->tokens[ $stackPtr ]['content'] !== 'str_replace' ) {
 			return;
 		}
 
 		$openBracket = $this->phpcsFile->findNext( Tokens::$emptyTokens, $stackPtr + 1, null, true );
 
-		if ( T_OPEN_PARENTHESIS !== $this->tokens[ $openBracket ]['code'] ) {
+		if ( $this->tokens[ $openBracket ]['code'] !== T_OPEN_PARENTHESIS ) {
 			return;
 		}
 
@@ -50,9 +50,9 @@ class StaticStrreplaceSniff extends Sniff {
 		for ( $i = 0; $i < 3; $i++ ) {
 			$param_ptr = $this->phpcsFile->findNext( array_merge( Tokens::$emptyTokens, [ T_COMMA ] ), $next_start_ptr, null, true );
 
-			if ( T_ARRAY === $this->tokens[ $param_ptr ]['code'] ) {
+			if ( $this->tokens[ $param_ptr ]['code'] === T_ARRAY ) {
 				$openBracket = $this->phpcsFile->findNext( Tokens::$emptyTokens, $param_ptr + 1, null, true );
-				if ( T_OPEN_PARENTHESIS !== $this->tokens[ $openBracket ]['code'] ) {
+				if ( $this->tokens[ $openBracket ]['code'] !== T_OPEN_PARENTHESIS ) {
 					return;
 				}
 
@@ -60,9 +60,9 @@ class StaticStrreplaceSniff extends Sniff {
 				$closeBracket = $this->tokens[ $openBracket ]['parenthesis_closer'];
 
 				$array_item_ptr = $this->phpcsFile->findNext( array_merge( Tokens::$emptyTokens, [ T_COMMA ] ), $openBracket + 1, $closeBracket, true );
-				while ( false !== $array_item_ptr ) {
+				while ( $array_item_ptr !== false ) {
 
-					if ( T_CONSTANT_ENCAPSED_STRING !== $this->tokens[ $array_item_ptr ]['code'] ) {
+					if ( $this->tokens[ $array_item_ptr ]['code'] !== T_CONSTANT_ENCAPSED_STRING ) {
 						return;
 					}
 					$array_item_ptr = $this->phpcsFile->findNext( array_merge( Tokens::$emptyTokens, [ T_COMMA ] ), $array_item_ptr + 1, $closeBracket, true );
@@ -73,7 +73,7 @@ class StaticStrreplaceSniff extends Sniff {
 
 			}
 
-			if ( T_CONSTANT_ENCAPSED_STRING !== $this->tokens[ $param_ptr ]['code'] ) {
+			if ( $this->tokens[ $param_ptr ]['code'] !== T_CONSTANT_ENCAPSED_STRING ) {
 				return;
 			}
 

--- a/WordPressVIPMinimum/Sniffs/Security/TwigSniff.php
+++ b/WordPressVIPMinimum/Sniffs/Security/TwigSniff.php
@@ -46,13 +46,13 @@ class TwigSniff extends Sniff {
 	 */
 	public function process_token( $stackPtr ) {
 
-		if ( 1 === preg_match( '/autoescape\s+false/', $this->tokens[ $stackPtr ]['content'] ) ) {
+		if ( preg_match( '/autoescape\s+false/', $this->tokens[ $stackPtr ]['content'] ) === 1 ) {
 			// Twig autoescape disabled.
 			$message = 'Found Twig autoescape disabling notation.';
 			$this->phpcsFile->addWarning( $message, $stackPtr, 'AutoescapeFalse' );
 		}
 
-		if ( 1 === preg_match( '/\|\s*raw/', $this->tokens[ $stackPtr ]['content'] ) ) {
+		if ( preg_match( '/\|\s*raw/', $this->tokens[ $stackPtr ]['content'] ) === 1 ) {
 			// Twig default unescape filter.
 			$message = 'Found Twig default unescape filter: "|raw".';
 			$this->phpcsFile->addWarning( $message, $stackPtr, 'RawFound' );

--- a/WordPressVIPMinimum/Sniffs/Security/UnderscorejsSniff.php
+++ b/WordPressVIPMinimum/Sniffs/Security/UnderscorejsSniff.php
@@ -47,13 +47,13 @@ class UnderscorejsSniff extends Sniff {
 	 */
 	public function process_token( $stackPtr ) {
 
-		if ( false !== strpos( $this->tokens[ $stackPtr ]['content'], '<%=' ) ) {
+		if ( strpos( $this->tokens[ $stackPtr ]['content'], '<%=' ) !== false ) {
 			// Underscore.js unescaped output.
 			$message = 'Found Underscore.js unescaped output notation: "<%=".';
 			$this->phpcsFile->addWarning( $message, $stackPtr, 'OutputNotation' );
 		}
 
-		if ( false !== strpos( $this->tokens[ $stackPtr ]['content'], 'interpolate' ) ) {
+		if ( strpos( $this->tokens[ $stackPtr ]['content'], 'interpolate' ) !== false ) {
 			// Underscore.js unescaped output.
 			$message = 'Found Underscore.js delimiter change notation.';
 			$this->phpcsFile->addWarning( $message, $stackPtr, 'InterpolateFound' );

--- a/WordPressVIPMinimum/Sniffs/Security/VuejsSniff.php
+++ b/WordPressVIPMinimum/Sniffs/Security/VuejsSniff.php
@@ -45,7 +45,7 @@ class VuejsSniff extends Sniff {
 	 */
 	public function process_token( $stackPtr ) {
 
-		if ( false !== strpos( $this->tokens[ $stackPtr ]['content'], 'v-html' ) ) {
+		if ( strpos( $this->tokens[ $stackPtr ]['content'], 'v-html' ) !== false ) {
 			// Vue autoescape disabled.
 			$message = 'Found Vue.js non-escaped (raw) HTML directive.';
 			$this->phpcsFile->addWarning( $message, $stackPtr, 'RawHTMLDirectiveFound' );

--- a/WordPressVIPMinimum/Sniffs/UserExperience/AdminBarRemovalSniff.php
+++ b/WordPressVIPMinimum/Sniffs/UserExperience/AdminBarRemovalSniff.php
@@ -160,8 +160,8 @@ class AdminBarRemovalSniff extends AbstractFunctionParameterSniff {
 		$file_name      = $this->phpcsFile->getFilename();
 		$file_extension = substr( strrchr( $file_name, '.' ), 1 );
 
-		if ( 'css' === $file_extension ) {
-			if ( \T_STYLE === $this->tokens[ $stackPtr ]['code'] ) {
+		if ( $file_extension === 'css' ) {
+			if ( $this->tokens[ $stackPtr ]['code'] === \T_STYLE ) {
 				$this->process_css_style( $stackPtr );
 				return;
 			}
@@ -201,25 +201,25 @@ class AdminBarRemovalSniff extends AbstractFunctionParameterSniff {
 		switch ( $matched_content ) {
 			case 'show_admin_bar':
 				$error = true;
-				if ( true === $this->remove_only && 'true' === $parameters[1]['raw'] ) {
+				if ( $this->remove_only === true && $parameters[1]['raw'] === 'true' ) {
 					$error = false;
 				}
 				break;
 
 			case 'add_filter':
 				$filter_name = $this->strip_quotes( $parameters[1]['raw'] );
-				if ( 'show_admin_bar' !== $filter_name ) {
+				if ( $filter_name !== 'show_admin_bar' ) {
 					break;
 				}
 
 				$error = true;
-				if ( true === $this->remove_only && isset( $parameters[2]['raw'] ) && '__return_true' === $this->strip_quotes( $parameters[2]['raw'] ) ) {
+				if ( $this->remove_only === true && isset( $parameters[2]['raw'] ) && $this->strip_quotes( $parameters[2]['raw'] ) === '__return_true' ) {
 					$error = false;
 				}
 				break;
 		}
 
-		if ( true === $error ) {
+		if ( $error === true ) {
 			$message = 'Removal of admin bar is prohibited.';
 			$this->phpcsFile->addError( $message, $stackPtr, 'RemovalDetected' );
 		}
@@ -237,20 +237,20 @@ class AdminBarRemovalSniff extends AbstractFunctionParameterSniff {
 		$content = trim( $this->tokens[ $stackPtr ]['content'] );
 
 		// No need to check an empty string.
-		if ( '' === $content ) {
+		if ( $content === '' ) {
 			return;
 		}
 
 		// Are we in a <style> tag ?
-		if ( true === $this->in_style[ $file_name ] ) {
-			if ( false !== strpos( $content, '</style>' ) ) {
+		if ( $this->in_style[ $file_name ] === true ) {
+			if ( strpos( $content, '</style>' ) !== false ) {
 				// Make sure we check any content on this line before the closing style tag.
 				$this->in_style[ $file_name ] = false;
 				$content                      = trim( substr( $content, 0, strpos( $content, '</style>' ) ) );
 			}
-		} elseif ( true === $this->has_html_open_tag( 'style', $stackPtr, $content ) ) {
+		} elseif ( $this->has_html_open_tag( 'style', $stackPtr, $content ) === true ) {
 			// Ok, found a <style> open tag.
-			if ( false === strpos( $content, '</style>' ) ) {
+			if ( strpos( $content, '</style>' ) === false ) {
 				// Make sure we check any content on this line after the opening style tag.
 				$this->in_style[ $file_name ] = true;
 				$content                      = trim( substr( $content, strpos( $content, '<style' ) + 6 ) );
@@ -266,8 +266,8 @@ class AdminBarRemovalSniff extends AbstractFunctionParameterSniff {
 		}
 
 		// Are we in one of the target selectors ?
-		if ( true === $this->in_target_selector[ $file_name ] ) {
-			if ( false !== strpos( $content, '}' ) ) {
+		if ( $this->in_target_selector[ $file_name ] === true ) {
+			if ( strpos( $content, '}' ) !== false ) {
 				// Make sure we check any content on this line before the selector closing brace.
 				$this->in_target_selector[ $file_name ] = false;
 				$content                                = trim( substr( $content, 0, strpos( $content, '}' ) ) );
@@ -276,8 +276,8 @@ class AdminBarRemovalSniff extends AbstractFunctionParameterSniff {
 			// Ok, found a new target selector.
 			$content = '';
 
-			if ( isset( $matches[1] ) && '' !== $matches[1] ) {
-				if ( false === strpos( $matches[1], '}' ) ) {
+			if ( isset( $matches[1] ) && $matches[1] !== '' ) {
+				if ( strpos( $matches[1], '}' ) === false ) {
 					// Make sure we check any content on this line before the closing brace.
 					$this->in_target_selector[ $file_name ] = true;
 					$content                                = trim( $matches[1] );
@@ -296,19 +296,19 @@ class AdminBarRemovalSniff extends AbstractFunctionParameterSniff {
 		// Now let's do the check for the CSS properties.
 		if ( ! empty( $content ) ) {
 			foreach ( $this->target_css_properties as $property => $requirements ) {
-				if ( false !== strpos( $content, $property ) ) {
+				if ( strpos( $content, $property ) !== false ) {
 					$error = true;
 
 					// Check the value of the CSS property.
-					if ( true === $this->remove_only && preg_match( '`' . preg_quote( $property, '`' ) . '\s*:\s*(.+?)\s*(?:!important)?;`', $content, $matches ) > 0 ) {
+					if ( $this->remove_only === true && preg_match( '`' . preg_quote( $property, '`' ) . '\s*:\s*(.+?)\s*(?:!important)?;`', $content, $matches ) > 0 ) {
 						$value = trim( $matches[1] );
 						$valid = $this->validate_css_property_value( $value, $requirements['type'], $requirements['value'] );
-						if ( true === $valid ) {
+						if ( $valid === true ) {
 							$error = false;
 						}
 					}
 
-					if ( true === $error ) {
+					if ( $error === true ) {
 						$this->addHidingDetectedError( $stackPtr );
 					}
 				}
@@ -333,10 +333,10 @@ class AdminBarRemovalSniff extends AbstractFunctionParameterSniff {
 
 		// Check if the CSS selector matches.
 		$opener = $this->phpcsFile->findPrevious( \T_OPEN_CURLY_BRACKET, $stackPtr );
-		if ( false !== $opener ) {
+		if ( $opener !== false ) {
 			for ( $i = ( $opener - 1 ); $i >= 0; $i-- ) {
 				if ( isset( Tokens::$commentTokens[ $this->tokens[ $i ]['code'] ] )
-					|| \T_CLOSE_CURLY_BRACKET === $this->tokens[ $i ]['code']
+					|| $this->tokens[ $i ]['code'] === \T_CLOSE_CURLY_BRACKET
 				) {
 					break;
 				}
@@ -346,20 +346,20 @@ class AdminBarRemovalSniff extends AbstractFunctionParameterSniff {
 			unset( $i );
 
 			foreach ( $this->target_css_selectors as $target_selector ) {
-				if ( false !== strpos( $selector, $target_selector ) ) {
+				if ( strpos( $selector, $target_selector ) !== false ) {
 					$error = true;
 
-					if ( true === $this->remove_only ) {
+					if ( $this->remove_only === true ) {
 						// Check the value of the CSS property.
 						$valuePtr = $this->phpcsFile->findNext( [ \T_COLON, \T_WHITESPACE ], $stackPtr + 1, null, true );
 						$value    = $this->tokens[ $valuePtr ]['content'];
 						$valid    = $this->validate_css_property_value( $value, $css_property['type'], $css_property['value'] );
-						if ( true === $valid ) {
+						if ( $valid === true ) {
 							$error = false;
 						}
 					}
 
-					if ( true === $error ) {
+					if ( $error === true ) {
 						$this->addHidingDetectedError( $stackPtr );
 					}
 				}
@@ -419,11 +419,11 @@ class AdminBarRemovalSniff extends AbstractFunctionParameterSniff {
 	 * @return bool True if the string contains an <tag_name> open tag, false otherwise.
 	 */
 	public function has_html_open_tag( $tag_name, $stackPtr = null, $content = null ) {
-		if ( null === $content && isset( $stackPtr ) ) {
+		if ( $content === null && isset( $stackPtr ) ) {
 			$content = $this->tokens[ $stackPtr ]['content'];
 		}
 
-		return null !== $content && false !== strpos( $content, '<' . $tag_name );
+		return $content !== null && strpos( $content, '<' . $tag_name ) !== false;
 	}
 
 }

--- a/WordPressVIPMinimum/Sniffs/Variables/ServerVariablesSniff.php
+++ b/WordPressVIPMinimum/Sniffs/Variables/ServerVariablesSniff.php
@@ -54,7 +54,7 @@ class ServerVariablesSniff extends Sniff {
 	 */
 	public function process_token( $stackPtr ) {
 
-		if ( '$_SERVER' !== $this->tokens[ $stackPtr ]['content'] ) {
+		if ( $this->tokens[ $stackPtr ]['content'] !== '$_SERVER' ) {
 			// Not the variable we are looking for.
 			return;
 		}

--- a/WordPressVIPMinimum/Sniffs/Variables/VariableAnalysisSniff.php
+++ b/WordPressVIPMinimum/Sniffs/Variables/VariableAnalysisSniff.php
@@ -76,14 +76,14 @@ class VariableAnalysisSniff extends \VariableAnalysis\Sniffs\CodeAnalysis\Variab
 	 */
 	public function process( File $phpcsFile, $stackPtr ) {
 
-		if ( false === $this->thrown['DeprecatedSniff'] ) {
+		if ( $this->thrown['DeprecatedSniff'] === false ) {
 			$this->thrown['DeprecatedSniff'] = $phpcsFile->addWarning(
 				'The "WordPressVIPMinimum.Variables.VariableAnalysis" sniff has been deprecated. Use the "VariableAnalysis.CodeAnalysis.VariableAnalysis" sniff instead. Please update your custom ruleset.',
 				0,
 				'DeprecatedSniff'
 			);
 		}
-		if ( ! empty( $this->exclude ) && false === $this->thrown['FoundPropertyForDeprecatedSniff'] ) {
+		if ( ! empty( $this->exclude ) && $this->thrown['FoundPropertyForDeprecatedSniff'] === false ) {
 			$this->thrown['FoundPropertyForDeprecatedSniff'] = $phpcsFile->addWarning(
 				'The "WordPressVIPMinimum.Variables.VariableAnalysis" sniff has been deprecated. Use the "CodeAnalysis.VariableAnalysis" sniff instead. "exclude" property setting found. Please update your custom ruleset.',
 				0,

--- a/tests/RulesetTest.php
+++ b/tests/RulesetTest.php
@@ -91,7 +91,7 @@ class RulesetTest {
 
 		// Travis and Windows support.
 		$phpcs_bin = getenv( 'PHPCS_BIN' );
-		if ( false === $phpcs_bin ) {
+		if ( $phpcs_bin === false ) {
 			// phpcs:ignore
 			putenv( 'PHPCS_BIN=phpcs' );
 		} else {
@@ -199,7 +199,7 @@ class RulesetTest {
 	 * @return bool True if string matches error type.
 	 */
 	private function violation_type_is_error( $violation ) {
-		return self::ERROR_TYPE === $violation->type;
+		return $violation->type === self::ERROR_TYPE;
 	}
 
 	/**
@@ -235,12 +235,12 @@ class RulesetTest {
 	 */
 	private function check_missing_expected_values() {
 		foreach ( $this->expected as $type => $lines ) {
-			if ( 'messages' === $type ) {
+			if ( $type === 'messages' ) {
 				continue;
 			}
 
 			foreach ( $lines as $line_number => $expected_count_of_type_violations ) {
-				if ( 0 === $expected_count_of_type_violations ) {
+				if ( $expected_count_of_type_violations === 0 ) {
 					continue;
 				}
 
@@ -261,7 +261,7 @@ class RulesetTest {
 	private function check_unexpected_values() {
 		foreach ( [ 'errors', 'warnings' ] as $type ) {
 			foreach ( $this->$type as $line_number => $actual_count_of_type_violations ) {
-				if ( 0 === $actual_count_of_type_violations ) {
+				if ( $actual_count_of_type_violations === 0 ) {
 					continue;
 				}
 

--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -24,15 +24,15 @@ $phpcsDir          = getenv( 'PHPCS_DIR' );
 $composerPHPCSPath = dirname( __DIR__ ) . $ds . 'vendor' . $ds . 'squizlabs' . $ds . 'php_codesniffer';
 
 // This may be a Composer install.
-if ( false === $phpcsDir && is_dir( $composerPHPCSPath ) ) {
+if ( $phpcsDir === false && is_dir( $composerPHPCSPath ) ) {
 	$phpcsDir = $composerPHPCSPath;
-} elseif ( false !== $phpcsDir ) {
+} elseif ( $phpcsDir !== false ) {
 	// PHPCS in a custom directory.
 	$phpcsDir = realpath( $phpcsDir );
 }
 
 // Try and load the PHPCS autoloader.
-if ( false !== $phpcsDir
+if ( $phpcsDir !== false
 	&& file_exists( $phpcsDir . $ds . 'autoload.php' )
 	&& file_exists( $phpcsDir . $ds . 'tests' . $ds . 'bootstrap.php' )
 ) {


### PR DESCRIPTION
### PHPCS ruleset: forbid yoda conditions in VIPCS codebase

In contrast to WPCS, disallow the use of Yoda conditions.

### CS: change yoda conditions to non-yoda

Fixes made with the auto-fixer available in the Slevomat standard via the `SlevomatCodingStandard.ControlStructures.DisallowYodaComparison` sniff and visually reviewed.

