### PR TITLE
IncludingFileSniff: add property of custom keywords to not trigger sniff

### DIFF
--- a/WordPressVIPMinimum/Tests/Files/IncludingFileUnitTest.inc
+++ b/WordPressVIPMinimum/Tests/Files/IncludingFileUnitTest.inc
@@ -26,3 +26,12 @@ require '../my_file.php'; // Not absolute path.
 require '../../my_file.php'; // Not absolute path.
 include( 'http://www.google.com/bad_file.php' ); // External URL.
 include_once("http://www.google.com/bad_file.php"); // External URL.
+
+// Allowed keywords
+include 'https://path.com/bad_file.php'; // Error - external URL with keyword from $allowedKeywords.
+require   $path; // Warning - custom variable with keyword from $allowedKeywords.
+include_once   dir_function(); // Error - custom functionm with keyword from $allowedKeywords.
+require CUSTOM_CONSTANT_DIR . 'file.php'; // OK.
+require_once ( VIPCS_PATH ) . 'file.php'; // OK.
+include_once      
+  DIR_CUSTOM , 'file.php'; // OK.

--- a/WordPressVIPMinimum/Tests/Files/IncludingFileUnitTest.php
+++ b/WordPressVIPMinimum/Tests/Files/IncludingFileUnitTest.php
@@ -29,6 +29,7 @@ class IncludingFileUnitTest extends AbstractSniffUnitTest {
 			26 => 1,
 			27 => 1,
 			28 => 1,
+			31 => 1,
 		];
 	}
 
@@ -43,6 +44,8 @@ class IncludingFileUnitTest extends AbstractSniffUnitTest {
 			19 => 1,
 			20 => 1,
 			21 => 1,
+			32 => 1,
+			33 => 1,
 		];
 	}
 


### PR DESCRIPTION
We're just doing an atomic commit for this one to solve #407 in reducing false positives.

However, the entire IncludingFileSniff needs a facelift with some breaking changes, so the work started in #626 will continue.