### PR TITLE
QA: remove redundant PHPCS ignore annotations

### DIFF
--- a/WordPress-VIP-Go/ruleset-test.php
+++ b/WordPress-VIP-Go/ruleset-test.php
@@ -342,7 +342,6 @@ require __DIR__ . '/../tests/RulesetTest.php';
 // Run the tests!
 $test = new RulesetTest( 'WordPress-VIP-Go', $expected );
 if ( $test->passes() ) {
-	// phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped
 	printf( 'All WordPress-VIP-Go tests passed!' . PHP_EOL );
 	exit( 0 );
 }

--- a/WordPressVIPMinimum/ruleset-test.inc
+++ b/WordPressVIPMinimum/ruleset-test.inc
@@ -443,7 +443,7 @@ add_filter( 'robots_txt', function() { // Warning.
 } );
 
 // WordPressVIPMinimum.Performance.BatcacheWhitelistedParams
-// phpcs:ignore WordPress.Security.NonceVerification.NoNonceVerification,WordPress.Security.ValidatedSanitizedInput.InputNotValidated
+// phpcs:ignore WordPress.Security.ValidatedSanitizedInput.InputNotValidated
 $test = sanitize_text_field( $_GET["utm_medium"] ); // Warning.
 
 // WordPressVIPMinimum.Performance.CacheValueOverride

--- a/WordPressVIPMinimum/ruleset-test.php
+++ b/WordPressVIPMinimum/ruleset-test.php
@@ -323,7 +323,7 @@ require __DIR__ . '/../tests/RulesetTest.php';
 // Run the tests!
 $test = new RulesetTest( 'WordPressVIPMinimum', $expected );
 if ( $test->passes() ) {
-	printf( 'All WordPressVIPMinimum tests passed!' . PHP_EOL ); // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped
+	printf( 'All WordPressVIPMinimum tests passed!' . PHP_EOL );
 	exit( 0 );
 }
 

--- a/tests/RulesetTest.php
+++ b/tests/RulesetTest.php
@@ -92,7 +92,7 @@ class RulesetTest {
 		// Travis and Windows support.
 		$phpcs_bin = getenv( 'PHPCS_BIN' );
 		if ( $phpcs_bin === false ) {
-			// phpcs:ignore
+			// phpcs:ignore WordPress.PHP.DiscouragedPHPFunctions.runtime_configuration_putenv -- This is test code, not production.
 			putenv( 'PHPCS_BIN=phpcs' );
 		} else {
 			$this->phpcs_bin = realpath( $phpcs_bin );
@@ -101,7 +101,6 @@ class RulesetTest {
 		$output = $this->collect_phpcs_result();
 
 		if ( ! is_object( $output ) || empty( $output ) ) {
-			// phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped
 			printf( 'The PHPCS command checking the ruleset hasn\'t returned any issues. Bailing ...' . PHP_EOL );
 			exit( 1 ); // Die early, if we don't have any output.
 		}
@@ -149,7 +148,7 @@ class RulesetTest {
 			$this->phpcs_bin,
 			$this->ruleset
 		);
-		// phpcs:ignore
+		// phpcs:ignore WordPress.PHP.DiscouragedPHPFunctions.system_calls_shell_exec -- This is test code, not production.
 		$output = shell_exec( $shell );
 
 		return json_decode( $output );


### PR DESCRIPTION
... and make two others more specific.

These ignore annotations have become redundant due to a combination of changes to the rulesets and upstream fixes.