### PR TITLE
Functions/DynamicCalls: various bug fixes and improvements

### DIFF
--- a/WordPressVIPMinimum/Sniffs/Functions/DynamicCallsSniff.php
+++ b/WordPressVIPMinimum/Sniffs/Functions/DynamicCallsSniff.php
@@ -7,6 +7,7 @@
 
 namespace WordPressVIPMinimum\Sniffs\Functions;
 
+use PHP_CodeSniffer\Util\Tokens;
 use WordPressVIPMinimum\Sniffs\Sniff;
 
 /**
@@ -98,7 +99,7 @@ class DynamicCallsSniff extends Sniff {
 		 * and checking if the first one is T_EQUAL.
 		 */
 		$t_item_key = $this->phpcsFile->findNext(
-			[ T_WHITESPACE ],
+			Tokens::$emptyTokens,
 			$this->stackPtr + 1,
 			null,
 			true,

--- a/WordPressVIPMinimum/Sniffs/Functions/DynamicCallsSniff.php
+++ b/WordPressVIPMinimum/Sniffs/Functions/DynamicCallsSniff.php
@@ -94,17 +94,6 @@ class DynamicCallsSniff extends Sniff {
 	 * @return void
 	 */
 	private function collect_variables() {
-		/*
-		 * Make sure we are working with a variable,
-		 * get its value if so.
-		 */
-
-		if (
-			$this->tokens[ $this->stackPtr ]['type'] !==
-				'T_VARIABLE'
-		) {
-			return;
-		}
 
 		$current_var_name = $this->tokens[ $this->stackPtr ]['content'];
 
@@ -178,17 +167,6 @@ class DynamicCallsSniff extends Sniff {
 		 */
 
 		if ( empty( $this->variables_arr ) ) {
-			return;
-		}
-
-		/*
-		 * Make sure we do have a variable to work with.
-		 */
-
-		if (
-			$this->tokens[ $this->stackPtr ]['type'] !==
-				'T_VARIABLE'
-		) {
 			return;
 		}
 

--- a/WordPressVIPMinimum/Sniffs/Functions/DynamicCallsSniff.php
+++ b/WordPressVIPMinimum/Sniffs/Functions/DynamicCallsSniff.php
@@ -181,7 +181,7 @@ class DynamicCallsSniff extends Sniff {
 			return;
 		}
 
-		$message = 'Dynamic calling is not recommended in the case of %s.';
+		$message = 'Dynamic calling is not recommended in the case of %s().';
 		$data    = [ $this->variables_arr[ $this->tokens[ $this->stackPtr ]['content'] ] ];
 		$this->phpcsFile->addError( $message, $this->stackPtr, 'DynamicCalls', $data );
 	}

--- a/WordPressVIPMinimum/Sniffs/Functions/DynamicCallsSniff.php
+++ b/WordPressVIPMinimum/Sniffs/Functions/DynamicCallsSniff.php
@@ -174,23 +174,15 @@ class DynamicCallsSniff extends Sniff {
 		}
 
 		/*
-		 * Check if we have an '(' next, or separated by whitespaces from our current position.
+		 * Check if we have an '(' next.
 		 */
-
-		$i = 0;
-
-		do {
-			$i++;
-		} while ( $this->tokens[ $this->stackPtr + $i ]['type'] === 'T_WHITESPACE' );
-
-		if ( $this->tokens[ $this->stackPtr + $i ]['type'] !== 'T_OPEN_PARENTHESIS' ) {
+		$next = $this->phpcsFile->findNext( Tokens::$emptyTokens, ( $this->stackPtr + 1 ), null, true );
+		if ( $next === false || $this->tokens[ $next ]['code'] !== T_OPEN_PARENTHESIS ) {
 			return;
 		}
 
-		$t_item_key = $this->stackPtr + $i;
-
 		$message = 'Dynamic calling is not recommended in the case of %s.';
 		$data    = [ $this->variables_arr[ $this->tokens[ $this->stackPtr ]['content'] ] ];
-		$this->phpcsFile->addError( $message, $t_item_key, 'DynamicCalls', $data );
+		$this->phpcsFile->addError( $message, $this->stackPtr, 'DynamicCalls', $data );
 	}
 }

--- a/WordPressVIPMinimum/Sniffs/Functions/DynamicCallsSniff.php
+++ b/WordPressVIPMinimum/Sniffs/Functions/DynamicCallsSniff.php
@@ -120,10 +120,6 @@ class DynamicCallsSniff extends Sniff {
 			return;
 		}
 
-		if ( $this->tokens[ $t_item_key ]['length'] !== 1 ) {
-			return;
-		}
-
 		/*
 		 * Find encapsulated string ( "" )
 		 */

--- a/WordPressVIPMinimum/Sniffs/Functions/DynamicCallsSniff.php
+++ b/WordPressVIPMinimum/Sniffs/Functions/DynamicCallsSniff.php
@@ -106,11 +106,7 @@ class DynamicCallsSniff extends Sniff {
 			true
 		);
 
-		if ( $t_item_key === false ) {
-			return;
-		}
-
-		if ( $this->tokens[ $t_item_key ]['type'] !== 'T_EQUAL' ) {
+		if ( $t_item_key === false || $this->tokens[ $t_item_key ]['code'] !== T_EQUAL ) {
 			return;
 		}
 

--- a/WordPressVIPMinimum/Sniffs/Functions/DynamicCallsSniff.php
+++ b/WordPressVIPMinimum/Sniffs/Functions/DynamicCallsSniff.php
@@ -141,9 +141,9 @@ class DynamicCallsSniff extends Sniff {
 		 *
 		 * Register its name and value in the internal array for later usage.
 		 */
-		$current_var_value = $this->tokens[ $value_ptr ]['content'];
+		$current_var_value = $this->strip_quotes( $this->tokens[ $value_ptr ]['content'] );
 
-		$this->variables_arr[ $current_var_name ] = str_replace( "'", '', $current_var_value );
+		$this->variables_arr[ $current_var_name ] = $current_var_value;
 	}
 
 	/**

--- a/WordPressVIPMinimum/Sniffs/Functions/DynamicCallsSniff.php
+++ b/WordPressVIPMinimum/Sniffs/Functions/DynamicCallsSniff.php
@@ -30,7 +30,7 @@ class DynamicCallsSniff extends Sniff {
 	 *
 	 * @var array
 	 */
-	private $blacklisted_functions = [
+	private $function_names = [
 		'assert'           => true,
 		'compact'          => true,
 		'extract'          => true,
@@ -141,7 +141,7 @@ class DynamicCallsSniff extends Sniff {
 		 */
 		$current_var_value = $this->strip_quotes( $this->tokens[ $value_ptr ]['content'] );
 
-		if ( isset( $this->blacklisted_functions[ $current_var_value ] ) === false ) {
+		if ( isset( $this->function_names[ $current_var_value ] ) === false ) {
 			// Text string is not one of the ones we're looking for.
 			return;
 		}

--- a/WordPressVIPMinimum/Tests/Functions/DynamicCallsUnitTest.inc
+++ b/WordPressVIPMinimum/Tests/Functions/DynamicCallsUnitTest.inc
@@ -30,3 +30,6 @@ $test_getting_the_actual_value_4 = 'get_defined_vars' . $source;
 $test_getting_the_actual_value_4(); // OK. Unclear what the actual variable value will be.
 
 $ensure_no_notices_are_thrown_on_parse_error = /*comment*/ ;
+
+$test_double_quoted_string = "assert";
+$test_double_quoted_string(); // Bad.

--- a/WordPressVIPMinimum/Tests/Functions/DynamicCallsUnitTest.inc
+++ b/WordPressVIPMinimum/Tests/Functions/DynamicCallsUnitTest.inc
@@ -6,10 +6,10 @@ function my_test() {
 
 
 $my_notokay_func = 'extract';
-$my_notokay_func();
+$my_notokay_func(); // Bad.
 
 $my_okay_func = 'my_test';
-$my_okay_func();
+$my_okay_func(); // OK.
 
 
 

--- a/WordPressVIPMinimum/Tests/Functions/DynamicCallsUnitTest.inc
+++ b/WordPressVIPMinimum/Tests/Functions/DynamicCallsUnitTest.inc
@@ -12,7 +12,7 @@ $my_okay_func = 'my_test';
 $my_okay_func(); // OK.
 
 $test_with_comment /*comment*/ = 'func_get_args';
-$test_with_comment(); // Bad.
+$test_with_comment /*comment*/ (); // Bad.
 
 $test_getting_the_actual_value_1 = function_call( 'extract' );
 $test_getting_the_actual_value_1(); // OK. Unclear what the actual variable value will be.
@@ -33,3 +33,6 @@ $ensure_no_notices_are_thrown_on_parse_error = /*comment*/ ;
 
 $test_double_quoted_string = "assert";
 $test_double_quoted_string(); // Bad.
+
+// Intentional parse error. This has to be the last test in the file.
+$my_notokay_func

--- a/WordPressVIPMinimum/Tests/Functions/DynamicCallsUnitTest.inc
+++ b/WordPressVIPMinimum/Tests/Functions/DynamicCallsUnitTest.inc
@@ -11,5 +11,5 @@ $my_notokay_func(); // Bad.
 $my_okay_func = 'my_test';
 $my_okay_func(); // OK.
 
-
-
+$test_with_comment /*comment*/ = 'func_get_args';
+$test_with_comment(); // Bad.

--- a/WordPressVIPMinimum/Tests/Functions/DynamicCallsUnitTest.inc
+++ b/WordPressVIPMinimum/Tests/Functions/DynamicCallsUnitTest.inc
@@ -13,3 +13,20 @@ $my_okay_func(); // OK.
 
 $test_with_comment /*comment*/ = 'func_get_args';
 $test_with_comment(); // Bad.
+
+$test_getting_the_actual_value_1 = function_call( 'extract' );
+$test_getting_the_actual_value_1(); // OK. Unclear what the actual variable value will be.
+
+$test_getting_the_actual_value_2 = $array['compact'];
+$test_getting_the_actual_value_2(); // OK. Unclear what the actual variable value will be.
+
+$test_getting_the_actual_value_3 = 10 ?>
+<div>html</div>
+<?php
+echo 'extract';
+$test_getting_the_actual_value_3(); // OK. Broken function call, but not calling extract().
+
+$test_getting_the_actual_value_4 = 'get_defined_vars' . $source;
+$test_getting_the_actual_value_4(); // OK. Unclear what the actual variable value will be.
+
+$ensure_no_notices_are_thrown_on_parse_error = /*comment*/ ;

--- a/WordPressVIPMinimum/Tests/Functions/DynamicCallsUnitTest.php
+++ b/WordPressVIPMinimum/Tests/Functions/DynamicCallsUnitTest.php
@@ -27,6 +27,7 @@ class DynamicCallsUnitTest extends AbstractSniffUnitTest {
 		return [
 			9  => 1,
 			15 => 1,
+			35 => 1,
 		];
 	}
 

--- a/WordPressVIPMinimum/Tests/Functions/DynamicCallsUnitTest.php
+++ b/WordPressVIPMinimum/Tests/Functions/DynamicCallsUnitTest.php
@@ -25,7 +25,8 @@ class DynamicCallsUnitTest extends AbstractSniffUnitTest {
 	 */
 	public function getErrorList() {
 		return [
-			9 => 1,
+			9  => 1,
+			15 => 1,
 		];
 	}
 


### PR DESCRIPTION
This PR is the result of a review of the `WordPressVIPMinimum.Functions.DynamicCalls` sniff.

It will be easiest to understand the different changes and their impact by reviewing this PR on the individual commits.

---

### Functions/DynamicCalls: annotate the unit tests

... to show which ones should fail and which should pass.

### Functions/DynamicCalls: remove redundant conditions [1]

This sniff only listens to `T_VARIABLE` tokens, so checking that what was received is a `T_VARIABLE` is redundant.

### Functions/DynamicCalls: remove redundant conditions [2]

The condition above checks if a token is `T_EQUAL` and bows out if it is not.
The only code matching on `T_EQUAL` is the `=` operator, which will always have a `length` of `1`.

### Functions/DynamicCalls: improve code readability

* Cutting code lines off at 50 chars is maybe taking it a little too far, especially as it makes assignments hard to read.
* Use proper tags in docblocks.
* Improve (fix) documentation (and move it to the right place).

### Functions/DynamicCalls: minor simplification

Join two conditions which both return anyway.

### Functions/DynamicCalls: bug fix - ignore comments [1]

Skip over both whitespace, as well as comments. This reduces false negatives.

Includes unit test.

### Functions/DynamicCalls: bug fix - don't blindly use the next text string

A variable value may be build up of multiple tokens.

As it was, the sniff would look for the first text string token after the equal sign within the variable assignment statement, but this disregards that:
1. The text string token found may not be the only token in the statement.
2. A statement can end on a PHP close tag (possibly a bug in PHPCS itself, but that's another matter), which would lead the sniff to look at the next statement for text strings.

Fixed now.

Includes unit tests, the first four of which resulted in false positives previously.

### Functions/DynamicCalls: bug fix - allow for double quotes

Text strings can use both single quotes as well as double quotes.

When the text string contains an interpolated variable, it will be tokenized as `T_DOUBLE_QUOTED_STRING`, but when it is a plain text string, a double quoted text string will be tokenized as `T_CONSTANT_ENCAPSED_STRING`, same as single quoted text string.

The sniff did not take this into account, leading to false negatives.

The sniff also would strip quotes from within a text - `'my\'text'` - . This did not cause a problem for this sniff as function names cannot have back slashes in them, but it was still wrong.

Fixed now by using the WPCS `strip_quotes()` method.

Includes unit test which would fail previously.

### Functions/DynamicCalls: bug fix - fix memory + performance issue

The sniff maintains a cache of all the variables it has seen and their assigned value.

When a variable is encountered, it would:
* Check if it was an (plain text) assignment and if so, register the variable name + value to the cache.
* Next, call the `find_dynamic_calls()` method, which first checks if any variables have been registered to the cache before doing anything.
* And then checks for dynamic function calls and if one is found, checks if the variable used is one registered in the cache with a value we are looking for.

This is highly inefficient as text string variable assignments are common and, as it was, _every single one_ would be added to the cache.

With a large code base, that means that the cache could grow pretty large.

It also means that the logic to determine if something is a dynamic function call would be executed even when there would be no text strings registered in the cache which could match any of the ones we're looking for.

By changing the order of the logic, the memory leak and performance inefficiency is removed.

With the updated logic, the sniff will:
* Check if it was an (plain text) assignment **and if the text string matches one we're looking for** and if so, register the variable name + value to the cache.
* Next, call the `find_dynamic_calls()` method, which first checks if any variables have been registered to the cache before doing anything.
* And then checks for dynamic function calls.

This means that if none of the previous assignments encountered matches any of the target text strings (~ 99% of the time), this sniff will bow out at step 2 before executing the logic to check if a variable assignment is a dynamic function call.

### Functions/DynamicCalls: rename private property

Rename the `private` `$blacklisted_functions` property to `$function_names` to get rid of the use of a non-inclusive term.

Loosely related to #492

### Functions/DynamicCalls: bug fix - ignore comments [2]

Skip over both whitespace, as well as comments and take live coding into account. This reduces false negatives, as well as fixing issue #590.

Includes unit tests.

Fixes #590

### Functions/DynamicCalls: error message tweak