### PR TITLE
Ignore return values when a filter callback is abstract

### DIFF
--- a/WordPressVIPMinimum/Sniffs/Hooks/AlwaysReturnInFilterSniff.php
+++ b/WordPressVIPMinimum/Sniffs/Hooks/AlwaysReturnInFilterSniff.php
@@ -180,7 +180,7 @@ class AlwaysReturnInFilterSniff extends Sniff {
 		 *
 		 * @see https://github.com/squizlabs/PHP_CodeSniffer/blob/master/src/Standards/Generic/Sniffs/NamingConventions/ConstructorNameSniff.php#L87-L90
 		 */
-		if ( false === isset( $this->tokens[ $stackPtr ]['scope_closer'] ) ) {
+		if ( isset( $this->tokens[ $stackPtr ]['scope_closer'] ) === false ) {
 			return;
 		}
 

--- a/WordPressVIPMinimum/Sniffs/Hooks/AlwaysReturnInFilterSniff.php
+++ b/WordPressVIPMinimum/Sniffs/Hooks/AlwaysReturnInFilterSniff.php
@@ -176,7 +176,7 @@ class AlwaysReturnInFilterSniff extends Sniff {
 	private function processFunctionBody( $stackPtr ) {
 
 		/**
-		 * Stop if the constructor doesn't have a body, like when it is abstract.
+		 * Stop if the function doesn't have a body, like when it is abstract.
 		 *
 		 * @see https://github.com/squizlabs/PHP_CodeSniffer/blob/master/src/Standards/Generic/Sniffs/NamingConventions/ConstructorNameSniff.php#L87-L90
 		 */

--- a/WordPressVIPMinimum/Sniffs/Hooks/AlwaysReturnInFilterSniff.php
+++ b/WordPressVIPMinimum/Sniffs/Hooks/AlwaysReturnInFilterSniff.php
@@ -179,7 +179,7 @@ class AlwaysReturnInFilterSniff extends Sniff {
 
 		$methodProps = $this->phpcsFile->getMethodProperties( $stackPtr );
 		if ( $methodProps['is_abstract'] === true ) {
-			$message = 'The callback for the `%s` filter hook-in points to an abstract method. Please, make sure that all child class implementations of this abstract method always return a value.';
+			$message = 'The callback for the `%s` filter hook-in points to an abstract method. Please ensure that child class implementations of this method always return a value.';
 			$data    = [ $filterName ];
 			$this->phpcsFile->addWarning( $message, $stackPtr, 'AbstractMethod', $data );
 			return;

--- a/WordPressVIPMinimum/Sniffs/Hooks/AlwaysReturnInFilterSniff.php
+++ b/WordPressVIPMinimum/Sniffs/Hooks/AlwaysReturnInFilterSniff.php
@@ -175,6 +175,15 @@ class AlwaysReturnInFilterSniff extends Sniff {
 	 */
 	private function processFunctionBody( $stackPtr ) {
 
+		/**
+		 * Stop if the constructor doesn't have a body, like when it is abstract.
+		 *
+		 * @see https://github.com/squizlabs/PHP_CodeSniffer/blob/master/src/Standards/Generic/Sniffs/NamingConventions/ConstructorNameSniff.php#L87-L90
+		 */
+		if ( false === isset( $this->tokens[ $stackPtr ]['scope_closer'] ) ) {
+			return;
+		}
+
 		$argPtr = $this->phpcsFile->findNext(
 			array_merge( Tokens::$emptyTokens, [ T_STRING, T_OPEN_PARENTHESIS ] ),
 			$stackPtr + 1,

--- a/WordPressVIPMinimum/Tests/Hooks/AlwaysReturnInFilterUnitTest.inc
+++ b/WordPressVIPMinimum/Tests/Hooks/AlwaysReturnInFilterUnitTest.inc
@@ -172,23 +172,26 @@ class bad_example_class_short_array { // Error.
 	}
 }
 
-abstract class good_example_abstract_class { // Ok.
+abstract class warning_filter_points_to_abstract_method {
 	public function __construct() {
-		add_filter( 'good_example_class_filter', [ $this, 'class_filter' ] );
+		add_filter( 'good_example_abstract_class', [ $this, 'abstract_method' ] );
 	}
 
-	abstract public function class_filter( $param );
+	abstract public function abstract_method( $param ); // Warning.
 }
 
-class good_example_abstract_class_implementation { // Ok.
-	public function class_filter( $param ) {
-		if ( 1 === 1 ) {
-			if ( 1 === 0 ) {
-				return 'whoops';
-			} else {
-				return 'here!';
-			}
-		}
-		return 'This is Okay';
+class tokenizer_bug_test {
+	public function __construct() {
+		add_filter( 'tokenizer_bug', [ $this, 'tokenizer_bug' ] );
 	}
+
+	public function tokenizer_bug( $param ): namespace\Foo {} // Ok (tokenizer bug in PHPCS < 3.5.7/3.6.0).
 }
+
+// Intentional parse error. This has to be the last test in the file!
+class parse_error_test {
+	public function __construct() {
+		add_filter( 'parse_error', [ $this, 'parse_error' ] );
+	}
+
+	public function parse_error( $param ) // Ok, parse error ignored.

--- a/WordPressVIPMinimum/Tests/Hooks/AlwaysReturnInFilterUnitTest.inc
+++ b/WordPressVIPMinimum/Tests/Hooks/AlwaysReturnInFilterUnitTest.inc
@@ -172,3 +172,23 @@ class bad_example_class_short_array { // Error.
 	}
 }
 
+abstract class good_example_abstract_class { // Ok.
+	public function __construct() {
+		add_filter( 'good_example_class_filter', [ $this, 'class_filter' ] );
+	}
+
+	abstract public function class_filter( $param );
+}
+
+class good_example_abstract_class_implementation { // Ok.
+	public function class_filter( $param ) {
+		if ( 1 === 1 ) {
+			if ( 1 === 0 ) {
+				return 'whoops';
+			} else {
+				return 'here!';
+			}
+		}
+		return 'This is Okay';
+	}
+}

--- a/WordPressVIPMinimum/Tests/Hooks/AlwaysReturnInFilterUnitTest.php
+++ b/WordPressVIPMinimum/Tests/Hooks/AlwaysReturnInFilterUnitTest.php
@@ -40,7 +40,9 @@ class AlwaysReturnInFilterUnitTest extends AbstractSniffUnitTest {
 	 * @return array <int line number> => <int number of warnings>
 	 */
 	public function getWarningList() {
-		return [];
+		return [
+			180 => 1,
+		];
 	}
 
 }


### PR DESCRIPTION
If a filter is defined in the constructor of an abstract class, and uses an abstract method as its callback, relying on implementing classes to define the return value, the `WordPressVIPMinimum.Hooks.AlwaysReturnInFilter.MissingReturnStatement` sniff causes phpcs to crash.

This PR adds a unit test to confirm the issue, and implements a fix using the same code that is used by phpcs itself.

Fixes #580 