### PR TITLE
ProperEscapingFunction: Flag when esc_attr is being used outside of HTML attributes

### DIFF
--- a/WordPressVIPMinimum/Sniffs/Security/ProperEscapingFunctionSniff.php
+++ b/WordPressVIPMinimum/Sniffs/Security/ProperEscapingFunctionSniff.php
@@ -86,7 +86,7 @@ class ProperEscapingFunctionSniff extends Sniff {
 
 		$content = $this->tokens[ $html ]['content'];
 
-		if ( $this->tokens[ $html ]['code'] !== 'T_INLINE_HTML' ) {
+		if ( isset( Tokens::$stringTokens[ $this->tokens[ $html ]['code'] ] ) === true ) {
 			$content = Sniff::strip_quotes( $content );
 		}
 

--- a/WordPressVIPMinimum/Sniffs/Security/ProperEscapingFunctionSniff.php
+++ b/WordPressVIPMinimum/Sniffs/Security/ProperEscapingFunctionSniff.php
@@ -23,7 +23,7 @@ class ProperEscapingFunctionSniff extends Sniff {
 	 *
 	 * @var array
 	 */
-	public $escaping_functions = [
+	protected $escaping_functions = [
 		'esc_url'    => 'url',
 		'esc_attr'   => 'attr',
 		'esc_attr__' => 'attr',

--- a/WordPressVIPMinimum/Sniffs/Security/ProperEscapingFunctionSniff.php
+++ b/WordPressVIPMinimum/Sniffs/Security/ProperEscapingFunctionSniff.php
@@ -94,7 +94,9 @@ class ProperEscapingFunctionSniff extends Sniff {
 	 */
 	public function process_token( $stackPtr ) {
 
-		if ( isset( $this->escaping_functions[ $this->tokens[ $stackPtr ]['content'] ] ) === false ) {
+		$function_name = strtolower( $this->tokens[ $stackPtr ]['content'] );
+
+		if ( isset( $this->escaping_functions[ $function_name ] ) === false ) {
 			return;
 		}
 
@@ -104,8 +106,6 @@ class ProperEscapingFunctionSniff extends Sniff {
 		if ( $html === false || isset( Tokens::$textStringTokens[ $this->tokens[ $html ]['code'] ] ) === false ) {
 			return;
 		}
-
-		$function_name = $this->tokens[ $stackPtr ]['content'];
 
 		$data = [ $function_name ];
 

--- a/WordPressVIPMinimum/Sniffs/Security/ProperEscapingFunctionSniff.php
+++ b/WordPressVIPMinimum/Sniffs/Security/ProperEscapingFunctionSniff.php
@@ -75,7 +75,7 @@ class ProperEscapingFunctionSniff extends Sniff {
 
 		$html = $this->phpcsFile->findPrevious( $this->echo_or_concat_tokens, $stackPtr - 1, null, true );
 
-		// Use $textStringTokens b/c heredoc and nowdoc tokens shouldn't be matched anyways.
+		// Use $textStringTokens b/c heredoc and nowdoc tokens will never be encountered in this context anyways.
 		if ( $html === false || isset( Tokens::$textStringTokens[ $this->tokens[ $html ]['code'] ] ) === false ) {
 			return;
 		}

--- a/WordPressVIPMinimum/Sniffs/Security/ProperEscapingFunctionSniff.php
+++ b/WordPressVIPMinimum/Sniffs/Security/ProperEscapingFunctionSniff.php
@@ -67,6 +67,7 @@ class ProperEscapingFunctionSniff extends Sniff {
 	 * @var array
 	 */
 	private $attr_endings = [
+		'=',
 		'="',
 		"='",
 		"=\\'",

--- a/WordPressVIPMinimum/Sniffs/Security/ProperEscapingFunctionSniff.php
+++ b/WordPressVIPMinimum/Sniffs/Security/ProperEscapingFunctionSniff.php
@@ -100,6 +100,12 @@ class ProperEscapingFunctionSniff extends Sniff {
 			return;
 		}
 
+		$next_non_empty = $this->phpcsFile->findNext( Tokens::$emptyTokens, ( $stackPtr + 1 ), null, true );
+		if ( $next_non_empty === false || $this->tokens[ $next_non_empty ]['code'] !== T_OPEN_PARENTHESIS ) {
+			// Not a function call.
+			return;
+		}
+
 		$html = $this->phpcsFile->findPrevious( $this->echo_or_concat_tokens, $stackPtr - 1, null, true );
 
 		// Use $textStringTokens b/c heredoc and nowdoc tokens will never be encountered in this context anyways..

--- a/WordPressVIPMinimum/Sniffs/Security/ProperEscapingFunctionSniff.php
+++ b/WordPressVIPMinimum/Sniffs/Security/ProperEscapingFunctionSniff.php
@@ -114,19 +114,21 @@ class ProperEscapingFunctionSniff extends Sniff {
 			$content = Sniff::strip_quotes( $content );
 		}
 
+		$escaping_type = $this->escaping_functions[ $function_name ];
+
 		if ( $this->is_outside_html_attr_context( $function_name, $content ) ) {
 			$message = 'Wrong escaping function, using `%s()` in a context outside of HTML attributes may not escape properly.';
 			$this->phpcsFile->addError( $message, $html, 'notAttrEscAttr', $data );
 			return;
 		}
 
-		if ( $function_name !== 'esc_url' && $this->attr_expects_url( $content ) ) {
+		if ( $escaping_type !== 'url' && $this->attr_expects_url( $content ) ) {
 			$message = 'Wrong escaping function. href, src, and action attributes should be escaped by `esc_url()`, not by `%s()`.';
 			$this->phpcsFile->addError( $message, $stackPtr, 'hrefSrcEscUrl', $data );
 			return;
 		}
 
-		if ( $function_name === 'esc_html' && $this->is_html_attr( $content ) ) {
+		if ( $escaping_type === 'html' && $this->is_html_attr( $content ) ) {
 			$message = 'Wrong escaping function. HTML attributes should be escaped by `esc_attr()`, not by `%s()`.';
 			$this->phpcsFile->addError( $message, $stackPtr, 'htmlAttrNotByEscHTML', $data );
 			return;

--- a/WordPressVIPMinimum/Sniffs/Security/ProperEscapingFunctionSniff.php
+++ b/WordPressVIPMinimum/Sniffs/Security/ProperEscapingFunctionSniff.php
@@ -116,7 +116,7 @@ class ProperEscapingFunctionSniff extends Sniff {
 
 		$escaping_type = $this->escaping_functions[ $function_name ];
 
-		if ( $this->is_outside_html_attr_context( $function_name, $content ) ) {
+		if ( $escaping_type === 'attr' && $this->is_outside_html_attr_context( $content ) ) {
 			$message = 'Wrong escaping function, using `%s()` in a context outside of HTML attributes may not escape properly.';
 			$this->phpcsFile->addError( $message, $html, 'notAttrEscAttr', $data );
 			return;
@@ -174,15 +174,14 @@ class ProperEscapingFunctionSniff extends Sniff {
 	}
 
 	/**
-	 * Tests whether escaping function is being used outside of HTML tag.
+	 * Tests whether an attribute escaping function is being used outside of an HTML tag.
 	 *
-	 * @param string $function_name Escaping function.
-	 * @param string $content       Haystack where we look for the end of a HTML tag.
+	 * @param string $content Haystack where we look for the end of a HTML tag.
 	 *
-	 * @return bool True if escaping attribute function and string ends with a HTML tag.
+	 * @return bool True if the passed string ends a HTML tag.
 	 */
-	public function is_outside_html_attr_context( $function_name, $content ) {
-		return $this->escaping_functions[ $function_name ] === 'attr' && $this->endswith( trim( $content ), '>' );
+	public function is_outside_html_attr_context( $content ) {
+		return $this->endswith( trim( $content ), '>' );
 	}
 
 	/**

--- a/WordPressVIPMinimum/Sniffs/Security/ProperEscapingFunctionSniff.php
+++ b/WordPressVIPMinimum/Sniffs/Security/ProperEscapingFunctionSniff.php
@@ -100,7 +100,7 @@ class ProperEscapingFunctionSniff extends Sniff {
 
 		$html = $this->phpcsFile->findPrevious( $this->echo_or_concat_tokens, $stackPtr - 1, null, true );
 
-		// Use $textStringTokens b/c heredoc and nowdoc tokens shouldn't be matched anyways.
+		// Use $textStringTokens b/c heredoc and nowdoc tokens will never be encountered in this context anyways..
 		if ( $html === false || isset( Tokens::$textStringTokens[ $this->tokens[ $html ]['code'] ] ) === false ) {
 			return;
 		}
@@ -110,7 +110,6 @@ class ProperEscapingFunctionSniff extends Sniff {
 		$data = [ $function_name ];
 
 		$content = $this->tokens[ $html ]['content'];
-
 		if ( isset( Tokens::$stringTokens[ $this->tokens[ $html ]['code'] ] ) === true ) {
 			$content = Sniff::strip_quotes( $content );
 		}
@@ -141,7 +140,7 @@ class ProperEscapingFunctionSniff extends Sniff {
 	 *
 	 * @param string $content Haystack in which we look for an open attribute which exects a URL value.
 	 *
-	 * @return bool True if string ends with open attribute which exects a URL value.
+	 * @return bool True if string ends with open attribute which expects a URL value.
 	 */
 	public function attr_expects_url( $content ) {
 		$attr_expects_url = false;
@@ -189,7 +188,7 @@ class ProperEscapingFunctionSniff extends Sniff {
 	 * A helper function which tests whether string ends with some other.
 	 *
 	 * @param string $haystack String which is being tested.
-	 * @param string $needle The substring, which we try to locate on the end of the $haystack.
+	 * @param string $needle   The substring, which we try to locate on the end of the $haystack.
 	 *
 	 * @return bool True if haystack ends with needle.
 	 */

--- a/WordPressVIPMinimum/Sniffs/Security/ProperEscapingFunctionSniff.php
+++ b/WordPressVIPMinimum/Sniffs/Security/ProperEscapingFunctionSniff.php
@@ -76,7 +76,7 @@ class ProperEscapingFunctionSniff extends Sniff {
 		$html = $this->phpcsFile->findPrevious( $this->echo_or_concat_tokens, $stackPtr - 1, null, true );
 
 		// Use $textStringTokens b/c heredoc and nowdoc tokens shouldn't be matched anyways.
-		if ( false === $html || false === isset( Tokens::$textStringTokens[ $this->tokens[ $html ]['code'] ] ) ) {
+		if ( $html === false || isset( Tokens::$textStringTokens[ $this->tokens[ $html ]['code'] ] ) === false ) {
 			return;
 		}
 

--- a/WordPressVIPMinimum/Sniffs/Security/ProperEscapingFunctionSniff.php
+++ b/WordPressVIPMinimum/Sniffs/Security/ProperEscapingFunctionSniff.php
@@ -47,6 +47,7 @@ class ProperEscapingFunctionSniff extends Sniff {
 		T_OPEN_TAG_WITH_ECHO => T_OPEN_TAG_WITH_ECHO,
 		T_STRING_CONCAT      => T_STRING_CONCAT,
 		T_COMMA              => T_COMMA,
+		T_NS_SEPARATOR       => T_NS_SEPARATOR,
 	];
 
 	/**

--- a/WordPressVIPMinimum/Sniffs/Security/ProperEscapingFunctionSniff.php
+++ b/WordPressVIPMinimum/Sniffs/Security/ProperEscapingFunctionSniff.php
@@ -158,6 +158,18 @@ class ProperEscapingFunctionSniff extends Sniff {
 	}
 
 	/**
+	 * Tests whether string ends with opening HTML tag for detection in attribute escaping.
+	 *
+	 * @param string $function_name Name of function.
+	 * @param string $content       Haystack where we look for the end of opening HTML tag.
+	 *
+	 * @return bool True if escaping attribute function and string ends with opening HTML tag.
+	 */
+	public function is_outside_html_attr_context( $function_name, $content ) {
+		return $this->escaping_functions[ $function_name ] === 'attr' && $this->endswith( trim( $content ), '>' );
+	}
+
+	/**
 	 * A helper function which tests whether string ends with some other.
 	 *
 	 * @param string $haystack String which is being tested.
@@ -167,17 +179,5 @@ class ProperEscapingFunctionSniff extends Sniff {
 	 */
 	public function endswith( $haystack, $needle ) {
 		return substr( $haystack, -strlen( $needle ) ) === $needle;
-	}
-
-	/**
-	 * Tests whether string ends with opening HTML tag for detection in attribute escaping.
-	 *
-	 * @param string $function_name Name of function.
-	 * @param string $content       Haystack where we look for the end of opening HTML tag.
-	 *
-	 * @return bool True if escaping attribute function and string ends with opening HTML tag.
-	 */
-	public function is_outside_html_attr_context( $function_name, $content ) {
-		return $this->escaping_functions[ $function_name ] === 'attr' && substr( trim( $content ), -1 ) === '>';
 	}
 }

--- a/WordPressVIPMinimum/Tests/Security/ProperEscapingFunctionUnitTest.inc
+++ b/WordPressVIPMinimum/Tests/Security/ProperEscapingFunctionUnitTest.inc
@@ -12,7 +12,7 @@ echo '<a title="' . esc_attr( $some_var ) . '"></a>'; // OK.
 
 echo "<a title='" . esc_attr( $some_var ) . "'></a>"; // OK.
 
-echo '<a title="' . esc_html( $some_var ) . '"></a>'; // Error.
+echo '<a title="' . esc_html_x( $some_var ) . '"></a>'; // Error.
 
 echo "<a title='" . esc_html( $some_var ) . "'></a>"; // Error.
 
@@ -20,7 +20,7 @@ echo "<a title='" . esc_html( $some_var ) . "'></a>"; // Error.
 
 <a href="<?php echo esc_attr( $some_var ); ?>">Hello</a> <!-- Error. -->
 
-<a href="" class="<?php echo esc_html( $some_var); ?>">Hey</a> <!-- Error. -->
+<a href="" class="<?php esc_html_e( $some_var); ?>">Hey</a> <!-- Error. -->
 
 <a href="<?php esc_url( $url );?>"></a> <!-- OK. -->
 
@@ -61,7 +61,7 @@ Test
 
 <h1><?php echo esc_attr__( $title, 'domain' ); ?></h1> <!-- Error --> ?>
 <?php echo '<h1>' . esc_attr__( $some_var, 'domain' ) . '</h1>'; // Error.
-echo '<h1>',      esc_attr__( $title, 'domain' ), '</h1>'; // Error.
+echo '<h1>',      esc_attr_x( $title, 'domain' ), '</h1>'; // Error.
 echo "<$tag>  " , esc_attr( $test ) , "</$tag>"; // Error.
 ?>
 <h1> <?php echo esc_attr( $title ) . '</h1>'; ?> // Error.
@@ -72,7 +72,7 @@ echo "<$tag>  " , esc_attr( $test ) , "</$tag>"; // Error.
 echo "<{$tag}>" . esc_attr( $tag_content ) . "</{$tag}>"; // Error.
 echo "<$tag" . '   >' . esc_attr( $tag_content ) . "</$tag>"; // Error.
 echo '<div class=\'' . esc_html($class) . '\'>'; // Error.
-echo "<div class=\"" . esc_html($class) . '">'; // Error.
+echo "<div class=\"" . esc_html__($class) . '">'; // Error.
 echo "<div $someAttribute class=\"" . esc_html($class) . '">'; // Error.
 echo '<a href=\'' . esc_html($url) . '\'>'; // Error.
 echo "<img src=\"" . esc_html($src) . '"/>'; // Error.

--- a/WordPressVIPMinimum/Tests/Security/ProperEscapingFunctionUnitTest.inc
+++ b/WordPressVIPMinimum/Tests/Security/ProperEscapingFunctionUnitTest.inc
@@ -45,7 +45,7 @@ echo 'data-param-url="' . esc_html( $share_url ) . '"'; // Error.
 <a href="#link"><?php echo esc_attr( 'testing' ); // Error.
 ?> </a>
 
-<?php echo ' <h' . "2>    " ,        esc_attr( $heading ) . "</h2">; // Error.
+<?php echo ' <h' . "2>    " ,        esc_attr( $heading ) . "</h2>"; // Error.
 ?> <style>
 h1 {
   color: <?php echo esc_attr( $color ) ?>; /* OK */

--- a/WordPressVIPMinimum/Tests/Security/ProperEscapingFunctionUnitTest.inc
+++ b/WordPressVIPMinimum/Tests/Security/ProperEscapingFunctionUnitTest.inc
@@ -40,7 +40,7 @@ echo 'data-param-url="' . esc_html( $share_url ) . '"'; // Error.
 
 <form method="post" action="<?php echo esc_html(admin_url('admin.php?page='.$base_name.'&amp;mode=logs&amp;id='.$poll_id)); ?>">
 
-?>
+
 
 <a href="#link"><?php echo esc_attr( 'testing' ); // Error.
 ?> </a>
@@ -68,6 +68,13 @@ echo "<$tag>  " , esc_attr( $test ) , "</$tag>"; // Error.
 <div><?= esc_attr($attr) ?></div><!-- Error -->
 <div><?php esc_attr_e($attr) ?></div><!-- Error -->
 <div data-tag="<?= esc_attr( $attr ); ?>"> <!-- OK -->
-<?php echo "<div> {$test} </div>"; // OK.
+<?php echo "<div>" . $test . "</div>"; // OK.
 echo "<{$tag}>" . esc_attr( $tag_content ) . "</{$tag}>"; // Error.
 echo "<$tag" . '   >' . esc_attr( $tag_content ) . "</$tag>"; // Error.
+echo '<div class=\'' . esc_html($class) . '\'>'; // Error.
+echo "<div class=\"" . esc_html($class) . '">'; // Error.
+echo "<div $someAttribute class=\"" . esc_html($class) . '">'; // Error.
+echo '<a href=\'' . esc_html($url) . '\'>'; // Error.
+echo "<img src=\"" . esc_html($src) . '"/>'; // Error.
+echo "<div $someAttributeName-url=\"" . esc_html($url) . '">'; // Error.
+echo '<a href="',  esc_html($url), '">'; // Error.

--- a/WordPressVIPMinimum/Tests/Security/ProperEscapingFunctionUnitTest.inc
+++ b/WordPressVIPMinimum/Tests/Security/ProperEscapingFunctionUnitTest.inc
@@ -2,19 +2,19 @@
 
 echo '<a href="' . esc_attr( $some_var ) . '"></a>'; // Error.
 
-echo "<a href='" . esc_attr( $some_var ) . "'></a>"; // Error.
+echo "<a href='" . \esc_attr( $some_var ) . "'></a>"; // Error.
 
-echo '<a href="' . esc_url( $some_var ) . '"></a>'; // OK.
+echo '<a href="' . \esc_url( $some_var ) . '"></a>'; // OK.
 
 echo "<a href='" . esc_url( $some_var ) . "'></a>"; // OK.
 
 echo '<a title="' . esc_attr( $some_var ) . '"></a>'; // OK.
 
-echo "<a title='" . esc_attr( $some_var ) . "'></a>"; // OK.
+echo "<a title='" . \esc_attr( $some_var ) . "'></a>"; // OK.
 
 echo '<a title="' . esc_html_x( $some_var ) . '"></a>'; // Error.
 
-echo "<a title='" . esc_html( $some_var ) . "'></a>"; // Error.
+echo "<a title='" . \esc_html( $some_var ) . "'></a>"; // Error.
 
 ?>
 
@@ -61,7 +61,7 @@ Test
 
 <h1><?php echo esc_attr__( $title, 'domain' ); ?></h1> <!-- Error --> ?>
 <?php echo '<h1>' . esc_attr__( $some_var, 'domain' ) . '</h1>'; // Error.
-echo '<h1>',      esc_attr_x( $title, 'domain' ), '</h1>'; // Error.
+echo '<h1>',      \esc_attr_x( $title, 'domain' ), '</h1>'; // Error.
 echo "<$tag>  " , esc_attr( $test ) , "</$tag>"; // Error.
 ?>
 <h1> <?php echo esc_attr( $title ) . '</h1>'; ?> // Error.
@@ -72,7 +72,7 @@ echo "<$tag>  " , esc_attr( $test ) , "</$tag>"; // Error.
 echo "<{$tag}>" . esc_attr( $tag_content ) . "</{$tag}>"; // Error.
 echo "<$tag" . '   >' . esc_attr( $tag_content ) . "</$tag>"; // Error.
 echo '<div class=\'' . esc_html($class) . '\'>'; // Error.
-echo "<div class=\"" . esc_html__($class) . '">'; // Error.
+echo "<div class=\"" . \esc_html__($class) . '">'; // Error.
 echo "<div $someAttribute class=\"" . esc_html($class) . '">'; // Error.
 echo '<a href=\'' . esc_html($url) . '\'>'; // Error.
 echo "<img src=\"" . esc_html($src) . '"/>'; // Error.

--- a/WordPressVIPMinimum/Tests/Security/ProperEscapingFunctionUnitTest.inc
+++ b/WordPressVIPMinimum/Tests/Security/ProperEscapingFunctionUnitTest.inc
@@ -63,3 +63,8 @@ Test
 <?php echo '<h1>' . esc_attr__( $some_var, 'domain' ) . '</h1>'; // Error.
 echo '<h1>',      esc_attr__( $title, 'domain' ), '</h1>'; // Error.
 echo '<h1>',      esc_attr__( $title, 'domain' )      . '</h1>'; // Error.
+?>
+<h1> <?php echo esc_attr( $title ) . '</h1>'; ?> // Error.
+<div><?= esc_attr($attr) ?></div><!-- Error -->
+<div><?php esc_attr_e($attr) ?></div><!-- Error -->
+<div data-tag="<?= esc_attr( $attr ); ?>"> <!-- OK -->

--- a/WordPressVIPMinimum/Tests/Security/ProperEscapingFunctionUnitTest.inc
+++ b/WordPressVIPMinimum/Tests/Security/ProperEscapingFunctionUnitTest.inc
@@ -62,7 +62,7 @@ Test
 <h1><?php echo esc_attr__( $title, 'domain' ); ?></h1> <!-- Error --> ?>
 <?php echo '<h1>' . esc_attr__( $some_var, 'domain' ) . '</h1>'; // Error.
 echo '<h1>',      esc_attr__( $title, 'domain' ), '</h1>'; // Error.
-echo "<" . "h1>" . esc_attr( $test ) . '</h1>'; // Error.
+echo "<$tag>  " , esc_attr( $test ) , "</$tag>"; // Error.
 ?>
 <h1> <?php echo esc_attr( $title ) . '</h1>'; ?> // Error.
 <div><?= esc_attr($attr) ?></div><!-- Error -->

--- a/WordPressVIPMinimum/Tests/Security/ProperEscapingFunctionUnitTest.inc
+++ b/WordPressVIPMinimum/Tests/Security/ProperEscapingFunctionUnitTest.inc
@@ -45,8 +45,8 @@ echo 'data-param-url="' . esc_html( $share_url ) . '"'; // Error.
 <a href="#link"><?php echo esc_attr( 'testing' ); // Error.
 ?> </a>
 
-<style>
-<style>
+<?php echo ' <h' . "2>    " ,        esc_attr( $heading ) . "</h2">; // Error.
+?> <style>
 h1 {
   color: <?php echo esc_attr( $color ) ?>; /* OK */
   font-family: Arial;
@@ -62,9 +62,12 @@ Test
 <h1><?php echo esc_attr__( $title, 'domain' ); ?></h1> <!-- Error --> ?>
 <?php echo '<h1>' . esc_attr__( $some_var, 'domain' ) . '</h1>'; // Error.
 echo '<h1>',      esc_attr__( $title, 'domain' ), '</h1>'; // Error.
-echo '<h1>',      esc_attr__( $title, 'domain' )      . '</h1>'; // Error.
+echo "<" . "h1>" . esc_attr( $test ) . '</h1>'; // Error.
 ?>
 <h1> <?php echo esc_attr( $title ) . '</h1>'; ?> // Error.
 <div><?= esc_attr($attr) ?></div><!-- Error -->
 <div><?php esc_attr_e($attr) ?></div><!-- Error -->
 <div data-tag="<?= esc_attr( $attr ); ?>"> <!-- OK -->
+<?php echo "<div> {$test} </div>"; // OK.
+echo "<{$tag}>" . esc_attr( $tag_content ) . "</{$tag}>"; // Error.
+echo "<$tag" . '   >' . esc_attr( $tag_content ) . "</$tag>"; // Error.

--- a/WordPressVIPMinimum/Tests/Security/ProperEscapingFunctionUnitTest.inc
+++ b/WordPressVIPMinimum/Tests/Security/ProperEscapingFunctionUnitTest.inc
@@ -1,8 +1,8 @@
 <?php
 
-echo '<a href="' . esc_attr( $some_var ) . '"></a>'; // NOK.
+echo '<a href="' . esc_attr( $some_var ) . '"></a>'; // Error.
 
-echo "<a href='" . esc_attr( $some_var ) . "'></a>"; // NOK.
+echo "<a href='" . esc_attr( $some_var ) . "'></a>"; // Error.
 
 echo '<a href="' . esc_url( $some_var ) . '"></a>'; // OK.
 
@@ -12,15 +12,15 @@ echo '<a title="' . esc_attr( $some_var ) . '"></a>'; // OK.
 
 echo "<a title='" . esc_attr( $some_var ) . "'></a>"; // OK.
 
-echo '<a title="' . esc_html( $some_var ) . '"></a>'; // NOK.
+echo '<a title="' . esc_html( $some_var ) . '"></a>'; // Error.
 
-echo "<a title='" . esc_html( $some_var ) . "'></a>"; // NOK.
+echo "<a title='" . esc_html( $some_var ) . "'></a>"; // Error.
 
 ?>
 
-<a href="<?php echo esc_attr( $some_var ); ?>">Hello</a> <!-- NOK. -->
+<a href="<?php echo esc_attr( $some_var ); ?>">Hello</a> <!-- Error. -->
 
-<a href="" class="<?php echo esc_html( $some_var); ?>">Hey</a> <!-- NOK. -->
+<a href="" class="<?php echo esc_html( $some_var); ?>">Hey</a> <!-- Error. -->
 
 <a href="<?php esc_url( $url );?>"></a> <!-- OK. -->
 
@@ -30,12 +30,33 @@ echo "<a title='" . esc_html( $some_var ) . "'></a>"; // NOK.
 
 echo '<media:content url="' . esc_url( $post_image ) . '" medium="image">'; // OK.
 
-echo '<media:content url="' . esc_attr( $post_image ) . '" medium="image">'; // NOK.
+echo '<media:content url="' . esc_attr( $post_image ) . '" medium="image">'; // Error.
 
 echo 'data-param-url="' . esc_url( $share_url ) . '"'; // OK.
 
-echo 'data-param-url="' . esc_html( $share_url ) . '"'; // NOK.
+echo 'data-param-url="' . esc_html( $share_url ) . '"'; // Error.
 
 ?>
 
 <form method="post" action="<?php echo esc_html(admin_url('admin.php?page='.$base_name.'&amp;mode=logs&amp;id='.$poll_id)); ?>">
+
+?>
+
+<a href="#link"><?php echo esc_attr( 'testing' ); // Error.
+?> </a>
+
+<style>
+<style>
+h1 {
+  color: <?php echo esc_attr( $color ) ?>; /* OK */
+  font-family: Arial;
+  font-size: 10px;
+}
+</style>
+
+<article id="foo-bar" data-property="<?php echo esc_attr( $year ); // OK.
+?>">
+Test
+</article>
+
+<h1><?php echo esc_attr__( $title, 'domain' ); ?></h1> <!-- Error -->

--- a/WordPressVIPMinimum/Tests/Security/ProperEscapingFunctionUnitTest.inc
+++ b/WordPressVIPMinimum/Tests/Security/ProperEscapingFunctionUnitTest.inc
@@ -34,7 +34,7 @@ echo '<media:content url="' . esc_attr( $post_image ) . '" medium="image">'; // 
 
 echo 'data-param-url="' . esc_url( $share_url ) . '"'; // OK.
 
-echo 'data-param-url="' . esc_html( $share_url ) . '"'; // Error.
+echo 'data-param-url="' . Esc_HTML( $share_url ) . '"'; // Error.
 
 ?>
 

--- a/WordPressVIPMinimum/Tests/Security/ProperEscapingFunctionUnitTest.inc
+++ b/WordPressVIPMinimum/Tests/Security/ProperEscapingFunctionUnitTest.inc
@@ -80,3 +80,5 @@ echo "<div $someAttributeName-url=\"" . esc_html($url) . '">'; // Error.
 echo '<a href="',  esc_html($url), '">'; // Error.
 
 echo '<a href=', esc_html($url), '>'; // Error.
+
+echo 'data-param-url="' . Esc_HTML::static_method( $share_url ) . '"'; // OK.

--- a/WordPressVIPMinimum/Tests/Security/ProperEscapingFunctionUnitTest.inc
+++ b/WordPressVIPMinimum/Tests/Security/ProperEscapingFunctionUnitTest.inc
@@ -78,3 +78,5 @@ echo '<a href=\'' . esc_html($url) . '\'>'; // Error.
 echo "<img src=\"" . esc_html($src) . '"/>'; // Error.
 echo "<div $someAttributeName-url=\"" . esc_html($url) . '">'; // Error.
 echo '<a href="',  esc_html($url), '">'; // Error.
+
+echo '<a href=', esc_html($url), '>'; // Error.

--- a/WordPressVIPMinimum/Tests/Security/ProperEscapingFunctionUnitTest.inc
+++ b/WordPressVIPMinimum/Tests/Security/ProperEscapingFunctionUnitTest.inc
@@ -59,4 +59,7 @@ h1 {
 Test
 </article>
 
-<h1><?php echo esc_attr__( $title, 'domain' ); ?></h1> <!-- Error -->
+<h1><?php echo esc_attr__( $title, 'domain' ); ?></h1> <!-- Error --> ?>
+<?php echo '<h1>' . esc_attr__( $some_var, 'domain' ) . '</h1>'; // Error.
+echo '<h1>',      esc_attr__( $title, 'domain' ), '</h1>'; // Error.
+echo '<h1>',      esc_attr__( $title, 'domain' )      . '</h1>'; // Error.

--- a/WordPressVIPMinimum/Tests/Security/ProperEscapingFunctionUnitTest.php
+++ b/WordPressVIPMinimum/Tests/Security/ProperEscapingFunctionUnitTest.php
@@ -35,6 +35,7 @@ class ProperEscapingFunctionUnitTest extends AbstractSniffUnitTest {
 			37 => 1,
 			41 => 1,
 			45 => 1,
+			48 => 1,
 			62 => 1,
 			63 => 1,
 			64 => 1,
@@ -42,6 +43,8 @@ class ProperEscapingFunctionUnitTest extends AbstractSniffUnitTest {
 			67 => 1,
 			68 => 1,
 			69 => 1,
+			72 => 1,
+			73 => 1,
 		];
 	}
 

--- a/WordPressVIPMinimum/Tests/Security/ProperEscapingFunctionUnitTest.php
+++ b/WordPressVIPMinimum/Tests/Security/ProperEscapingFunctionUnitTest.php
@@ -34,6 +34,8 @@ class ProperEscapingFunctionUnitTest extends AbstractSniffUnitTest {
 			33 => 1,
 			37 => 1,
 			41 => 1,
+			45 => 1,
+			62 => 1,
 		];
 	}
 

--- a/WordPressVIPMinimum/Tests/Security/ProperEscapingFunctionUnitTest.php
+++ b/WordPressVIPMinimum/Tests/Security/ProperEscapingFunctionUnitTest.php
@@ -36,6 +36,9 @@ class ProperEscapingFunctionUnitTest extends AbstractSniffUnitTest {
 			41 => 1,
 			45 => 1,
 			62 => 1,
+			63 => 1,
+			64 => 1,
+			65 => 1,
 		];
 	}
 

--- a/WordPressVIPMinimum/Tests/Security/ProperEscapingFunctionUnitTest.php
+++ b/WordPressVIPMinimum/Tests/Security/ProperEscapingFunctionUnitTest.php
@@ -39,6 +39,9 @@ class ProperEscapingFunctionUnitTest extends AbstractSniffUnitTest {
 			63 => 1,
 			64 => 1,
 			65 => 1,
+			67 => 1,
+			68 => 1,
+			69 => 1,
 		];
 	}
 

--- a/WordPressVIPMinimum/Tests/Security/ProperEscapingFunctionUnitTest.php
+++ b/WordPressVIPMinimum/Tests/Security/ProperEscapingFunctionUnitTest.php
@@ -52,6 +52,7 @@ class ProperEscapingFunctionUnitTest extends AbstractSniffUnitTest {
 			78 => 1,
 			79 => 1,
 			80 => 1,
+			82 => 1,
 		];
 	}
 

--- a/WordPressVIPMinimum/Tests/Security/ProperEscapingFunctionUnitTest.php
+++ b/WordPressVIPMinimum/Tests/Security/ProperEscapingFunctionUnitTest.php
@@ -45,6 +45,13 @@ class ProperEscapingFunctionUnitTest extends AbstractSniffUnitTest {
 			69 => 1,
 			72 => 1,
 			73 => 1,
+			74 => 1,
+			75 => 1,
+			76 => 1,
+			77 => 1,
+			78 => 1,
+			79 => 1,
+			80 => 1,
 		];
 	}
 


### PR DESCRIPTION
Fixes #155.

Also replaced "NOK" in the test with "Error" since "NOK" is harder to distinguish from "OK".