### PR TITLE
CI: fix test failure for the VIPCS VariableAnalysis sniff

### DIFF
--- a/WordPressVIPMinimum/Sniffs/Variables/VariableAnalysisSniff.php
+++ b/WordPressVIPMinimum/Sniffs/Variables/VariableAnalysisSniff.php
@@ -47,21 +47,6 @@ class VariableAnalysisSniff extends \VariableAnalysis\Sniffs\CodeAnalysis\Variab
 	];
 
 	/**
-	 * Returns an array of tokens this test wants to listen for.
-	 *
-	 * @return int[]
-	 */
-	public function register() {
-		return [
-			T_VARIABLE,
-			T_DOUBLE_QUOTED_STRING,
-			T_HEREDOC,
-			T_CLOSE_CURLY_BRACKET,
-			T_STRING,
-		];
-	}
-
-	/**
 	 * Don't use.
 	 *
 	 * @since      2.2.0 Added to allow for throwing the deprecation notices.


### PR DESCRIPTION
PR #450 deprecated the VIPCS native VariableAnalysis sniff in favour of using the upstream `VariableAnalysis` standard.

While the `process()` method - after throwing deprecation notices - would correctly hand off to the `parent::process()` method to let the upstream sniff handle throwing the errors, the `register()` method did not defer to the parent method.

This meant that the sniff would only listen to the original tokens the VIPCS native sniff was previously listening too and process those.
At the time of the switch-over, the tokens the VIPCS sniff was listening to and the tokens the VA sniff was listening to, happened to be the same.

However, in the mean time, in particularly in the VA `2.10.0` release, the tokens the VA sniff is listening to have been updated, while the VIPCS sniff was not updated to match.

In practice, that meant that the VIPCS sniff was "missing" some tokens, and therefore not receiving them to `process()`.

One of the checks affected, luckily, was covered by a unit test in the VIPCS sniff, which means we have now caught this issue, which could otherwise have remained in the codebase until the VIPCS native sniff was removed.

Fixed now by letting the (deprecated) VIPCS native version of the sniff defer to the upstream parent for the `register()` method as well (by removing the method in the VIPCS sniff so the call will fall through to the parent sniff).