### PR TITLE
Documentation: various minor improvements

### DIFF
--- a/WordPressVIPMinimum/Sniffs/Functions/CheckReturnValueSniff.php
+++ b/WordPressVIPMinimum/Sniffs/Functions/CheckReturnValueSniff.php
@@ -291,7 +291,7 @@ class CheckReturnValueSniff extends Sniff {
 	 * Function used as as callback for the array_reduce call.
 	 *
 	 * @param string $carry The final string.
-	 * @param array  $item Processed item.
+	 * @param array  $item  Processed item.
 	 *
 	 * @return string
 	 */

--- a/WordPressVIPMinimum/Sniffs/Functions/RestrictedFunctionsSniff.php
+++ b/WordPressVIPMinimum/Sniffs/Functions/RestrictedFunctionsSniff.php
@@ -396,7 +396,7 @@ class RestrictedFunctionsSniff extends AbstractFunctionRestrictionsSniff {
 				if ( isset( $skipped[ $this->tokens[ $prev ]['code'] ] ) ) {
 					return false;
 				}
-				// Skip namespaced functions, ie: \foo\bar() not \bar().
+				// Skip namespaced functions, ie: `\foo\bar()` not `\bar()`.
 				if ( $this->tokens[ $prev ]['code'] === \T_NS_SEPARATOR ) {
 					$pprev = $this->phpcsFile->findPrevious( Tokens::$emptyTokens, $prev - 1, null, true );
 					if ( $pprev !== false && $this->tokens[ $pprev ]['code'] === \T_STRING ) {

--- a/WordPressVIPMinimum/Sniffs/Hooks/AlwaysReturnInFilterSniff.php
+++ b/WordPressVIPMinimum/Sniffs/Hooks/AlwaysReturnInFilterSniff.php
@@ -122,8 +122,8 @@ class AlwaysReturnInFilterSniff extends Sniff {
 	 * Process string.
 	 *
 	 * @param int $stackPtr The position in the stack where the token was found.
-	 * @param int $start The start of the token.
-	 * @param int $end The end of the token.
+	 * @param int $start    The start of the token.
+	 * @param int $end      The end of the token.
 	 */
 	private function processString( $stackPtr, $start = 0, $end = null ) {
 
@@ -149,8 +149,8 @@ class AlwaysReturnInFilterSniff extends Sniff {
 	 * Process function.
 	 *
 	 * @param int $stackPtr The position in the stack where the token was found.
-	 * @param int $start The start of the token.
-	 * @param int $end The end of the token.
+	 * @param int $start    The start of the token.
+	 * @param int $end      The end of the token.
 	 */
 	private function processFunction( $stackPtr, $start = 0, $end = null ) {
 

--- a/WordPressVIPMinimum/Sniffs/Hooks/PreGetPostsSniff.php
+++ b/WordPressVIPMinimum/Sniffs/Hooks/PreGetPostsSniff.php
@@ -195,7 +195,7 @@ class PreGetPostsSniff extends Sniff {
 	/**
 	 * Process function's body
 	 *
-	 * @param int    $stackPtr The position in the stack where the token was found.
+	 * @param int    $stackPtr     The position in the stack where the token was found.
 	 * @param string $variableName Variable name.
 	 */
 	private function processFunctionBody( $stackPtr, $variableName ) {
@@ -363,7 +363,7 @@ class PreGetPostsSniff extends Sniff {
 	 * Is the current code a WP_Query call?
 	 *
 	 * @param int  $stackPtr The position in the stack where the token was found.
-	 * @param null $method Method.
+	 * @param null $method   Method.
 	 *
 	 * @return bool
 	 */

--- a/WordPressVIPMinimum/Sniffs/JS/StringConcatSniff.php
+++ b/WordPressVIPMinimum/Sniffs/JS/StringConcatSniff.php
@@ -65,8 +65,8 @@ class StringConcatSniff extends Sniff {
 	/**
 	 * Consolidated violation.
 	 *
-	 * @param int   $stackPtr  The position of the current token in the stack passed in $tokens.
-	 * @param array $data      Replacements for the error message.
+	 * @param int   $stackPtr The position of the current token in the stack passed in $tokens.
+	 * @param array $data     Replacements for the error message.
 	 */
 	private function addFoundError( $stackPtr, array $data ) {
 		$message = 'HTML string concatenation detected, this is a security risk, use DOM node construction or a templating language instead: %s.';

--- a/WordPressVIPMinimum/Sniffs/Performance/RegexpCompareSniff.php
+++ b/WordPressVIPMinimum/Sniffs/Performance/RegexpCompareSniff.php
@@ -18,16 +18,14 @@ class RegexpCompareSniff extends AbstractArrayAssignmentRestrictionsSniff {
 
 	/**
 	 * Groups of variables to restrict.
-	 * This should be overridden in extending classes.
 	 *
 	 * Example: groups => array(
-	 *     'wpdb' => array(
-	 *         'type'          => 'error' | 'warning',
-	 *         'message'       => 'Dont use this one please!',
-	 *         'variables'     => array( '$val', '$var' ),
-	 *         'object_vars'   => array( '$foo->bar', .. ),
-	 *         'array_members' => array( '$foo['bar']', .. ),
-	 *     )
+	 *  'groupname' => array(
+	 *      'type'     => 'error' | 'warning',
+	 *      'message'  => 'Dont use this one please!',
+	 *      'keys'     => array( 'key1', 'another_key' ),
+	 *      'callback' => array( 'class', 'method' ), // Optional.
+	 *  )
 	 * )
 	 *
 	 * @return array

--- a/WordPressVIPMinimum/Sniffs/Performance/RemoteRequestTimeoutSniff.php
+++ b/WordPressVIPMinimum/Sniffs/Performance/RemoteRequestTimeoutSniff.php
@@ -18,16 +18,14 @@ class RemoteRequestTimeoutSniff extends AbstractArrayAssignmentRestrictionsSniff
 
 	/**
 	 * Groups of variables to restrict.
-	 * This should be overridden in extending classes.
 	 *
 	 * Example: groups => array(
-	 *     'wpdb' => array(
-	 *         'type'          => 'error' | 'warning',
-	 *         'message'       => 'Dont use this one please!',
-	 *         'variables'     => array( '$val', '$var' ),
-	 *         'object_vars'   => array( '$foo->bar', .. ),
-	 *         'array_members' => array( '$foo['bar']', .. ),
-	 *     )
+	 *  'groupname' => array(
+	 *      'type'     => 'error' | 'warning',
+	 *      'message'  => 'Dont use this one please!',
+	 *      'keys'     => array( 'key1', 'another_key' ),
+	 *      'callback' => array( 'class', 'method' ), // Optional.
+	 *  )
 	 * )
 	 *
 	 * @return array

--- a/WordPressVIPMinimum/Sniffs/Security/ProperEscapingFunctionSniff.php
+++ b/WordPressVIPMinimum/Sniffs/Security/ProperEscapingFunctionSniff.php
@@ -146,7 +146,7 @@ class ProperEscapingFunctionSniff extends Sniff {
 	 * A helper function which tests whether string ends with some other.
 	 *
 	 * @param string $haystack String which is being tested.
-	 * @param string $needle The substring, which we try to locate on the end of the $haystack.
+	 * @param string $needle   The substring, which we try to locate on the end of the $haystack.
 	 *
 	 * @return bool True if haystack ends with needle.
 	 */

--- a/WordPressVIPMinimum/Sniffs/UserExperience/AdminBarRemovalSniff.php
+++ b/WordPressVIPMinimum/Sniffs/UserExperience/AdminBarRemovalSniff.php
@@ -319,7 +319,7 @@ class AdminBarRemovalSniff extends AbstractFunctionParameterSniff {
 	/**
 	 * Processes this test for T_STYLE tokens in CSS files.
 	 *
-	 * @param int $stackPtr  The position of the current token in the stack passed in $tokens.
+	 * @param int $stackPtr The position of the current token in the stack passed in $tokens.
 	 *
 	 * @return void
 	 */
@@ -370,7 +370,7 @@ class AdminBarRemovalSniff extends AbstractFunctionParameterSniff {
 	/**
 	 * Consolidated violation.
 	 *
-	 * @param int $stackPtr  The position of the current token in the stack passed in $tokens.
+	 * @param int $stackPtr The position of the current token in the stack passed in $tokens.
 	 */
 	private function addHidingDetectedError( $stackPtr ) {
 		$message = 'Hiding of the admin bar is not allowed.';

--- a/WordPressVIPMinimum/Sniffs/Variables/VariableAnalysisSniff.php
+++ b/WordPressVIPMinimum/Sniffs/Variables/VariableAnalysisSniff.php
@@ -17,7 +17,7 @@ namespace WordPressVIPMinimum\Sniffs\Variables;
 use PHP_CodeSniffer\Files\File;
 
 /**
- * Checks the for undefined function variables.
+ * Checks for undefined function variables.
  *
  * This sniff checks that all function variables
  * are defined in the function body.

--- a/tests/RulesetTest.php
+++ b/tests/RulesetTest.php
@@ -158,7 +158,7 @@ class RulesetTest {
 	/**
 	 * Process the Decoded JSON output from PHP_CodeSniffer.
 	 *
-	 * @param stdClass $output Deconded JSON output from PHP_CodeSniffer.
+	 * @param \stdClass $output Decoded JSON output from PHP_CodeSniffer.
 	 */
 	private function process_output( $output ) {
 		foreach ( $output->files as $file ) {
@@ -310,9 +310,9 @@ class RulesetTest {
 	 * Print out the message reporting found issues.
 	 *
 	 * @param int    $expected Expected number of issues.
-	 * @param string $type The type of the issue.
-	 * @param int    $number Real number of issues.
-	 * @param int    $line Line number.
+	 * @param string $type     The type of the issue.
+	 * @param int    $number   Real number of issues.
+	 * @param int    $line     Line number.
 	 */
 	private function error_warning_message( $expected, $type, $number, $line ) {
 		// phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped


### PR DESCRIPTION
... picked up along the way.

Fixes:
* A few typos.
* Alignment of parameter descriptions.
* Wrong example code for some sniffs implementing an abstract sniff.
* A warning about commented out code which would start showing once PHPCS 3.6.0 will be released.