### PR TITLE
Travis: retry composer install on failure

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -46,7 +46,7 @@ jobs:
         - ./bin/php-lint
 
         # Add PHPCS locally for the XSD.
-        - composer require squizlabs/php_codesniffer
+        - travis_retry composer require squizlabs/php_codesniffer
         # Validate the XML files and check the code-style consistency of the XML files.
         - ./bin/xml-lint
 
@@ -62,7 +62,7 @@ jobs:
       php: 7.4
       env: PHPCS_BRANCH="dev-master"
       before_install: phpenv config-rm xdebug.ini || echo 'No xdebug config.'
-      install: composer install --no-suggest
+      install: travis_retry composer install --no-suggest
       script:
         # Run PHPCS against VIPCS.
         - ./bin/phpcs
@@ -96,14 +96,14 @@ before_install:
     fi
 
 install:
-  - composer require squizlabs/php_codesniffer:"$PHPCS_BRANCH" --no-update --no-suggest --no-scripts
+  - travis_retry composer require squizlabs/php_codesniffer:"$PHPCS_BRANCH" --no-update --no-suggest --no-scripts
   - |
     if [[ $TRAVIS_PHP_VERSION == "nightly" ]]; then
-        # PHPUnit 7.x does not allow for installation on PHP 8, so ignore platform
-        # requirements to get PHPUnit 7.x to install on nightly.
-        composer install --ignore-platform-reqs --no-suggest
+      # PHPUnit 7.x does not allow for installation on PHP 8, so ignore platform
+      # requirements to get PHPUnit 7.x to install on nightly.
+      travis_retry composer install --ignore-platform-reqs --no-suggest
     else
-      composer install --no-suggest
+      travis_retry composer install --no-suggest
     fi
 
 script:


### PR DESCRIPTION
The builds are failing a little too often for my taste on the below error.
```
[Composer\Downloader\TransportException]
Peer fingerprint did not match
```

I'm prefixing the `composer install` commands now with `travis_retry` in an attempt to get round this problem.

Ref:
* https://docs.travis-ci.com/user/common-build-problems/#timeouts-installing-dependencies