### PR TITLE
Travis: add build against PHP 8.0

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -67,8 +67,13 @@ jobs:
         # Run PHPCS against VIPCS.
         - ./bin/phpcs
 
-    # Builds which need a different distro.
+    # Builds which need a different distro or specific PHPCS version.
     - stage: test
+    - php: 8.0
+      env: PHPCS_BRANCH="dev-master"
+    - php: 8.0
+      # PHPCS 3.5.7 is the lowest version of PHPCS which supports PHP 8.0.
+      env: PHPCS_BRANCH="3.5.7"
     - php: 5.5
       dist: trusty
       env: PHPCS_BRANCH="dev-master"
@@ -98,7 +103,7 @@ before_install:
 install:
   - travis_retry composer require squizlabs/php_codesniffer:"$PHPCS_BRANCH" --no-update --no-suggest --no-scripts
   - |
-    if [[ $TRAVIS_PHP_VERSION == "nightly" ]]; then
+    if [[ $TRAVIS_PHP_VERSION == "nightly" || $TRAVIS_PHP_VERSION == "8.0" ]]; then
       # PHPUnit 7.x does not allow for installation on PHP 8, so ignore platform
       # requirements to get PHPUnit 7.x to install on nightly.
       travis_retry composer install --ignore-platform-reqs --no-suggest


### PR DESCRIPTION
PHP 8.0 has been branched off two months ago, so `nightly` is now PHP 8.1 and in the mean time PHP 8.0 was released last week.

As of today, there is a PHP 8.0 image available on Travis.

This PR adds a two new builds against PHP 8.0 to the matrix and, as PHP 8.0 has been released, these builds are not allowed to fail.

PHPCS 3.5.7 is the first PHPCS version which is runtime compatible with PHP 8.0.
Once the minimum supported PHPCS version of this package has been upped to PHPCS 3.5.7, these builds don't need to be special cased anymore.