### PR TITLE
Hooks/AlwaysReturnInFilter: adjust expectations for a test

### DIFF
--- a/WordPressVIPMinimum/Tests/Hooks/AlwaysReturnInFilterUnitTest.inc
+++ b/WordPressVIPMinimum/Tests/Hooks/AlwaysReturnInFilterUnitTest.inc
@@ -185,7 +185,7 @@ class tokenizer_bug_test {
 		add_filter( 'tokenizer_bug', [ $this, 'tokenizer_bug' ] );
 	}
 
-	public function tokenizer_bug( $param ): namespace\Foo {} // Ok (tokenizer bug in PHPCS < 3.5.7/3.6.0).
+	public function tokenizer_bug( $param ): namespace\Foo {} // Ok (tokenizer bug PHPCS < 3.5.7) / Error in PHPCS >= 3.5.7.
 }
 
 // Intentional parse error. This has to be the last test in the file!

--- a/WordPressVIPMinimum/Tests/Hooks/AlwaysReturnInFilterUnitTest.php
+++ b/WordPressVIPMinimum/Tests/Hooks/AlwaysReturnInFilterUnitTest.php
@@ -7,7 +7,9 @@
 
 namespace WordPressVIPMinimum\Tests\Hooks;
 
+use PHP_CodeSniffer\Config;
 use PHP_CodeSniffer\Tests\Standards\AbstractSniffUnitTest;
+
 /**
  * Unit test class for the Hooks/AlwaysReturn sniff.
  *
@@ -31,6 +33,7 @@ class AlwaysReturnInFilterUnitTest extends AbstractSniffUnitTest {
 			105 => 1,
 			129 => 1,
 			163 => 1,
+			188 => version_compare( Config::VERSION, '3.5.7', '>=' ) ? 1 : 0,
 		];
 	}
 


### PR DESCRIPTION
... as an upstream PR containing a bug fix for the tokenizer issue this test documents has been merged.

Ref:
* squizlabc/PHP_CodeSniffer#3066