### PR TITLE
LowExpiryCacheTime: improve handling of potential parse errors in eval-ed code

### DIFF
--- a/WordPressVIPMinimum/Tests/Performance/LowExpiryCacheTimeUnitTest.php
+++ b/WordPressVIPMinimum/Tests/Performance/LowExpiryCacheTimeUnitTest.php
@@ -55,6 +55,7 @@ class LowExpiryCacheTimeUnitTest extends AbstractSniffUnitTest {
 			77  => 1,
 			78  => 1,
 			79  => 1,
+			82  => ( PHP_VERSION_ID > 50600 ) ? 0 : 1,
 			88  => 1,
 			94  => 1,
 			95  => 1,


### PR DESCRIPTION
Issue reported by @GaryJones in https://github.com/Automattic/VIP-Coding-Standards/issues/628#issuecomment-790653774

In rare cases, it is possible that the call to `eval()` with "safe" tokens only, would still result in a parse error.

An example of such a case is when the PHP 5.6 `**` (`T_POW`) operator is used. PHPCS backfills the tokenization, which means that the operator is correctly recognized by the sniff as a "safe" token to use in the `eval()` statement.

However, when the sniff is being run on PHP 5.4/5.5, the `eval()` will also be run on PHP 5.4/5.5 and while PHPCS backfills the token, PHP does not, resulting in a parse error in the `eval`-ed code, upon which the `eval()` will return `false`.

This commit:
* Silences the parse error notice.
* Checks the output of the `eval()` for it being boolean `false` and if so, flags the statement for manual inspection, same as when any "non-safe" token is encountered.