### PR TITLE
Files/IncludingNonPHPFile: various improvements

### DIFF
--- a/WordPressVIPMinimum/Sniffs/Files/IncludingNonPHPFileSniff.php
+++ b/WordPressVIPMinimum/Sniffs/Files/IncludingNonPHPFileSniff.php
@@ -77,7 +77,7 @@ class IncludingNonPHPFileSniff extends Sniff {
 				continue;
 			}
 
-			$extension = $regexMatches[1];
+			$extension = strtolower( $regexMatches[1] );
 			if ( isset( $this->php_extensions[ $extension ] ) === true ) {
 				return;
 			}

--- a/WordPressVIPMinimum/Sniffs/Files/IncludingNonPHPFileSniff.php
+++ b/WordPressVIPMinimum/Sniffs/Files/IncludingNonPHPFileSniff.php
@@ -29,8 +29,9 @@ class IncludingNonPHPFileSniff extends Sniff {
 	 * @var array Key is the extension, value is irrelevant.
 	 */
 	private $php_extensions = [
-		'php' => true,
-		'inc' => true,
+		'php'  => true,
+		'inc'  => true,
+		'phar' => true,
 	];
 
 	/**

--- a/WordPressVIPMinimum/Sniffs/Files/IncludingNonPHPFileSniff.php
+++ b/WordPressVIPMinimum/Sniffs/Files/IncludingNonPHPFileSniff.php
@@ -62,9 +62,10 @@ class IncludingNonPHPFileSniff extends Sniff {
 	 * @return void
 	 */
 	public function process_token( $stackPtr ) {
-		$curStackPtr = $stackPtr;
-		while ( $this->phpcsFile->findNext( Tokens::$stringTokens, $curStackPtr + 1, null, false, null, true ) !== false ) {
-			$curStackPtr = $this->phpcsFile->findNext( Tokens::$stringTokens, $curStackPtr + 1, null, false, null, true );
+		$curStackPtr      = $stackPtr;
+		$end_of_statement = $this->phpcsFile->findEndOfStatement( $stackPtr );
+		while ( $this->phpcsFile->findNext( Tokens::$stringTokens, $curStackPtr + 1, $end_of_statement + 1 ) !== false ) {
+			$curStackPtr = $this->phpcsFile->findNext( Tokens::$stringTokens, $curStackPtr + 1, $end_of_statement + 1 );
 
 			$stringWithoutEnclosingQuotationMarks = trim( $this->tokens[ $curStackPtr ]['content'], "\"'" );
 

--- a/WordPressVIPMinimum/Sniffs/Files/IncludingNonPHPFileSniff.php
+++ b/WordPressVIPMinimum/Sniffs/Files/IncludingNonPHPFileSniff.php
@@ -7,7 +7,6 @@
 
 namespace WordPressVIPMinimum\Sniffs\Files;
 
-use PHP_CodeSniffer\Files\File;
 use WordPressVIPMinimum\Sniffs\Sniff;
 use PHP_CodeSniffer\Util\Tokens;
 

--- a/WordPressVIPMinimum/Sniffs/Files/IncludingNonPHPFileSniff.php
+++ b/WordPressVIPMinimum/Sniffs/Files/IncludingNonPHPFileSniff.php
@@ -22,6 +22,28 @@ use PHP_CodeSniffer\Util\Tokens;
 class IncludingNonPHPFileSniff extends Sniff {
 
 	/**
+	 * File extensions used for PHP files.
+	 *
+	 * Files with these extensions are allowed to be `include`d.
+	 *
+	 * @var array Key is the extension, value is irrelevant.
+	 */
+	private $php_extensions = [
+		'php' => true,
+		'inc' => true,
+	];
+
+	/**
+	 * File extensions used for SVG and CSS files.
+	 *
+	 * @var array Key is the extension, value is irrelevant.
+	 */
+	private $svg_css_extensions = [
+		'css' => true,
+		'svg' => true,
+	];
+
+	/**
 	 * Returns an array of tokens this test wants to listen for.
 	 *
 	 * @return array
@@ -49,14 +71,14 @@ class IncludingNonPHPFileSniff extends Sniff {
 				$stringWithoutEnclosingQuotationMarks = $this->tokens[ $curStackPtr ]['content'];
 			}
 
-			$isFileName = preg_match( '/.*(\.[a-z]{2,})$/i', $stringWithoutEnclosingQuotationMarks, $regexMatches );
+			$isFileName = preg_match( '/.*\.([a-z]{2,})$/i', $stringWithoutEnclosingQuotationMarks, $regexMatches );
 
 			if ( $isFileName === false || $isFileName === 0 ) {
 				continue;
 			}
 
 			$extension = $regexMatches[1];
-			if ( in_array( $extension, [ '.php', '.inc' ], true ) === true ) {
+			if ( isset( $this->php_extensions[ $extension ] ) === true ) {
 				return;
 			}
 
@@ -64,7 +86,7 @@ class IncludingNonPHPFileSniff extends Sniff {
 			$data    = [ $this->tokens[ $stackPtr ]['content'] ];
 			$code    = 'IncludingNonPHPFile';
 
-			if ( in_array( $extension, [ '.svg', '.css' ], true ) === true ) {
+			if ( isset( $this->svg_css_extensions[ $extension ] ) === true ) {
 				// Be more specific for SVG and CSS files.
 				$message = 'Local SVG and CSS files should be loaded via `file_get_contents` rather than via `%s`.';
 				$code    = 'IncludingSVGCSSFile';

--- a/WordPressVIPMinimum/Sniffs/Files/IncludingNonPHPFileSniff.php
+++ b/WordPressVIPMinimum/Sniffs/Files/IncludingNonPHPFileSniff.php
@@ -66,11 +66,7 @@ class IncludingNonPHPFileSniff extends Sniff {
 		while ( $this->phpcsFile->findNext( Tokens::$stringTokens, $curStackPtr + 1, null, false, null, true ) !== false ) {
 			$curStackPtr = $this->phpcsFile->findNext( Tokens::$stringTokens, $curStackPtr + 1, null, false, null, true );
 
-			if ( $this->tokens[ $curStackPtr ]['code'] === T_CONSTANT_ENCAPSED_STRING ) {
-				$stringWithoutEnclosingQuotationMarks = trim( $this->tokens[ $curStackPtr ]['content'], "\"'" );
-			} else {
-				$stringWithoutEnclosingQuotationMarks = $this->tokens[ $curStackPtr ]['content'];
-			}
+			$stringWithoutEnclosingQuotationMarks = trim( $this->tokens[ $curStackPtr ]['content'], "\"'" );
 
 			$isFileName = preg_match( '`\.([a-z]{2,})$`i', $stringWithoutEnclosingQuotationMarks, $regexMatches );
 

--- a/WordPressVIPMinimum/Sniffs/Files/IncludingNonPHPFileSniff.php
+++ b/WordPressVIPMinimum/Sniffs/Files/IncludingNonPHPFileSniff.php
@@ -74,7 +74,7 @@ class IncludingNonPHPFileSniff extends Sniff {
 
 			$isFileName = preg_match( '`\.([a-z]{2,})$`i', $stringWithoutEnclosingQuotationMarks, $regexMatches );
 
-			if ( $isFileName === false || $isFileName === 0 ) {
+			if ( $isFileName !== 1 ) {
 				continue;
 			}
 

--- a/WordPressVIPMinimum/Sniffs/Files/IncludingNonPHPFileSniff.php
+++ b/WordPressVIPMinimum/Sniffs/Files/IncludingNonPHPFileSniff.php
@@ -98,6 +98,10 @@ class IncludingNonPHPFileSniff extends Sniff {
 			}
 
 			$this->phpcsFile->addError( $message, $curStackPtr, $code, $data );
+
+			// Don't throw more than one error for any one statement.
+			return;
+
 		} while ( $curStackPtr > $stackPtr );
 	}
 

--- a/WordPressVIPMinimum/Sniffs/Files/IncludingNonPHPFileSniff.php
+++ b/WordPressVIPMinimum/Sniffs/Files/IncludingNonPHPFileSniff.php
@@ -71,7 +71,7 @@ class IncludingNonPHPFileSniff extends Sniff {
 				$stringWithoutEnclosingQuotationMarks = $this->tokens[ $curStackPtr ]['content'];
 			}
 
-			$isFileName = preg_match( '/.*\.([a-z]{2,})$/i', $stringWithoutEnclosingQuotationMarks, $regexMatches );
+			$isFileName = preg_match( '`\.([a-z]{2,})$`i', $stringWithoutEnclosingQuotationMarks, $regexMatches );
 
 			if ( $isFileName === false || $isFileName === 0 ) {
 				continue;

--- a/WordPressVIPMinimum/Sniffs/Files/IncludingNonPHPFileSniff.php
+++ b/WordPressVIPMinimum/Sniffs/Files/IncludingNonPHPFileSniff.php
@@ -64,8 +64,12 @@ class IncludingNonPHPFileSniff extends Sniff {
 	public function process_token( $stackPtr ) {
 		$curStackPtr      = $stackPtr;
 		$end_of_statement = $this->phpcsFile->findEndOfStatement( $stackPtr );
-		while ( $this->phpcsFile->findNext( Tokens::$stringTokens, $curStackPtr + 1, $end_of_statement + 1 ) !== false ) {
-			$curStackPtr = $this->phpcsFile->findNext( Tokens::$stringTokens, $curStackPtr + 1, $end_of_statement + 1 );
+
+		do {
+			$curStackPtr = $this->phpcsFile->findNext( Tokens::$stringTokens, $curStackPtr + 1, $end_of_statement + 1);
+			if ( $curStackPtr === false ) {
+				return;
+			}
 
 			$stringWithoutEnclosingQuotationMarks = trim( $this->tokens[ $curStackPtr ]['content'], "\"'" );
 
@@ -94,7 +98,7 @@ class IncludingNonPHPFileSniff extends Sniff {
 			}
 
 			$this->phpcsFile->addError( $message, $curStackPtr, $code, $data );
-		}
+		} while ( $curStackPtr <= $end_of_statement );
 	}
 
 }

--- a/WordPressVIPMinimum/Sniffs/Files/IncludingNonPHPFileSniff.php
+++ b/WordPressVIPMinimum/Sniffs/Files/IncludingNonPHPFileSniff.php
@@ -11,10 +11,9 @@ use WordPressVIPMinimum\Sniffs\Sniff;
 use PHP_CodeSniffer\Util\Tokens;
 
 /**
- * WordPressVIPMinimum_Sniffs_Files_IncludingNonPHPFileSniff.
+ * Ensure that non-PHP files are included via `file_get_contents()` instead of using `include/require[_once]`.
  *
- * Checks that __DIR__, dirname( __FILE__ ) or plugin_dir_path( __FILE__ )
- * is used when including or requiring files.
+ * This prevents potential PHP code embedded in those files from being automatically executed.
  *
  * @package VIPCS\WordPressVIPMinimum
  */
@@ -51,7 +50,6 @@ class IncludingNonPHPFileSniff extends Sniff {
 	public function register() {
 		return Tokens::$includeTokens;
 	}
-
 
 	/**
 	 * Processes this test, when one of its tokens is encountered.

--- a/WordPressVIPMinimum/Sniffs/Files/IncludingNonPHPFileSniff.php
+++ b/WordPressVIPMinimum/Sniffs/Files/IncludingNonPHPFileSniff.php
@@ -82,13 +82,16 @@ class IncludingNonPHPFileSniff extends Sniff {
 				return;
 			}
 
-			$message = 'Local non-PHP file should be loaded via `file_get_contents` rather than via `%s`.';
-			$data    = [ $this->tokens[ $stackPtr ]['content'] ];
+			$message = 'Local non-PHP file should be loaded via `file_get_contents` rather than via `%s`. Found: %s';
+			$data    = [
+				strtolower( $this->tokens[ $stackPtr ]['content'] ),
+				$this->tokens[ $curStackPtr ]['content'],
+			];
 			$code    = 'IncludingNonPHPFile';
 
 			if ( isset( $this->svg_css_extensions[ $extension ] ) === true ) {
 				// Be more specific for SVG and CSS files.
-				$message = 'Local SVG and CSS files should be loaded via `file_get_contents` rather than via `%s`.';
+				$message = 'Local SVG and CSS files should be loaded via `file_get_contents` rather than via `%s`. Found: %s';
 				$code    = 'IncludingSVGCSSFile';
 			}
 

--- a/WordPressVIPMinimum/Sniffs/Files/IncludingNonPHPFileSniff.php
+++ b/WordPressVIPMinimum/Sniffs/Files/IncludingNonPHPFileSniff.php
@@ -62,11 +62,11 @@ class IncludingNonPHPFileSniff extends Sniff {
 	 * @return void
 	 */
 	public function process_token( $stackPtr ) {
-		$curStackPtr      = $stackPtr;
 		$end_of_statement = $this->phpcsFile->findEndOfStatement( $stackPtr );
+		$curStackPtr      = ( $end_of_statement + 1 );
 
 		do {
-			$curStackPtr = $this->phpcsFile->findNext( Tokens::$stringTokens, $curStackPtr + 1, $end_of_statement + 1);
+			$curStackPtr = $this->phpcsFile->findPrevious( Tokens::$stringTokens, $curStackPtr - 1, $stackPtr );
 			if ( $curStackPtr === false ) {
 				return;
 			}
@@ -98,7 +98,7 @@ class IncludingNonPHPFileSniff extends Sniff {
 			}
 
 			$this->phpcsFile->addError( $message, $curStackPtr, $code, $data );
-		} while ( $curStackPtr <= $end_of_statement );
+		} while ( $curStackPtr > $stackPtr );
 	}
 
 }

--- a/WordPressVIPMinimum/Tests/Files/IncludingNonPHPFileUnitTest.inc
+++ b/WordPressVIPMinimum/Tests/Files/IncludingNonPHPFileUnitTest.inc
@@ -55,3 +55,9 @@ echo file_get_contents( 'index-loop.css' ); // XSS OK.
 include_once 'path/to/geoip.phar'; // OK.
 
 require dirname(__DIR__) . '/externals/aws-sdk.phar'; // OK.
+
+require "$path/$file.inc"; // OK.
+
+require "$path/$file.css"; // NOK.
+
+include_once $path . '/' . "$file.js"; // NOK.

--- a/WordPressVIPMinimum/Tests/Files/IncludingNonPHPFileUnitTest.inc
+++ b/WordPressVIPMinimum/Tests/Files/IncludingNonPHPFileUnitTest.inc
@@ -76,6 +76,10 @@ include_once '/src.php' . DIRECTORY_SEPARATOR . $subdir . '/filename.css'; // NO
 
 include_once '/src.csv' . DIRECTORY_SEPARATOR . $subdir . '/filename.png'; // NOK.
 
+include 'http://www.example.com/file.php?foo=1&bar=2'; // OK - this sniff is not about remote includes.
+
+require __DIR__ . '/' . $subdir . '/' . $filename . '.' . $extension; // OK - undetermined.
+
 // Live coding.
 // Intentional parse error. This has to be the last test in the file.
 include $path . 'filename.css

--- a/WordPressVIPMinimum/Tests/Files/IncludingNonPHPFileUnitTest.inc
+++ b/WordPressVIPMinimum/Tests/Files/IncludingNonPHPFileUnitTest.inc
@@ -71,6 +71,9 @@ if ((include 'vars.svg') && $imported_var === 'foo') {} // NOK.
 require ( dirname(__FILE__) . '/path' ) . 'concatafterparentheses.php'; // OK.
 require ( dirname(__FILE__) . '/path' ) . 'concatafterparentheses.py'; // NOK.
 
+include_once '/src.css' . DIRECTORY_SEPARATOR . $subdir . '/filename.php'; // OK.
+include_once '/src.php' . DIRECTORY_SEPARATOR . $subdir . '/filename.css'; // NOK.
+
 // Live coding.
 // Intentional parse error. This has to be the last test in the file.
 include $path . 'filename.css

--- a/WordPressVIPMinimum/Tests/Files/IncludingNonPHPFileUnitTest.inc
+++ b/WordPressVIPMinimum/Tests/Files/IncludingNonPHPFileUnitTest.inc
@@ -60,4 +60,17 @@ require "$path/$file.inc"; // OK.
 
 require "$path/$file.css"; // NOK.
 
-include_once $path . '/' . "$file.js"; // NOK.
+include_once $path . '/' . "$file.js" ?><!-- NOK. -->
+<?php
+echo 'some .css'; // OK.
+
+if ((include 'vars.php') == TRUE) {} // OK.
+
+if ((include 'vars.svg') && $imported_var === 'foo') {} // NOK.
+
+require ( dirname(__FILE__) . '/path' ) . 'concatafterparentheses.php'; // OK.
+require ( dirname(__FILE__) . '/path' ) . 'concatafterparentheses.py'; // NOK.
+
+// Live coding.
+// Intentional parse error. This has to be the last test in the file.
+include $path . 'filename.css

--- a/WordPressVIPMinimum/Tests/Files/IncludingNonPHPFileUnitTest.inc
+++ b/WordPressVIPMinimum/Tests/Files/IncludingNonPHPFileUnitTest.inc
@@ -74,6 +74,8 @@ require ( dirname(__FILE__) . '/path' ) . 'concatafterparentheses.py'; // NOK.
 include_once '/src.css' . DIRECTORY_SEPARATOR . $subdir . '/filename.php'; // OK.
 include_once '/src.php' . DIRECTORY_SEPARATOR . $subdir . '/filename.css'; // NOK.
 
+include_once '/src.csv' . DIRECTORY_SEPARATOR . $subdir . '/filename.png'; // NOK.
+
 // Live coding.
 // Intentional parse error. This has to be the last test in the file.
 include $path . 'filename.css

--- a/WordPressVIPMinimum/Tests/Files/IncludingNonPHPFileUnitTest.inc
+++ b/WordPressVIPMinimum/Tests/Files/IncludingNonPHPFileUnitTest.inc
@@ -2,25 +2,25 @@
 
 require_once __DIR__ . "/my_file.php"; // OK.
 
-require_once "my_file.php"; // OK.
+require "my_file.php"; // OK.
 
-include( __DIR__ . "/my_file.php" ); // OK.
+include_once( __DIR__ . "/my_file.php" ); // OK.
 
 include ( MY_CONSTANT . "my_file.php" ); // OK.
 
 require_once ( MY_CONSTANT . "my_file.php" ); // OK.
 
-include( locate_template('index-loop.php') ); // OK.
+Include( locate_template('index-loop.php') ); // OK.
 
 require_once __DIR__ . "/my_file.svg"; // NOK.
 
-require_once "my_file.svg"; // NOK.
+Require_Once "my_file.svg"; // NOK.
 
 include( __DIR__ . "/my_file.svg" ); // NOK.
 
 include ( MY_CONSTANT . "my_file.svg" ); // NOK.
 
-require_once ( MY_CONSTANT . "my_file.svg" ); // NOK.
+require ( MY_CONSTANT . "my_file.svg" ); // NOK.
 
 include( locate_template('index-loop.svg') ); // NOK.
 
@@ -28,7 +28,7 @@ require_once __DIR__ . "/my_file.css"; // NOK.
 
 require_once "my_file.css"; // NOK.
 
-include( __DIR__ . "/my_file.css" ); // NOK.
+include_once( __DIR__ . "/my_file.css" ); // NOK.
 
 include ( MY_CONSTANT . "my_file.css" ); // NOK.
 
@@ -36,7 +36,7 @@ require_once ( MY_CONSTANT . "my_file.css" ); // NOK.
 
 include( locate_template('index-loop.css') ); // NOK.
 
-require_once __DIR__ . "/my_file.csv"; // NOK.
+REQUIRE_ONCE __DIR__ . "/my_file.csv"; // NOK.
 
 require_once "my_file.inc"; // OK.
 

--- a/WordPressVIPMinimum/Tests/Files/IncludingNonPHPFileUnitTest.inc
+++ b/WordPressVIPMinimum/Tests/Files/IncludingNonPHPFileUnitTest.inc
@@ -51,3 +51,7 @@ include( locate_template('index-loop.csv') ); // NOK.
 echo file_get_contents( 'index-loop.svg' ); // XSS OK.
 
 echo file_get_contents( 'index-loop.css' ); // XSS OK.
+
+include_once 'path/to/geoip.phar'; // OK.
+
+require dirname(__DIR__) . '/externals/aws-sdk.phar'; // OK.

--- a/WordPressVIPMinimum/Tests/Files/IncludingNonPHPFileUnitTest.inc
+++ b/WordPressVIPMinimum/Tests/Files/IncludingNonPHPFileUnitTest.inc
@@ -6,13 +6,13 @@ require "my_file.php"; // OK.
 
 include_once( __DIR__ . "/my_file.php" ); // OK.
 
-include ( MY_CONSTANT . "my_file.php" ); // OK.
+include ( MY_CONSTANT . "my_file.INC" ); // OK.
 
 require_once ( MY_CONSTANT . "my_file.php" ); // OK.
 
-Include( locate_template('index-loop.php') ); // OK.
+Include( locate_template('index-loop.PHP') ); // OK.
 
-require_once __DIR__ . "/my_file.svg"; // NOK.
+require_once __DIR__ . "/my_file.SVG"; // NOK.
 
 Require_Once "my_file.svg"; // NOK.
 
@@ -24,7 +24,7 @@ require ( MY_CONSTANT . "my_file.svg" ); // NOK.
 
 include( locate_template('index-loop.svg') ); // NOK.
 
-require_once __DIR__ . "/my_file.css"; // NOK.
+require_once __DIR__ . "/my_file.CSS"; // NOK.
 
 require_once "my_file.css"; // NOK.
 
@@ -34,13 +34,13 @@ include ( MY_CONSTANT . "my_file.css" ); // NOK.
 
 require_once ( MY_CONSTANT . "my_file.css" ); // NOK.
 
-include( locate_template('index-loop.css') ); // NOK.
+include( locate_template('index-loop.Css') ); // NOK.
 
 REQUIRE_ONCE __DIR__ . "/my_file.csv"; // NOK.
 
 require_once "my_file.inc"; // OK.
 
-include( __DIR__ . "/my_file.csv" ); // NOK.
+include( __DIR__ . "/my_file.CSV" ); // NOK.
 
 include ( MY_CONSTANT . "my_file.csv" ); // NOK.
 

--- a/WordPressVIPMinimum/Tests/Files/IncludingNonPHPFileUnitTest.php
+++ b/WordPressVIPMinimum/Tests/Files/IncludingNonPHPFileUnitTest.php
@@ -41,6 +41,8 @@ class IncludingNonPHPFileUnitTest extends AbstractSniffUnitTest {
 			45 => 1,
 			47 => 1,
 			49 => 1,
+			61 => 1,
+			63 => 1,
 		];
 	}
 

--- a/WordPressVIPMinimum/Tests/Files/IncludingNonPHPFileUnitTest.php
+++ b/WordPressVIPMinimum/Tests/Files/IncludingNonPHPFileUnitTest.php
@@ -45,6 +45,7 @@ class IncludingNonPHPFileUnitTest extends AbstractSniffUnitTest {
 			63 => 1,
 			69 => 1,
 			72 => 1,
+			75 => 1,
 		];
 	}
 

--- a/WordPressVIPMinimum/Tests/Files/IncludingNonPHPFileUnitTest.php
+++ b/WordPressVIPMinimum/Tests/Files/IncludingNonPHPFileUnitTest.php
@@ -46,6 +46,7 @@ class IncludingNonPHPFileUnitTest extends AbstractSniffUnitTest {
 			69 => 1,
 			72 => 1,
 			75 => 1,
+			77 => 1,
 		];
 	}
 

--- a/WordPressVIPMinimum/Tests/Files/IncludingNonPHPFileUnitTest.php
+++ b/WordPressVIPMinimum/Tests/Files/IncludingNonPHPFileUnitTest.php
@@ -43,6 +43,8 @@ class IncludingNonPHPFileUnitTest extends AbstractSniffUnitTest {
 			49 => 1,
 			61 => 1,
 			63 => 1,
+			69 => 1,
+			72 => 1,
 		];
 	}
 

--- a/WordPressVIPMinimum/Tests/Files/IncludingNonPHPFileUnitTest.php
+++ b/WordPressVIPMinimum/Tests/Files/IncludingNonPHPFileUnitTest.php
@@ -8,8 +8,9 @@
 namespace WordPressVIPMinimum\Tests\Files;
 
 use PHP_CodeSniffer\Tests\Standards\AbstractSniffUnitTest;
+
 /**
- * Unit test class for the IncludingFile sniff.
+ * Unit test class for the IncludingNonPHPFile sniff.
  *
  * @package VIPCS\WordPressVIPMinimum
  *


### PR DESCRIPTION
This PR is the result of a full review of the `WordPressVIPMinimum.Files.IncludingNonPHPFile` sniff.

It will be easiest to understand the different changes and their impact by reviewing this PR on the individual commits.

Fixes #515

## Commit Details

### Files/IncludingNonPHPFile: minor efficiency fix [1]

* Move the extensions against which checks are being run to private properties.
* Removes the `.` from the part in the regex which is being remembered.
    Note: The `.` before the extension is still required, it is just no longer _remembered_.
* Changes the extension checks from using the relatively expensive `in_array()` to the lightweight `isset()`.

### Files/IncludingNonPHPFile: minor efficiency fix [2]

The regex will work just the same without the `.*`.

### Files/IncludingNonPHPFile: improve the existing unit tests

* The existing unit tests only tested against `require_once` and `include`, while the sniff looks for all variations.
    The newly added unit tests make sure that all four variations have at least one positive/negative test associated with it.
* Add some capitalization variations to the `include|require[_once]` keywords.

### Files/IncludingNonPHPFile: improve the error message

* Make sure the `include|require[_once]` keyword is always referred to in lower case in the error message.
* Make the error message more informative by displaying the text snippet which triggered the error.

### Files/IncludingNonPHPFile: bug fix [1] - case sensitivity of file extension

The regex used to retrieve an extension, would retrieve it case-insensitively, but the previous `in_array()` check (now `isset()`), checked the extension in a case-sensitive manner.

Whether the file extension is used in upper, lower or mixed case, does not matter to the `include` as long as a matching file is found, so the sniff should check the extension in a case insensitive manner.

As things were, a file name like `file.PHP` would trigger a false positive for the `IncludingNonPHPFile` error and a file called `file.Css` would incorrectly throw the `IncludingNonPHPFile` error instead of the `IncludingSVGCSSFile` error which it should have thrown.

Fixed now.

Tested by adjusting some of the existing unit tests.

### Files/IncludingNonPHPFile: bug fix [2] - allow for "phar" file extension

PHAR (PHP Archive) files should be regarded as PHP files for the purposes of this sniff.

Includes unit tests.

Fixes #478

### Files/IncludingNonPHPFile: bug fix [3] - extensions in interpolated strings

The sniff looks for `Tokens::$stringTokens` when examining the statement.

The `Tokens::$stringTokens` array contains two tokens:
1. `T_CONSTANT_ENCAPSED_STRING` - these are either single or double quoted text strings without variables within them.
2. `T_DOUBLE_QUOTED_STRING` - these are double quoted text strings with interpolated variables in the text string.

As things were, the quotes would be stripped off the first, but not off the contents of `T_DOUBLE_QUOTED_STRING`-type tokens.

As the regex matches extensions at the very end of the text string and doesn't allow for a double quote at the end, this effectively meant that text in double quoted strings would never be recognized as containing a non-PHP extension. (= false negative)

Includes unit tests.

### Files/IncludingNonPHPFile: bug fix [4] - fix bleed through /end of statement

An `include`/`require` statement can be used within template files to include another template.
In that case, the statement can be ended by a PHP close tag without there ever being a semi-colon.

Even though the `findNext()` function call indicated that it only wants to look "locally", the `findNext()` method itself does not take a PHP close tag into account when determining whether the statement has ended. This could be considered a bug upstream, but that's another matter.

In practice, this meant that when an `include|require[_once]` statement ended on a PHP close tag, the `findNext()` would continue looking for text string tokens and could report an error on a text string which is unrelated to the `include|require[_once]` statement. (= false positive).

Determining the end of the statement properly before calling `findNext()` fixes this, however, the `findEndOfStatement()` method will return the last non-whitespace token in a statement, which for statements nested in brackets can be a token which is _part_ of the statement.

As the `findNext()` method does not look at the `$end` token, we need to `+1` the result of `findEndOfStatement()` to make sure the whole statement is considered.

Includes unit tests.

### Files/IncludingNonPHPFile: efficiency fix [3]

To prevent an assignment in condition, the same function call was executed twice.

By changing the code around slightly and using a `do - while` loop instead of a `while`, the duplicate function call can be removed.

### Files/IncludingNonPHPFile: efficiency fix [4]/bug fix [5] - extension at end of statement

An `include|require[_once]` statement can only include one (1) file and the file extension of that file will normally be at the _end_ of the statement.

So far, the sniff would walk from the start of the statement to the end, while walking from the end of the statement to the start, will get us a result more quickly and more accurately.

Includes unit tests. The first would be a false negative, the second a false positive without this fix.

### Files/IncludingNonPHPFile: efficiency fix [5]/bug fix [6] - one error per statement

An `include|require[_once]` statement can only include one (1) file, so there should only ever be one file extension in the statement and by extension, only ever be one error for any particular `include|require[_once]` statement.

Once a file extension has been found which generates an error, we can therefore stop sniffing that statement.
This is similar to the sniff breaking off checking the statement once a text string with `.php` as a file extension is found, as was already done.

Includes unit tests.

### Files/IncludingNonPHPFile: add some additional unit tests

... to document the behaviour of the sniff for certain situations.

### Files/IncludingNonPHPFile: remove unused `use` statement

### Files/IncludingNonPHPFile: minor simplification

`preg_match()` will return `false` for an invalid regex, `0` for "no match" and `1` for a match as it only looks for one match - in contrast to `preg_match_all()`-.

As the regex uses an "end of text string" anchor, using `preg_match()` is the right function, but that also means we can simplify the return value check a little.

### Files/IncludingNonPHPFile: fix class docblocks

The existing text was unrelated to the actual sniff. Probably legacy copy/paste.

 