### PR TITLE
ProperEscapingFunction: further improve attribute matching

### DIFF
--- a/WordPressVIPMinimum/Sniffs/Security/ProperEscapingFunctionSniff.php
+++ b/WordPressVIPMinimum/Sniffs/Security/ProperEscapingFunctionSniff.php
@@ -23,7 +23,7 @@ class ProperEscapingFunctionSniff extends Sniff {
 	 *
 	 * @var string
 	 */
-	const ATTR_END_REGEX = '`(?<attrname>href|src|url|(^|\s+)action)?=(?:\\\\)?["\']*$`i';
+	const ATTR_END_REGEX = '`(?<attrname>href|src|url|(^|\s+)action)?(?<=[a-z0-9_-])=(?:\\\\)?["\']*$`i';
 
 	/**
 	 * List of escaping functions which are being tested.

--- a/WordPressVIPMinimum/Tests/Security/ProperEscapingFunctionUnitTest.inc
+++ b/WordPressVIPMinimum/Tests/Security/ProperEscapingFunctionUnitTest.inc
@@ -106,3 +106,10 @@ echo '<a href="',  esc_html($url), '">'; // Error.
 <div>html</div>
 <?= '<h1 class="', esc_attr( $test ), '">'; ?><!-- OK -->
 <div>html</div>
+
+// Issue #680 - only match = when preceeded by something which could be an HTML attribute.
+<option value="<?php echo esc_attr( $i ); ?>" <?php echo ( $filter_importance === $i ) ? 'selected' : ''; ?> >
+	&gt;=<?php echo esc_html( $i ); ?>
+</option>
+
+<A HREF="<?= esc_url($url) ?>" data-num2=<?= esc_attr( $num2 )><?php echo esc_html( $link ); ?><a/>


### PR DESCRIPTION
Prior to VIPCS 2.3.0, equal signs not followed by quotes were ignored by this sniff, even though unquoted values for attributes in HTML is supported as long as the value does not contain whitespace.

However, detecting equal signs not followed by quotes could confuse the attribute detecting as equal signs without quotes can also be used outside of HTML attribute context.

This improves the attribute detection further by making sure that an equal sign (with or without subsequent quotes) is preceded by at least one alphanumeric character to indicate it _could_ be an HTML attribute.

Includes tests.

Fixes #680