### PR TITLE
Composer: require the DealerDirect plugin

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ This project contains two rulesets:
 
 These rulesets contain only the rules which are considered to be "errors" and "warnings" according to the [WordPress VIP Go documentation](https://wpvip.com/documentation/vip-go/code-review-blockers-warnings-notices/)
 
-The rulesets use rules from the [WordPress Coding Standards](https://github.com/WordPress/WordPress-Coding-Standards) (WPCS) project.
+The rulesets use rules from the [WordPress Coding Standards](https://github.com/WordPress/WordPress-Coding-Standards) (WPCS) project, as well as the [VariableAnalysis](https://github.com/sirbrillig/phpcs-variable-analysis) standard.
 
 Go to https://wpvip.com/documentation/phpcs-review-feedback/ to learn about why violations are flagged as errors vs warnings and what the levels mean.
 
@@ -18,20 +18,17 @@ Go to https://wpvip.com/documentation/phpcs-review-feedback/ to learn about why 
 * PHP 5.4+
 * [PHPCS 3.5.5+](https://github.com/squizlabs/PHP_CodeSniffer/releases)
 * [WPCS 2.3.0+](https://github.com/WordPress-Coding-Standards/WordPress-Coding-Standards/releases)
+* [VariableAnalysis 2.8.3+](https://github.com/sirbrillig/phpcs-variable-analysis/releases)
 
 ## Installation
 
 `composer require automattic/vipwpcs`, or `composer g require automattic/vipwpcs` if installing globally. 
 
-This will install the latest compatible versions of PHPCS and WPCS. 
+This will install the latest compatible versions of PHPCS, WPCS and VariableAnalysis and register the external standards with PHP_CodeSniffer.
 
 Please refer to the [installation instructions for installing PHP_CodeSniffer for WordPress.com VIP](https://wpvip.com/documentation/how-to-install-php-code-sniffer-for-wordpress-com-vip/) for more details.
 
-We recommend the [PHP_CodeSniffer Standards Composer Installer Plugin](https://github.com/Dealerdirect/phpcodesniffer-composer-installer), which handles the registration of all of the installed standards, so there is no need to set the `installed_paths` config value manually, for single or multiple standards.
-
-Alternatively, you should register the standard to PHPCS by appending the VIPCS directory to the end of the installed paths. e.g.
-
-`phpcs --config-set installed_paths /path/to/wpcsstandard,path/to/vipcsstandard`
+As of VIPCS version 2.3.0, there is no need to `require` the [PHP_CodeSniffer Standards Composer Installer Plugin](https://github.com/Dealerdirect/phpcodesniffer-composer-installer) anymore as it is now a requirement of VIPCS itself.
 
 ## Contribution
 

--- a/composer.json
+++ b/composer.json
@@ -16,17 +16,14 @@
 	],
 	"require": {
 		"php": ">=5.4",
+		"dealerdirect/phpcodesniffer-composer-installer": "^0.4.1 || ^0.5 || ^0.6.2 || ^0.7",
 		"sirbrillig/phpcs-variable-analysis": "^2.8.3",
 		"squizlabs/php_codesniffer": "^3.5.5",
 		"wp-coding-standards/wpcs": "^2.3"
 	},
 	"require-dev": {
-		"dealerdirect/phpcodesniffer-composer-installer": "^0.7",
 		"phpcompatibility/php-compatibility": "^9",
 		"phpunit/phpunit": "^4 || ^5 || ^6 || ^7"
-	},
-	"suggest": {
-		"dealerdirect/phpcodesniffer-composer-installer": "^0.7 || This Composer plugin will manage the PHPCS 'installed_paths' automatically."
 	},
 	"scripts": {
 		"install-codestandards": "Dealerdirect\\Composer\\Plugin\\Installers\\PHPCodeSniffer\\Plugin::run",


### PR DESCRIPTION
As VIPCS requires two external standards, including the new `VariableAnalysis` dependency, let's require the DealerDirect plugin to make life easier on people who install via Composer.

Includes updating the Readme to mention the `VariableAnalysis` standard, as well as mention that the DealerDirect plugin is now a project requirement.

Note: I've widened the version constraints for the DealerDirect plugin to prevent conflicts with customer projects which already required the plugin, but potentially at a different version.
The version constraints now set covers all released versions which support external standards properly.