### PR TITLE
GH Actions: always check that all sniffs are feature complete

### DIFF
--- a/.github/workflows/basics.yml
+++ b/.github/workflows/basics.yml
@@ -57,3 +57,9 @@ jobs:
 
       - name: Show PHPCS results in PR
         run: cs2pr ./phpcs-report.xml
+
+      # Check that the sniffs available are feature complete.
+      # For now, just check that all sniffs have unit tests.
+      # At a later stage the documentation check can be activated.
+      - name: Check sniff feature completeness
+        run: composer check-complete

--- a/composer.json
+++ b/composer.json
@@ -25,6 +25,7 @@
 		"php-parallel-lint/php-parallel-lint": "^1.0",
 		"php-parallel-lint/php-console-highlighter": "^0.5",
 		"phpcompatibility/php-compatibility": "^9",
+		"phpcsstandards/phpcsdevtools": "^1.0",
 		"phpunit/phpunit": "^4 || ^5 || ^6 || ^7"
 	},
 	"scripts": {
@@ -37,11 +38,15 @@
 		"phpcs": "bin/phpcs",
 		"phpunit": "bin/unit-tests",
 		"coverage": "bin/unit-tests-coverage",
+		"check-complete": [
+			"@php ./vendor/phpcsstandards/phpcsdevtools/bin/phpcs-check-feature-completeness -q ./WordPressVIPMinimum"
+		],
 		"test": [
 			"@lint",
 			"@ruleset",
 			"@phpunit",
-			"@phpcs"
+			"@phpcs",
+			"@check-complete"
 		]
 	},
 	"support": {


### PR DESCRIPTION
The `phpcsstandards/phpcsdevtools` package includes a script which can check whether sniffs are feature complete, i.e. whether all sniffs have unit tests and documentation.

By adding this check to the `basics` GH Actions workflow, we prevent untested and/or undocumented sniffs from entering the repo.

For now, the documentation check is silenced.

P.S.: the `PHPCSDevTools` package contains a few more goodies which having the package (dev-)required now make available to developers, like the `PHPCSDebug` standard to get detailed information about the tokens in a file.
Have a look at the package [readme](https://github.com/PHPCSStandards/PHPCSDevTools) for more information.

Related to #628