### PR TITLE
WordPress-VIP-Go: Replace WordPress.WP.GlobalVariablesOverride.OverrideProhibited with WordPress.WP.GlobalVariablesOverride.Prohibited

### DIFF
--- a/WordPress-VIP-Go/ruleset.xml
+++ b/WordPress-VIP-Go/ruleset.xml
@@ -223,7 +223,7 @@
 		<!-- We trust that translations are safe on VIP Go -->
 		<severity>1</severity>
 	</rule>
-	<rule ref="WordPress.WP.GlobalVariablesOverride.OverrideProhibited">
+	<rule ref="WordPress.WP.GlobalVariablesOverride.Prohibited">
 		<!-- This is often a false positive. Still nice to flag for a check -->
 		<severity>3</severity>
 	</rule>


### PR DESCRIPTION
Fixes #609.