### PR TITLE
WordPress.Security.NonceVerification.NoNonceVerification: Remove outdated reference from WordPress-VIP-Go ruleset and let inheritance from parent

### DIFF
--- a/WordPress-VIP-Go/ruleset-test.inc
+++ b/WordPress-VIP-Go/ruleset-test.inc
@@ -67,7 +67,7 @@ $external_resource = file_get_contents( $test ); // Warning + Message.
 $file_content = file_get_contents( 'my-file.svg' ); // Ok.
 wpcom_vip_file_get_contents( $bar ); // Ok.
 
-// WordPress.Security.NonceVerification.NoNonceVerification
+// WordPress.Security.NonceVerification (inherited from parent)
 function bar_foo() {
 	if ( ! isset( $_POST['test'] ) ) { // Error.
 		return;

--- a/WordPress-VIP-Go/ruleset.xml
+++ b/WordPress-VIP-Go/ruleset.xml
@@ -129,11 +129,6 @@
 
 
 	<!-- Warnings and other things -->
-	<rule ref="WordPress.Security.NonceVerification.NoNonceVerification">
-		<!-- Needs a manual check -->
-		<type>warning</type>
-		<severity>10</severity>
-	</rule>
 	<rule ref="WordPress.Security.ValidatedSanitizedInput.InputNotSanitized">
 		<!-- Needs a manual check -->
 		<type>warning</type>


### PR DESCRIPTION
Fixes #605.