### PR TITLE
GH Actions: switch over to parallel linting of PHP files

### DIFF
--- a/.github/workflows/basics.yml
+++ b/.github/workflows/basics.yml
@@ -26,9 +26,6 @@ jobs:
           coverage: none
           tools: cs2pr
 
-      - name: 'Lint PHP against parse errors'
-        run: ./bin/php-lint
-
       - name: Install xmllint
         run: sudo apt-get install --no-install-recommends -y libxml2-utils
 

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -11,7 +11,45 @@ on:
   workflow_dispatch:
 
 jobs:
+  #### PHP LINT STAGE ####
+  # Linting against high/low PHP versions should catch everything.
+  # If needs be, we can always add interim versions at a later point in time.
+  lint:
+    runs-on: ubuntu-latest
+
+    strategy:
+      matrix:
+        php: ['5.4', 'latest']
+        experimental: [false]
+
+        include:
+          - php: '8.1'
+            experimental: true
+
+    name: "Lint: PHP ${{ matrix.php }}"
+    continue-on-error: ${{ matrix.experimental }}
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v2
+
+      - name: Install PHP
+        uses: shivammathur/setup-php@v2
+        with:
+          php-version: ${{ matrix.php }}
+          coverage: none
+          tools: cs2pr
+
+      - name: Install Composer dependencies
+        uses: "ramsey/composer-install@v1"
+
+      - name: Lint against parse errors
+        run: ./bin/php-lint --checkstyle | cs2pr
+
   test:
+    # No use running the tests if there is a linting error somewhere as they would fail anyway.
+    needs: lint
+
     runs-on: ubuntu-latest
 
     strategy:

--- a/bin/php-lint
+++ b/bin/php-lint
@@ -2,21 +2,9 @@
 #
 # Lint the PHP files against parse errors.
 #
-# The find utility recursively descends the directory tree for each path listed.
-#
-# find . = Start with all files in this package
-# -path ./vendor -prune = But remove those in the vendor directory
-# -o -path ./bin -prune = And remove those in the bin directory
-# -o -path ./.git -prune = And remove those in the .git directory
-# -o -name "*.php" = And only consider those with a .php extension
-# -exec php -l {} = Run PHP linter on the remaining files
-# | grep "^[Parse error|Fatal error]" = Look in the results for any parse or fatal errors.
-#
 # EXAMPLE TO RUN LOCALLY:
 #
 #   ./bin/php-lint
 #
 
-if find . -path ./vendor -prune -o -path ./bin -prune -o -path ./.git -prune -o -name "*.php" -exec php -l -f {} \; | grep "^[Errors parsing]"; then
-    exit 1;
-fi
+"$(pwd)/vendor/bin/parallel-lint" . -e php --exclude vendor --exclude .git $@

--- a/composer.json
+++ b/composer.json
@@ -22,6 +22,8 @@
 		"wp-coding-standards/wpcs": "^2.3"
 	},
 	"require-dev": {
+		"php-parallel-lint/php-parallel-lint": "^1.0",
+		"php-parallel-lint/php-console-highlighter": "^0.5",
 		"phpcompatibility/php-compatibility": "^9",
 		"phpunit/phpunit": "^4 || ^5 || ^6 || ^7"
 	},


### PR DESCRIPTION
### Composer

This installs two additional PHP packages in `require-dev`:
* [`php-parallel-lint`](https://packagist.org/packages/php-parallel-lint/php-parallel-lint) which allows for linting PHP files in parallel (faster), as well as automatically recursively walking directories.
* [`php-console-highlighter`](https://packagist.org/packages/php-parallel-lint/php-console-highlighter) which provides PHP code highlighting in the command line console, allowing the linter to display the results in a more meaningful manner.

It also adjusts the existing `bin/php-lint` script to use this new dependency instead of using *nix specific commands.

### GH Actions

As it was, PHP linting was only done on PHP 7.4 as part of the `basics` workflow.

This commit changes this to run linting on the lowest (PHP 5.4) and highest (latest/PHP 8.0) supported PHP versions as part of the `test` workflow. (And by "supported", I mean _runtime_ support in this case, not _syntax support_.)

The running of the tests has been made dependent on the linting jobs passing as if the linting turns up failures, we can be sure that there will be (or should be) failures in the test runs anyway.

This new job uses the "CS2PR" tool which will show any errors as feedback in the actual PR code view.

It also runs the linter against PHP 8.1 - against which we are currently not yet running the tests - as an early warning system in case of upcoming issues.

Ref:
* https://github.com/php-parallel-lint/PHP-Parallel-Lint/releases/tag/v1.3.0
* https://github.com/php-parallel-lint/PHP-Console-Highlighter/releases/tag/v0.5

Related to #628