### PR TITLE
Composer: Change minimum stability to stable

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -28,7 +28,6 @@
 	"suggest": {
 		"dealerdirect/phpcodesniffer-composer-installer": "^0.7 || This Composer plugin will manage the PHPCS 'installed_paths' automatically."
 	},
-	"minimum-stability": "RC",
 	"scripts": {
 		"install-codestandards": "Dealerdirect\\Composer\\Plugin\\Installers\\PHPCodeSniffer\\Plugin::run",
 		"ruleset": "bin/ruleset-tests",


### PR DESCRIPTION
We don't require or require-dev any packages that are not stable, so no need to continue allowing RC at this time.

Fixes #562.