### PR TITLE
Performance: more selective sniffing for efficiency

### DIFF
--- a/WordPressVIPMinimum/Sniffs/Compatibility/ZoninatorSniff.php
+++ b/WordPressVIPMinimum/Sniffs/Compatibility/ZoninatorSniff.php
@@ -22,7 +22,7 @@ class ZoninatorSniff extends Sniff {
 	 * @return array(int)
 	 */
 	public function register() {
-		return Tokens::$functionNameTokens;
+		return [ T_STRING ];
 	}
 
 

--- a/WordPressVIPMinimum/Sniffs/Functions/CheckReturnValueSniff.php
+++ b/WordPressVIPMinimum/Sniffs/Functions/CheckReturnValueSniff.php
@@ -60,7 +60,7 @@ class CheckReturnValueSniff extends Sniff {
 	 * @return array(int)
 	 */
 	public function register() {
-		return Tokens::$functionNameTokens;
+		return [ T_STRING ];
 	}
 
 	/**
@@ -86,7 +86,7 @@ class CheckReturnValueSniff extends Sniff {
 	 */
 	private function isFunctionCall( $stackPtr ) {
 
-		if ( in_array( $this->tokens[ $stackPtr ]['code'], Tokens::$functionNameTokens, true ) === false ) {
+		if ( $this->tokens[ $stackPtr ]['code'] !== T_STRING ) {
 			return false;
 		}
 
@@ -162,14 +162,14 @@ class CheckReturnValueSniff extends Sniff {
 		$closeBracket = $this->tokens[ $openBracket ]['parenthesis_closer'];
 
 		$startNext = $openBracket + 1;
-		$next      = $this->phpcsFile->findNext( Tokens::$functionNameTokens, $startNext, $closeBracket, false, null, true );
+		$next      = $this->phpcsFile->findNext( T_STRING, $startNext, $closeBracket, false, null, true );
 		while ( $next ) {
 			if ( in_array( $this->tokens[ $next ]['content'], $this->catch[ $functionName ], true ) === true ) {
 				$message = "`%s`'s return type must be checked before calling `%s` using that value.";
 				$data    = [ $this->tokens[ $next ]['content'], $functionName ];
 				$this->phpcsFile->addError( $message, $next, 'DirectFunctionCall', $data );
 			}
-			$next = $this->phpcsFile->findNext( Tokens::$functionNameTokens, $next + 1, $closeBracket, false, null, true );
+			$next = $this->phpcsFile->findNext( T_STRING, $next + 1, $closeBracket, false, null, true );
 		}
 	}
 
@@ -269,7 +269,7 @@ class CheckReturnValueSniff extends Sniff {
 		foreach ( $callees as $callee ) {
 			$notFunctionsCallee = array_key_exists( $callee, $this->notFunctions ) ? (array) $this->notFunctions[ $callee ] : [];
 			// Check whether the found token is one of the function calls (or foreach call) we are interested in.
-			if ( in_array( $this->tokens[ $nextFunctionCallWithVariable ]['code'], array_merge( Tokens::$functionNameTokens, $notFunctionsCallee ), true ) === true
+			if ( in_array( $this->tokens[ $nextFunctionCallWithVariable ]['code'], array_merge( [ T_STRING ], $notFunctionsCallee ), true ) === true
 				&& $this->tokens[ $nextFunctionCallWithVariable ]['content'] === $callee
 			) {
 				$this->addNonCheckedVariableError( $nextFunctionCallWithVariable, $variableName, $callee );
@@ -278,7 +278,7 @@ class CheckReturnValueSniff extends Sniff {
 
 			$search = array_merge( Tokens::$emptyTokens, [ T_EQUAL ] );
 			$next   = $this->phpcsFile->findNext( $search, $nextVariableOccurrence + 1, null, true );
-			if ( in_array( $this->tokens[ $next ]['code'], Tokens::$functionNameTokens, true ) === true
+			if ( $this->tokens[ $next ]['code'] === T_STRING
 				&& $this->tokens[ $next ]['content'] === $callee
 			) {
 				$this->addNonCheckedVariableError( $next, $variableName, $callee );

--- a/WordPressVIPMinimum/Sniffs/Hooks/AlwaysReturnInFilterSniff.php
+++ b/WordPressVIPMinimum/Sniffs/Hooks/AlwaysReturnInFilterSniff.php
@@ -30,7 +30,7 @@ class AlwaysReturnInFilterSniff extends Sniff {
 	 * @return array(int)
 	 */
 	public function register() {
-		return Tokens::$functionNameTokens;
+		return [ T_STRING ];
 	}
 
 	/**
@@ -130,7 +130,7 @@ class AlwaysReturnInFilterSniff extends Sniff {
 		$callbackFunctionName = substr( $this->tokens[ $stackPtr ]['content'], 1, -1 );
 
 		$callbackFunctionPtr = $this->phpcsFile->findNext(
-			Tokens::$functionNameTokens,
+			T_STRING,
 			$start,
 			$end,
 			false,

--- a/WordPressVIPMinimum/Sniffs/Hooks/PreGetPostsSniff.php
+++ b/WordPressVIPMinimum/Sniffs/Hooks/PreGetPostsSniff.php
@@ -25,7 +25,7 @@ class PreGetPostsSniff extends Sniff {
 	 * @return array(int)
 	 */
 	public function register() {
-		return Tokens::$functionNameTokens;
+		return [ T_STRING ];
 	}
 
 	/**
@@ -120,7 +120,7 @@ class PreGetPostsSniff extends Sniff {
 		$callbackFunctionName = substr( $this->tokens[ $stackPtr ]['content'], 1, -1 );
 
 		$callbackFunctionPtr = $this->phpcsFile->findNext(
-			Tokens::$functionNameTokens,
+			T_STRING,
 			0,
 			null,
 			false,
@@ -394,7 +394,7 @@ class PreGetPostsSniff extends Sniff {
 			true
 		);
 
-		return $next && in_array( $this->tokens[ $next ]['code'], Tokens::$functionNameTokens, true ) === true && $method === $this->tokens[ $next ]['content'];
+		return $next && $this->tokens[ $next ]['code'] === T_STRING && $method === $this->tokens[ $next ]['content'];
 	}
 
 	/**

--- a/WordPressVIPMinimum/Sniffs/Performance/CacheValueOverrideSniff.php
+++ b/WordPressVIPMinimum/Sniffs/Performance/CacheValueOverrideSniff.php
@@ -29,7 +29,7 @@ class CacheValueOverrideSniff extends Sniff {
 	 * @return array(int)
 	 */
 	public function register() {
-		return Tokens::$functionNameTokens;
+		return [ T_STRING ];
 	}
 
 
@@ -96,10 +96,6 @@ class CacheValueOverrideSniff extends Sniff {
 	 * @return bool
 	 */
 	private function isFunctionCall( $stackPtr ) {
-
-		if ( in_array( $this->tokens[ $stackPtr ]['code'], Tokens::$functionNameTokens, true ) === false ) {
-			return false;
-		}
 
 		// Find the next non-empty token.
 		$openBracket = $this->phpcsFile->findNext( Tokens::$emptyTokens, $stackPtr + 1, null, true );

--- a/WordPressVIPMinimum/Sniffs/Performance/FetchingRemoteDataSniff.php
+++ b/WordPressVIPMinimum/Sniffs/Performance/FetchingRemoteDataSniff.php
@@ -24,7 +24,7 @@ class FetchingRemoteDataSniff extends Sniff {
 	 * @return array
 	 */
 	public function register() {
-		return Tokens::$functionNameTokens;
+		return [ T_STRING ];
 	}
 
 	/**

--- a/WordPressVIPMinimum/Sniffs/Performance/TaxonomyMetaInOptionsSniff.php
+++ b/WordPressVIPMinimum/Sniffs/Performance/TaxonomyMetaInOptionsSniff.php
@@ -51,7 +51,7 @@ class TaxonomyMetaInOptionsSniff extends Sniff {
 	 * @return array
 	 */
 	public function register() {
-		return Tokens::$functionNameTokens;
+		return [ T_STRING ];
 	}
 
 	/**

--- a/WordPressVIPMinimum/Sniffs/Security/ExitAfterRedirectSniff.php
+++ b/WordPressVIPMinimum/Sniffs/Security/ExitAfterRedirectSniff.php
@@ -24,7 +24,7 @@ class ExitAfterRedirectSniff extends Sniff {
 	 * @return array
 	 */
 	public function register() {
-		return Tokens::$functionNameTokens;
+		return [ T_STRING ];
 	}
 
 	/**

--- a/WordPressVIPMinimum/Sniffs/Security/ProperEscapingFunctionSniff.php
+++ b/WordPressVIPMinimum/Sniffs/Security/ProperEscapingFunctionSniff.php
@@ -35,7 +35,7 @@ class ProperEscapingFunctionSniff extends Sniff {
 	 * @return array
 	 */
 	public function register() {
-		return Tokens::$functionNameTokens;
+		return [ T_STRING ];
 	}
 
 	/**

--- a/WordPressVIPMinimum/Sniffs/Security/StaticStrreplaceSniff.php
+++ b/WordPressVIPMinimum/Sniffs/Security/StaticStrreplaceSniff.php
@@ -24,7 +24,7 @@ class StaticStrreplaceSniff extends Sniff {
 	 * @return array
 	 */
 	public function register() {
-		return Tokens::$functionNameTokens;
+		return [ T_STRING ];
 	}
 
 	/**


### PR DESCRIPTION
The `register()` method tells PHPCS which tokens a sniff is listening for.

A number of sniffs were currently registering the [`Tokens::$functionNameTokens`](https://github.com/squizlabs/PHP_CodeSniffer/blob/9cce6859a595b3fa77fc823d9b0d451951dcf9d2/src/Util/Tokens.php#L570-L583) array.
In all cases, these sniffs were only looking for specific function calls, and in most cases, a "name" check is the first thing in the sniff code or else such a check was done at a later point in the code.

This makes using the `Tokens::$functionNameTokens` array highly inefficient, as the _only_ token within that array which could have the "name" the sniff is looking for is `T_STRING`. The other eleven (!) tokens registered would **never** match and would never trigger an error, but would be passed to the sniff even so.

This commit replaces the use of the `Tokens::$functionNameTokens` array in nearly all places in the code base with `T_STRING` for higher accuracy and more efficient sniffing.

**Note**: in a future PR, once PHPCSUtils is used, these sniffs should be adjusted to take the [PHP 8.0 namespaced identifier name tokens](https://wiki.php.net/rfc/namespaced_names_as_token) into account, but that is for later.