### PR TITLE
ProperEscapingFunction: improve "action" match precision

### DIFF
--- a/WordPressVIPMinimum/Sniffs/Security/ProperEscapingFunctionSniff.php
+++ b/WordPressVIPMinimum/Sniffs/Security/ProperEscapingFunctionSniff.php
@@ -23,7 +23,7 @@ class ProperEscapingFunctionSniff extends Sniff {
 	 *
 	 * @var string
 	 */
-	const ATTR_END_REGEX = '`(?<attrname>href|src|url|\s+action)?=(?:(?:\\\\)?["\'])?$`i';
+	const ATTR_END_REGEX = '`(?<attrname>href|src|url|(^|\s+)action)?=(?:\\\\)?["\']*$`i';
 
 	/**
 	 * List of escaping functions which are being tested.

--- a/WordPressVIPMinimum/Sniffs/Security/ProperEscapingFunctionSniff.php
+++ b/WordPressVIPMinimum/Sniffs/Security/ProperEscapingFunctionSniff.php
@@ -57,6 +57,39 @@ class ProperEscapingFunctionSniff extends Sniff {
 	];
 
 	/**
+	 * List of attributes associated with url outputs.
+	 *
+	 * @deprecated 2.3.1 Currently unused by the sniff, but needed for
+	 *                   for public methods which extending sniffs may be
+	 *                   relying on.
+	 *
+	 * @var array
+	 */
+	private $url_attrs = [
+		'href',
+		'src',
+		'url',
+		'action',
+	];
+
+	/**
+	 * List of syntaxes for inside attribute detection.
+	 *
+	 * @deprecated 2.3.1 Currently unused by the sniff, but needed for
+	 *                   for public methods which extending sniffs may be
+	 *                   relying on.
+	 *
+	 * @var array
+	 */
+	private $attr_endings = [
+		'=',
+		'="',
+		"='",
+		"=\\'",
+		'=\\"',
+	];
+
+	/**
 	 * Returns an array of tokens this test wants to listen for.
 	 *
 	 * @return array
@@ -131,6 +164,48 @@ class ProperEscapingFunctionSniff extends Sniff {
 			$this->phpcsFile->addError( $message, $stackPtr, 'htmlAttrNotByEscHTML', $data );
 			return;
 		}
+	}
+
+	/**
+	 * Tests whether provided string ends with open attribute which expects a URL value.
+	 *
+	 * @deprecated 2.3.1
+	 *
+	 * @param string $content Haystack in which we look for an open attribute which exects a URL value.
+	 *
+	 * @return bool True if string ends with open attribute which expects a URL value.
+	 */
+	public function attr_expects_url( $content ) {
+		$attr_expects_url = false;
+		foreach ( $this->url_attrs as $attr ) {
+			foreach ( $this->attr_endings as $ending ) {
+				if ( $this->endswith( $content, $attr . $ending ) === true ) {
+					$attr_expects_url = true;
+					break;
+				}
+			}
+		}
+		return $attr_expects_url;
+	}
+
+	/**
+	 * Tests whether provided string ends with open HMTL attribute.
+	 *
+	 * @deprecated 2.3.1
+	 *
+	 * @param string $content Haystack in which we look for open HTML attribute.
+	 *
+	 * @return bool True if string ends with open HTML attribute.
+	 */
+	public function is_html_attr( $content ) {
+		$is_html_attr = false;
+		foreach ( $this->attr_endings as $ending ) {
+			if ( $this->endswith( $content, $ending ) === true ) {
+				$is_html_attr = true;
+				break;
+			}
+		}
+		return $is_html_attr;
 	}
 
 	/**

--- a/WordPressVIPMinimum/Tests/Security/ProperEscapingFunctionUnitTest.inc
+++ b/WordPressVIPMinimum/Tests/Security/ProperEscapingFunctionUnitTest.inc
@@ -38,9 +38,9 @@ echo 'data-param-url="' . Esc_HTML( $share_url ) . '"'; // Error.
 
 ?>
 
-<form method="post" action="<?php echo esc_html(admin_url('admin.php?page='.$base_name.'&amp;mode=logs&amp;id='.$poll_id)); ?>">
-
-
+<form method="post" action="<?php echo esc_html(admin_url('admin.php?page='.$base_name.'&amp;mode=logs&amp;id='.$poll_id)); ?>"><!-- Error. -->
+<input data-action="<?php echo esc_attr( $my_var ); ?>"><!-- OK. -->
+<a href='https://demo.com?foo=bar&my-action=<?php echo esc_attr( $var ); ?>'>link</a><!-- OK. -->
 
 <a href="#link"><?php echo esc_attr( 'testing' ); // Error.
 ?> </a>

--- a/WordPressVIPMinimum/Tests/Security/ProperEscapingFunctionUnitTest.inc
+++ b/WordPressVIPMinimum/Tests/Security/ProperEscapingFunctionUnitTest.inc
@@ -85,3 +85,13 @@ echo 'data-param-url="' . Esc_HTML::static_method( $share_url ) . '"'; // OK.
 
 // Not a target for this sniff (yet).
 printf( '<meta name="generator" content="%s">', esc_attr( $content ) ); // OK.
+?>
+
+// Making sure tabs and new lines before "action" are handled correctly.
+<input class="something something-else something-more"
+	action="<?php echo esc_attr( $my_var ); ?>"><!-- Error. -->
+<?php
+echo '<input class="something something-else something-more"
+	action="', esc_url( $my_var ), '">'; // OK.
+echo '<input class="something something-else something-more"
+action="', esc_attr( $my_var ), '">'; // Error.

--- a/WordPressVIPMinimum/Tests/Security/ProperEscapingFunctionUnitTest.php
+++ b/WordPressVIPMinimum/Tests/Security/ProperEscapingFunctionUnitTest.php
@@ -53,6 +53,8 @@ class ProperEscapingFunctionUnitTest extends AbstractSniffUnitTest {
 			79 => 1,
 			80 => 1,
 			82 => 1,
+			92 => 1,
+			97 => 1,
 		];
 	}
 


### PR DESCRIPTION
In VIPCS 2.2.0, checking for the use of `esc_url()` for "action" HTML attributes was introduced in PR #575 in response to issue #554.

As it is not inconceivable that "action" is used as a suffix for custom HTML attributes - like "data-action"- for which the value does not necessarily has to be a URL, the check for the "action" HTML attribute should make sure it is the complete attribute name and not used as a suffix for a custom attribute name.

This change contains a minor refactor of the code which examines the content of the previous text string.

Instead of looping over the various lists and doing a `substr()` on the same content 25 times, it will now use a regular expression to gather the necessary information to throw the right errors in one go.

Includes unit tests.

Fixes #669

Note: This PR removes two `private` properties which were introduced in #624/VIPCS 2.3.0 and two `public` methods.

The removal of the properties is safe. The removal of the `public` methods could be considered a BC-break as these methods were `public`, though they never should have been.

If so preferred, the `public` methods could be deprecated instead and remain in the code base as dead code/emptied out methods until the next major release upon which they could be removed.

---

## New commits since pulling

### ProperEscapingFunction: fine-tune attribute regex

This adds test cases with:
* No space before "action" as it is at the start of the line in a multi-line text string.
* A tab before "action".

... and makes minor adjustments to the regex to safeguard handling these cases correctly.

### ProperEscapingFunction: deprecate, don't remove

... the `public` methods and as those use the `private` properties and extending sniffs may rely on the functionality of the `public` methods, we can't removed the `private` properties yet either, so deprecating those too.