### PR TITLE
WPQueryParams: sniff for `exclude` array key being set

### DIFF
--- a/WordPressVIPMinimum/Tests/Performance/WPQueryParamsUnitTest.inc
+++ b/WordPressVIPMinimum/Tests/Performance/WPQueryParamsUnitTest.inc
@@ -17,3 +17,7 @@ $q = new WP_Query( $query_args );
 $query_args[ 'suppress_filters' ] = true;
 
 $q = new WP_query( $query_args );
+
+get_posts( [ 'exclude' => $post_ids ] ); // Warning.
+
+$exclude = [ 1, 2, 3 ];

--- a/WordPressVIPMinimum/Tests/Performance/WPQueryParamsUnitTest.php
+++ b/WordPressVIPMinimum/Tests/Performance/WPQueryParamsUnitTest.php
@@ -39,6 +39,7 @@ class WPQueryParamsUnitTest extends AbstractSniffUnitTest {
 		return [
 			4  => 1,
 			11 => 1,
+			21 => 1,
 		];
 	}
 


### PR DESCRIPTION
Note: I've split this change into two commits to allow for moving the second commit to the 3.0.0 release if so desired.

---

### WPQueryParams: sniff for `exclude` array key being set

This:
* Switches the `WordPressVIPMinimum.Performance.WPQueryParams` sniff over to use the WordPressCS `AbstractArrayAssignmentRestrictionsSniff` as the parent sniff.
* Adds sniffing for the `exclude` array key via the `AbstractArrayAssignmentRestrictionsSniff` sniff logic.

Includes unit test.

Fixes #369

### WPQueryParams: defer to the parent sniff

This changes over the existing keys being sniffed for by this sniff to use the logic from the new `AbstractArrayAssignmentRestrictionsSniff` parent instead of custom logic.

Note: this is a BC-break as the error codes for the existing checks change!
* `WordPressVIPMinimum.Performance.WPQueryParams.PostNotIn` is now `WordPressVIPMinimum.Performance.WPQueryParams.PostNotIn_post__not_in`
* `WordPressVIPMinimum.Performance.WPQueryParams.SuppressFiltersTrue` is now `WordPressVIPMinimum.Performance.WPQueryParams.SuppressFilters_suppress_filters`