### PR TITLE
IncludingFile: Add custom keywords to detect to reduce false positives

### DIFF
--- a/WordPressVIPMinimum/Tests/Files/IncludingFileUnitTest.inc
+++ b/WordPressVIPMinimum/Tests/Files/IncludingFileUnitTest.inc
@@ -13,7 +13,6 @@ require dirname( __FILE__, 2 ) . '/my_file.php' );
 require dirname( dirname( __FILE__ ) ) . '/my_file.php' );
 require dirname( dirname( __DIR__ ) ) . '/my_file.php' );
 require_once( get_parent_theme_file_path( '/my_file.php' ); );
-require_once(    $custom_path );
 include CUSTOM__DIR . 
 'file.php';
 include_once CUSTOMBASE . 'test.php';
@@ -23,6 +22,7 @@ include ( MY_CONSTANT . "my_file.php" ); // Custom constant.
 require_once ( MY_CONSTANT . "my_file.php" ); // Custom constant.
 require_once( custom_function( 'test_file.php' ) ); // Custom function.
 require custom_function /* comment */ ( 'test_file.php' ); // Custom function.
+require_once(    $custom_path ); // Custom variable.
 
 // Errors.
 require_once "my_file.php"; // Not absolute path.
@@ -32,3 +32,5 @@ include( 'http://www.google.com/bad_file.php' ); // External URL.
 include_once("http://www.google.com/bad_file.php"); // External URL.
 include( 'http://www.path.com/bad.php' ); // External URL but includes keyword from $customPaths.
 require 'https://dir.com/file.php' ); // External URL but includes keyword from $customPaths.
+include( TEMPLATEPATH . 'file.php' ); // Restricted constant.
+require_once STYLESHEETPATH . "path.php"; // Restricted constant.

--- a/WordPressVIPMinimum/Tests/Files/IncludingFileUnitTest.inc
+++ b/WordPressVIPMinimum/Tests/Files/IncludingFileUnitTest.inc
@@ -4,7 +4,7 @@ function custom_function( $file ) {
 	return 'http://www.google.com/' . $file;
 }
 
-// Ok.
+// OK.
 require_once __DIR__ . "/my_file.php";
 include( __DIR__ . "/my_file.php" );
 include( locate_template('index-loop.php') );
@@ -13,6 +13,10 @@ require dirname( __FILE__, 2 ) . '/my_file.php' );
 require dirname( dirname( __FILE__ ) ) . '/my_file.php' );
 require dirname( dirname( __DIR__ ) ) . '/my_file.php' );
 require_once( get_parent_theme_file_path( '/my_file.php' ); );
+require_once(    $custom_path );
+include CUSTOM__DIR . 
+'file.php';
+include_once CUSTOMBASE . 'test.php';
 
 // Warnings.
 include ( MY_CONSTANT . "my_file.php" ); // Custom constant.
@@ -26,3 +30,5 @@ require '../my_file.php'; // Not absolute path.
 require '../../my_file.php'; // Not absolute path.
 include( 'http://www.google.com/bad_file.php' ); // External URL.
 include_once("http://www.google.com/bad_file.php"); // External URL.
+include( 'http://www.path.com/bad.php' ); // External URL but includes keyword from $customPaths.
+require 'https://dir.com/file.php' ); // External URL but includes keyword from $customPaths.

--- a/WordPressVIPMinimum/Tests/Files/IncludingFileUnitTest.php
+++ b/WordPressVIPMinimum/Tests/Files/IncludingFileUnitTest.php
@@ -31,6 +31,8 @@ class IncludingFileUnitTest extends AbstractSniffUnitTest {
 			32 => 1,
 			33 => 1,
 			34 => 1,
+			35 => 1,
+			36 => 1,
 		];
 	}
 
@@ -41,6 +43,7 @@ class IncludingFileUnitTest extends AbstractSniffUnitTest {
 	 */
 	public function getWarningList() {
 		return [
+			21 => 1,
 			22 => 1,
 			23 => 1,
 			24 => 1,

--- a/WordPressVIPMinimum/Tests/Files/IncludingFileUnitTest.php
+++ b/WordPressVIPMinimum/Tests/Files/IncludingFileUnitTest.php
@@ -24,11 +24,13 @@ class IncludingFileUnitTest extends AbstractSniffUnitTest {
 	 */
 	public function getErrorList() {
 		return [
-			24 => 1,
-			25 => 1,
-			26 => 1,
-			27 => 1,
 			28 => 1,
+			29 => 1,
+			30 => 1,
+			31 => 1,
+			32 => 1,
+			33 => 1,
+			34 => 1,
 		];
 	}
 
@@ -39,10 +41,10 @@ class IncludingFileUnitTest extends AbstractSniffUnitTest {
 	 */
 	public function getWarningList() {
 		return [
-			18 => 1,
-			19 => 1,
-			20 => 1,
-			21 => 1,
+			22 => 1,
+			23 => 1,
+			24 => 1,
+			25 => 1,
 		];
 	}
 


### PR DESCRIPTION
Fixes #407.

Takes into account for URLs and $restrictedConstants with keywords from $customPaths.