### PR TITLE
Security/Underscorejs: bug fixes and enhancements

### DIFF
--- a/WordPressVIPMinimum/Sniffs/Security/UnderscorejsSniff.php
+++ b/WordPressVIPMinimum/Sniffs/Security/UnderscorejsSniff.php
@@ -62,6 +62,16 @@ class UnderscorejsSniff extends Sniff {
 	 */
 	public function process_token( $stackPtr ) {
 		/*
+		 * Ignore Gruntfile.js files as they are configuration, not code.
+		 */
+		$file_name = $this->strip_quotes( $this->phpcsFile->getFileName() );
+		$file_name = strtolower( basename( $file_name ) );
+
+		if ( $file_name === 'gruntfile.js' ) {
+			return;
+		}
+
+		/*
 		 * Check for delimiter change in JS files.
 		 */
 		if ( $this->tokens[ $stackPtr ]['code'] === T_STRING

--- a/WordPressVIPMinimum/Sniffs/Security/UnderscorejsSniff.php
+++ b/WordPressVIPMinimum/Sniffs/Security/UnderscorejsSniff.php
@@ -8,6 +8,7 @@
 
 namespace WordPressVIPMinimum\Sniffs\Security;
 
+use PHP_CodeSniffer\Util\Tokens;
 use WordPressVIPMinimum\Sniffs\Sniff;
 
 /**
@@ -30,12 +31,10 @@ class UnderscorejsSniff extends Sniff {
 	 * @return array
 	 */
 	public function register() {
-		return [
-			T_CONSTANT_ENCAPSED_STRING,
-			T_PROPERTY,
-			T_INLINE_HTML,
-			T_HEREDOC,
-		];
+		$targets   = Tokens::$textStringTokens;
+		$targets[] = T_PROPERTY;
+
+		return $targets;
 	}
 
 	/**

--- a/WordPressVIPMinimum/Sniffs/Security/UnderscorejsSniff.php
+++ b/WordPressVIPMinimum/Sniffs/Security/UnderscorejsSniff.php
@@ -106,6 +106,10 @@ class UnderscorejsSniff extends Sniff {
 		$match_count = preg_match_all( self::UNESCAPED_INTERPOLATE_REGEX, $content, $matches );
 		if ( $match_count > 0 ) {
 			foreach ( $matches[0] as $match ) {
+				if ( strpos( $match, '_.escape(' ) !== false ) {
+					continue;
+				}
+
 				// Underscore.js unescaped output.
 				$message = 'Found Underscore.js unescaped output notation: "%s".';
 				$data    = [ $match ];

--- a/WordPressVIPMinimum/Sniffs/Security/UnderscorejsSniff.php
+++ b/WordPressVIPMinimum/Sniffs/Security/UnderscorejsSniff.php
@@ -27,6 +27,13 @@ class UnderscorejsSniff extends Sniff {
 	const UNESCAPED_INTERPOLATE_REGEX = '`<%=\s*(?:.+?%>|$)`';
 
 	/**
+	 * Regex to match the "interpolate" keyword when used to overrule the ERB-style delimiters.
+	 *
+	 * @var string
+	 */
+	const INTERPOLATE_KEYWORD_REGEX = '`(?:templateSettings\.interpolate|\.interpolate\s*=\s*/|interpolate\s*:\s*/)`';
+
+	/**
 	 * A list of tokenizers this sniff supports.
 	 *
 	 * @var string[]
@@ -107,7 +114,7 @@ class UnderscorejsSniff extends Sniff {
 		}
 
 		if ( $this->phpcsFile->tokenizerType !== 'JS'
-			&& strpos( $content, 'interpolate' ) !== false
+			&& preg_match( self::INTERPOLATE_KEYWORD_REGEX, $content ) > 0
 		) {
 			// Underscore.js delimiter change.
 			$message = 'Found Underscore.js delimiter change notation.';

--- a/WordPressVIPMinimum/Tests/Security/Gruntfile.js
+++ b/WordPressVIPMinimum/Tests/Security/Gruntfile.js
@@ -1,0 +1,100 @@
+
+module.exports = function(grunt) {
+
+	require('load-grunt-tasks')(grunt);
+
+	// Project configuration.
+	grunt.initConfig({
+		pkg: grunt.file.readJSON('package.json'),
+
+		checktextdomain: {
+			options:{
+				text_domain: '<%= pkg.name %>',
+				correct_domain: true,
+				keywords: [
+					'__:1,2d',
+					'_e:1,2d',
+					'_x:1,2c,3d',
+					'esc_html__:1,2d',
+					'esc_html_e:1,2d',
+					'esc_html_x:1,2c,3d',
+					'esc_attr__:1,2d',
+					'esc_attr_e:1,2d',
+					'esc_attr_x:1,2c,3d',
+					'_ex:1,2c,3d',
+					'_n:1,2,4d',
+					'_nx:1,2,4c,5d',
+					'_n_noop:1,2,3d',
+					'_nx_noop:1,2,3c,4d'
+				]
+			},
+			files: {
+				src:  [
+					'**/*.php',
+				],
+				expand: true
+			}
+		},
+
+		makepot: {
+			target: {
+				options: {
+					domainPath: '/languages/',    // Where to save the POT file.
+					mainFile: 'style.css',      // Main project file.
+					potFilename: '<%= pkg.name %>.pot',   // Name of the POT file.
+					type: 'wp-theme',  // Type of project (wp-plugin or wp-theme).
+					processPot: function( pot, options ) {
+						pot.headers['plural-forms'] = 'nplurals=2; plural=n != 1;';
+						pot.headers['x-poedit-basepath'] = '.\n';
+						pot.headers['x-poedit-language'] = 'English\n';
+						pot.headers['x-poedit-country'] = 'UNITED STATES\n';
+						pot.headers['x-poedit-sourcecharset'] = 'utf-8\n';
+						pot.headers['X-Poedit-KeywordsList'] = '__;_e;__ngettext:1,2;_n:1,2;__ngettext_noop:1,2;_n_noop:1,2;_c,_nc:4c,1,2;_x:1,2c;_ex:1,2c;_nx:4c,1,2;_nx_noop:4c,1,2;\n';
+						pot.headers['x-textdomain-support'] = 'yes\n';
+						return pot;
+					}
+				}
+			}
+		},
+
+		// Clean up build directory
+		clean: {
+			main: ['build/<%= pkg.name %>']
+		},
+
+		// Copy the theme into the build directory
+		copy: {
+			main: {
+				src:  [
+					'**',
+					'!build/**',
+					'!.git/**',
+					'!Gruntfile.js',
+					'!package.json',
+					'!.gitignore',
+					'!.gitmodules',
+				],
+				dest: 'build/<%= pkg.name %>/'
+			}
+		},
+
+		//Compress build directory into <name>.zip and <name>-<version>.zip
+		compress: {
+			main: {
+				options: {
+					mode: 'zip',
+					archive: './build/<%= pkg.name %>.zip'
+				},
+				expand: true,
+				cwd: 'build/<%= pkg.name %>/',
+				src: ['**/*'],
+				dest: '<%= pkg.name %>/'
+			}
+		}
+
+	});
+
+	// Default task(s).
+	grunt.registerTask( 'build', [ 'clean', 'copy', 'compress' ] );
+	grunt.registerTask( 'i18n', [ 'checktextdomain', 'makepot' ] );
+};

--- a/WordPressVIPMinimum/Tests/Security/UnderscorejsUnitTest.inc
+++ b/WordPressVIPMinimum/Tests/Security/UnderscorejsUnitTest.inc
@@ -73,3 +73,36 @@ function test_interpolate_match_precision() {
 	</script>
 	<?php
 }
+
+// Recognize escaping.
+function dont_trigger_when_escaped() {
+	$script = <<<EOD
+		var html = _.template('<li><%= _.escape(name) %></li>', { name: 'John Smith' }); // OK.
+		
+		var html = _.template(
+			"<pre>The \"<% __p+=_.escape(o.text) %>\" is the same<br />" + // OK.
+				"as the  \"<%= _.escape(o.text) %>\" and the same<br />" + // OK.
+				"as the \"<%- o.text %>\"</pre>", // OK.
+			{
+				text: "<b>some text</b> and \n it's a line break"
+			},
+			{
+				variable: "o"
+			}
+		);
+EOD;
+
+	echo $script;
+}
+
+function display_foo {
+?>
+	<script id="template" type="text/template">
+		<li class="dashboard-post-item" dashboard-id="<%= _.escape( id ) %>"><!-- OK -->
+			<div class="image-wrapper">
+				<img src="<%= _.escape( image_url ) %>" class="dashboard-image"><!-- OK -->
+			</div>
+		</li>
+	</script>
+<?php
+}

--- a/WordPressVIPMinimum/Tests/Security/UnderscorejsUnitTest.inc
+++ b/WordPressVIPMinimum/Tests/Security/UnderscorejsUnitTest.inc
@@ -47,3 +47,6 @@ $heredoc = <<<EOD
 		<%= name %>
 	</label><!-- NOK - 1 per line -->
 EOD;
+
+// Make sure the JS specific check does not trigger on PHP code.
+$obj->interpolate = true;

--- a/WordPressVIPMinimum/Tests/Security/UnderscorejsUnitTest.inc
+++ b/WordPressVIPMinimum/Tests/Security/UnderscorejsUnitTest.inc
@@ -106,3 +106,15 @@ function display_foo {
 	</script>
 <?php
 }
+
+function print_foo() {
+?>
+	<script id="template" type="text/template">
+		var compiled = _.template("<% print('Hello ' + _.escape(epithet)); %>"); /* OK */
+		var compiled = _.template("<% print('Hello ' + epithet); %>"); /* NOK */
+		var compiled = _.template("<% __p+=o.text %>"); /* NOK */
+
+		compiled({epithet: "stooge"});
+	</script>
+<?php
+}

--- a/WordPressVIPMinimum/Tests/Security/UnderscorejsUnitTest.inc
+++ b/WordPressVIPMinimum/Tests/Security/UnderscorejsUnitTest.inc
@@ -50,3 +50,26 @@ EOD;
 
 // Make sure the JS specific check does not trigger on PHP code.
 $obj->interpolate = true;
+
+// Test matching the "interpolate" keyword with higher precision (mirrors same check in JS).
+function test_interpolate_match_precision() {
+	?>
+	<script type="text/javascript">
+	_.templateSettings.interpolate = /\{\{(.+?)\}\}/g; /* NOK */
+
+	options.interpolate=_.templateSettings.interpolate; /* NOK */
+	var interpolate = options.interpolate || reNoMatch, /* Ignore */
+		source = "__p += '";
+
+	// Prevent false positives on "interpolate".
+	var preventMisidentification = 'text interpolate text'; // OK.
+	var interpolate = THREE.CurveUtils.interpolate; // OK.
+
+	var p = function(f, d) {
+		return s.interpolate(m(f), _(d), 0.5, e.color_space) // OK.
+	}
+
+	y.interpolate.bezier = b; // OK.
+	</script>
+	<?php
+}

--- a/WordPressVIPMinimum/Tests/Security/UnderscorejsUnitTest.inc
+++ b/WordPressVIPMinimum/Tests/Security/UnderscorejsUnitTest.inc
@@ -12,6 +12,38 @@ EOT;
 <script type="text/template" id="js-tpl--example">
 			<a
 				href="<%= post_url %>"> <!-- NOK. -->
-				<h3><%- post_title %></h3>
+				<h3><%- post_title %></h3><!-- OK -->
 			</a>
 </script>
+
+<?php
+
+function single_quoted_string() {
+	echo '<div class="thumb" data-attid="<%=   data.id   %>" data-origsrc="<%- data.originalSrc %>">'. // NOK x 1.
+		'<img src="<%- data.src %>" alt="<%=data.alt%>"/>'. // NOK x 1.
+	'</div>';
+}
+
+function single_quoted_string_with_concatenation( $data ) {
+	echo '<img src="<%= ' . $data['src'] . ' %>" alt="<%- data.alt %>"/>'; // NOK x 1.
+}
+
+function double_quoted_string( $name, $value, $is_template ) {
+	echo $is_template ? "<%={$name}%>" : esc_attr( $value ); // NOK.
+}
+
+$nowdoc = <<<'EOT'
+<script type="text/template" id="prefix-template">
+	<section class="prefix-photo prefix-image">
+		<img src="<%= img.src %>" class="prefix-image" width="<%= img.width %>" height="<%= img.height %>" /><!-- NOK x 3 -->
+	</section>
+</script>
+EOT;
+
+$heredoc = <<<EOD
+	<label
+		class="$classes prefix-form-ui-label-<%- htmlAttr.id %><%= ordinal %>"
+		for="<%- htmlAttr.id %><%= ordinal %>">
+		<%= name %>
+	</label><!-- NOK - 1 per line -->
+EOD;

--- a/WordPressVIPMinimum/Tests/Security/UnderscorejsUnitTest.js
+++ b/WordPressVIPMinimum/Tests/Security/UnderscorejsUnitTest.js
@@ -39,3 +39,7 @@ var html = _.template(
 		variable: "o"
 	}
 );
+
+var compiled = _.template("<% print('Hello ' + _.escape(epithet)); %>"); /* OK */
+var compiled = _.template("<% print('Hello ' + epithet); %>"); /* NOK */
+var compiled = _.template("<% __p+=o.text %>"); /* NOK */

--- a/WordPressVIPMinimum/Tests/Security/UnderscorejsUnitTest.js
+++ b/WordPressVIPMinimum/Tests/Security/UnderscorejsUnitTest.js
@@ -24,3 +24,18 @@ var p = function(f, d) {
 }
 
 y.interpolate.bezier = b; // OK.
+
+// Recognize escaping.
+var html = _.template('<li><%= _.escape(name) %></li>', { name: 'John Smith' }); // OK.
+
+var html = _.template(
+	"<pre>The \"<% __p+=_.escape(o.text) %>\" is the same<br />" + // OK.
+		"as the  \"<%= _.escape(o.text) %>\" and the same<br />" + // OK.
+		"as the \"<%- o.text %>\"</pre>", // OK.
+	{
+		text: "<b>some text</b> and \n it's a line break"
+	},
+	{
+		variable: "o"
+	}
+);

--- a/WordPressVIPMinimum/Tests/Security/UnderscorejsUnitTest.js
+++ b/WordPressVIPMinimum/Tests/Security/UnderscorejsUnitTest.js
@@ -4,3 +4,23 @@ var html = _.template('<li><%- name %></li>', { name: 'John Smith' }); // OK.
 var html = _.template('<li><%= name %></li>', { name: 'John Smith' }); // NOK.
 var html = _.template('<li><%=type.item%></li>', { name: 'John Smith' }); // NOK.
 
+_.templateSettings.interpolate = /\{\{(.+?)\}\}/g; /* NOK */
+_.templateSettings = {
+	interpolate: /\{\{(.+?)\}\}/g /* NOK */
+};
+
+options.interpolate=_.templateSettings.interpolate; /* NOK */
+var interpolate = options.interpolate || reNoMatch, /* Ignore */
+	source = "__p += '";
+
+var template = _.template('<li>{{ name }}</li>'); /* NOK, due to the interpolate, but not flagged. */
+
+// Prevent false positives on "interpolate".
+var preventMisidentification = 'text interpolate text'; // OK.
+var interpolate = THREE.CurveUtils.interpolate; // OK.
+
+var p = function(f, d) {
+	return s.interpolate(m(f), _(d), 0.5, e.color_space) // OK.
+}
+
+y.interpolate.bezier = b; // OK.

--- a/WordPressVIPMinimum/Tests/Security/UnderscorejsUnitTest.js
+++ b/WordPressVIPMinimum/Tests/Security/UnderscorejsUnitTest.js
@@ -1,0 +1,6 @@
+
+var html = _.template('<li><%- name %></li>', { name: 'John Smith' }); // OK.
+
+var html = _.template('<li><%= name %></li>', { name: 'John Smith' }); // NOK.
+var html = _.template('<li><%=type.item%></li>', { name: 'John Smith' }); // NOK.
+

--- a/WordPressVIPMinimum/Tests/Security/UnderscorejsUnitTest.php
+++ b/WordPressVIPMinimum/Tests/Security/UnderscorejsUnitTest.php
@@ -30,21 +30,35 @@ class UnderscorejsUnitTest extends AbstractSniffUnitTest {
 	/**
 	 * Returns the lines where warnings should occur.
 	 *
+	 * @param string $testFile The name of the file being tested.
+	 *
 	 * @return array <int line number> => <int number of warnings>
 	 */
-	public function getWarningList() {
-		return [
-			6  => 1,
-			14 => 1,
-			22 => 1,
-			23 => 1,
-			28 => 1,
-			32 => 1,
-			38 => 3,
-			45 => 1,
-			46 => 1,
-			47 => 1,
-		];
+	public function getWarningList( $testFile = '' ) {
+		switch ( $testFile ) {
+			case 'UnderscorejsUnitTest.inc':
+				return [
+					6  => 1,
+					14 => 1,
+					22 => 1,
+					23 => 1,
+					28 => 1,
+					32 => 1,
+					38 => 3,
+					45 => 1,
+					46 => 1,
+					47 => 1,
+				];
+
+			case 'UnderscorejsUnitTest.js':
+				return [
+					4 => 1,
+					5 => 1,
+				];
+
+			default:
+				return [];
+		}
 	}
 
 }

--- a/WordPressVIPMinimum/Tests/Security/UnderscorejsUnitTest.php
+++ b/WordPressVIPMinimum/Tests/Security/UnderscorejsUnitTest.php
@@ -48,6 +48,8 @@ class UnderscorejsUnitTest extends AbstractSniffUnitTest {
 					45 => 1,
 					46 => 1,
 					47 => 1,
+					58 => 1,
+					60 => 1,
 				];
 
 			case 'UnderscorejsUnitTest.js':

--- a/WordPressVIPMinimum/Tests/Security/UnderscorejsUnitTest.php
+++ b/WordPressVIPMinimum/Tests/Security/UnderscorejsUnitTest.php
@@ -52,8 +52,11 @@ class UnderscorejsUnitTest extends AbstractSniffUnitTest {
 
 			case 'UnderscorejsUnitTest.js':
 				return [
-					4 => 1,
-					5 => 1,
+					4  => 1,
+					5  => 1,
+					7  => 1,
+					9  => 1,
+					12 => 1,
 				];
 
 			default:

--- a/WordPressVIPMinimum/Tests/Security/UnderscorejsUnitTest.php
+++ b/WordPressVIPMinimum/Tests/Security/UnderscorejsUnitTest.php
@@ -40,7 +40,7 @@ class UnderscorejsUnitTest extends AbstractSniffUnitTest {
 			23 => 1,
 			28 => 1,
 			32 => 1,
-			38 => 1,
+			38 => 3,
 			45 => 1,
 			46 => 1,
 			47 => 1,

--- a/WordPressVIPMinimum/Tests/Security/UnderscorejsUnitTest.php
+++ b/WordPressVIPMinimum/Tests/Security/UnderscorejsUnitTest.php
@@ -36,6 +36,14 @@ class UnderscorejsUnitTest extends AbstractSniffUnitTest {
 		return [
 			6  => 1,
 			14 => 1,
+			22 => 1,
+			23 => 1,
+			28 => 1,
+			32 => 1,
+			38 => 1,
+			45 => 1,
+			46 => 1,
+			47 => 1,
 		];
 	}
 

--- a/WordPressVIPMinimum/Tests/Security/UnderscorejsUnitTest.php
+++ b/WordPressVIPMinimum/Tests/Security/UnderscorejsUnitTest.php
@@ -19,6 +19,21 @@ use PHP_CodeSniffer\Tests\Standards\AbstractSniffUnitTest;
 class UnderscorejsUnitTest extends AbstractSniffUnitTest {
 
 	/**
+	 * Get a list of all test files to check.
+	 *
+	 * @param string $testFileBase The base path that the unit tests files will have.
+	 *
+	 * @return string[]
+	 */
+	protected function getTestFiles( $testFileBase ) {
+		return [
+			$testFileBase . 'inc',
+			$testFileBase . 'js',
+			__DIR__ . DIRECTORY_SEPARATOR . 'Gruntfile.js',
+		];
+	}
+
+	/**
 	 * Returns the lines where errors should occur.
 	 *
 	 * @return array <int line number> => <int number of errors>

--- a/WordPressVIPMinimum/Tests/Security/UnderscorejsUnitTest.php
+++ b/WordPressVIPMinimum/Tests/Security/UnderscorejsUnitTest.php
@@ -53,18 +53,20 @@ class UnderscorejsUnitTest extends AbstractSniffUnitTest {
 		switch ( $testFile ) {
 			case 'UnderscorejsUnitTest.inc':
 				return [
-					6  => 1,
-					14 => 1,
-					22 => 1,
-					23 => 1,
-					28 => 1,
-					32 => 1,
-					38 => 3,
-					45 => 1,
-					46 => 1,
-					47 => 1,
-					58 => 1,
-					60 => 1,
+					6   => 1,
+					14  => 1,
+					22  => 1,
+					23  => 1,
+					28  => 1,
+					32  => 1,
+					38  => 3,
+					45  => 1,
+					46  => 1,
+					47  => 1,
+					58  => 1,
+					60  => 1,
+					114 => 1,
+					115 => 1,
 				];
 
 			case 'UnderscorejsUnitTest.js':
@@ -74,6 +76,8 @@ class UnderscorejsUnitTest extends AbstractSniffUnitTest {
 					7  => 1,
 					9  => 1,
 					12 => 1,
+					44 => 1,
+					45 => 1,
 				];
 
 			default:


### PR DESCRIPTION
Result of a review of the `WordPressVIPMinimum.Security.Underscorejs` sniff.

Not claiming completeness as JS, like PHP, can be written in lots of different ways - think ternaries, method chaining etc - and my JS is a bit rusty ;-).
Consider this a first round of improvements.

Input regarding underscores syntaxes based on:
* https://www.topjavatutorial.com/underscore-js/underscore-js-escape-unescape-functions/
* https://underscorejs.org/
* https://devdocs.io/underscore/index
* https://stackoverflow.com/questions/4778881/how-to-use-underscore-js-as-a-template-engine

Code samples largely based on samples found via:
* https://wpdirectory.net/search/01EN00V6N7CVNF8SXDW6EA91NV
* https://wpdirectory.net/search/01EN00VG3ERYZ2BZZ5VFFZ62N4
* https://wpdirectory.net/search/01EN375V8PHQYTZB9T39VB9X6R
* https://wpdirectory.net/search/01EN39JTD2A9W51AGPVZJ6ANHB

Fixes #546

---

## Commit details

### Security/Underscorejs: sniff all text string tokens

So far, only single quoted text strings, heredocs and inline HTML were sniffed.
However, there are two more text string token types: nowdoc and double quoted strings.

This adds these tokens to the `register()` method to be sniffed.

This commit also ensures that there is at least one unit test in place for each of these token types and that the tests use a variety of whitespace.

### Security/Underscorejs: throw an error for each violation

So far, the sniff would throw one error per text string, independently of how often the unescaped output notation would occur in the text string.

While for simple text strings, this is not much of an issue, for long and complex text strings, it may be more difficult to spot all the unescaped output notations in the text string.

This changes the sniff to:
* Throw a warning for each occurrence of the unescaped output notation in a text string.
* Include a snippet from the text string with the details of the unescaped output notation.
    Old: `Found Underscore.js unescaped output notation: "<%=".`
    New: `Found Underscore.js unescaped output notation: "<%= post_url %>".`

To allow the sniff to also match on a text string being concatenated together, the regex has to also match when `<%=` occurs at the end of the text string and will only display `<%=` in that case.
To this end, we also need to remove the text string quotes (if they exist) from the token content.

### Security/Underscorejs: add JS test case file

Add a basic JS test case file.

Tests for `interpolate` will be added in a follow-up commit.

### Security/Underscorejs: improve check for `interpolate` in JS files

The `interpolate` property in JS can be set using various syntaxes. While the current check will in no way catch them all, the changes now made should improve the accuracy of detecting a change in the delimiter via `interpolate` in JS files.

Notes:
* Add checking for `T_STRING` to detect `_.templateSettings.interpolate =` syntax. This was previously not detected (false negative).
* Add some defensive coding to prevent false positives when the `interpolate` keyword is used in another context than underscorejs.
* Limit the check for `T_STRING` and `T_PROPERTY` to Javascript files only to prevent false positives when scanning PHP files.
* Limit the check for `interpolate` in text strings to PHP only. This prevents false positives when the keyword is used in a text string in JS.

Includes unit tests covering all the above.

### Security/Underscorejs: improve check for `interpolate` in PHP files

Match the `interpolate` property in PHP files with the similar precision as in JS files.

Includes unit tests.

### Security/Underscorejs: bug fix - don't error when variable is escaped

Prevent triggering a warning when the variable being printed is escaped using `_.escape()`.

Includes unit tests.

Fixes #345

### Security/Underscorejs: ignore Gruntfile.js files

These are configuration files and not part of the production code.

This check does not verify whether this file is in the project root as we don't know what the project root is. It will plainly ignore any file called `Gruntfile.js` in a case-insensitive manner.

Includes unit tests.

### Security/Underscorejs: enhancement - check for print execution statements

Add a new check for the JS native `print` command and the `_p+=` variation, when used without being combined with `_.escape()`.

Includes unit tests.

