### PR TITLE
Update WordPress-VIP-Go/ruleset.xml to configure VariableAnalysis

### DIFF
--- a/WordPress-VIP-Go/ruleset.xml
+++ b/WordPress-VIP-Go/ruleset.xml
@@ -252,8 +252,7 @@
 		<severity>0</severity>
 	</rule>
 
-	<!-- Do not report on undefined variables before require nor
-	     in file scope. See discussion here: https://github.com/Automattic/vip-go-ci/issues/120 --> 
+	<!-- Do not report on undefined variables before require nor in file scope. -->
 	<rule ref="VariableAnalysis.CodeAnalysis.VariableAnalysis">
 		<properties>
 			<property name="allowUnusedVariablesBeforeRequire" value="true"/>

--- a/WordPress-VIP-Go/ruleset.xml
+++ b/WordPress-VIP-Go/ruleset.xml
@@ -251,6 +251,16 @@
 	<rule ref="VariableAnalysis.CodeAnalysis.VariableAnalysis.UnusedVariable">
 		<severity>0</severity>
 	</rule>
+
+	<!-- Do not report on undefined variables before require nor
+	     in file scope. See discussion here: https://github.com/Automattic/vip-go-ci/issues/120 --> 
+	<rule ref="VariableAnalysis.CodeAnalysis.VariableAnalysis">
+		<properties>
+			<property name="allowUnusedVariablesBeforeRequire" value="true"/>
+			<property name="allowUndefinedVariablesInFileScope" value="true"/>
+		</properties>
+	</rule>
+
 	<rule ref="WordPress.DB.SlowDBQuery.slow_db_query_meta_key">
 		<!-- We are silencing this one because VIP Go has a combined index on meta_key, meta_value-->
 		<severity>0</severity>


### PR DESCRIPTION
This patch will configure `VariableAnalysis` for `WordPress-VIP-Go` so not to report on undefined variables under certain circumstances. To quote [an issue reported](https://github.com/Automattic/vip-go-ci/issues/120) for `vip-go-ci`:

> When template partials are require'd from within a class, then the partial may use $this->... to insert display a value. At PHP runtime, it works, but for PHPCS analysis, it sees a PHP file with an undefined $this and so reports it via the VariableAnalysis package. Technically it's correct, and while it could be ignored, it's not practical or desirable to do that.

This patch will accomplish this, reducing noise a bit for our end-users.

See [here for more discussion](https://github.com/Automattic/vip-go-ci/issues/120).

## Details on testing

The following code was put into a file:

```
<?php
// Example foo.php template.
 
// Set defaults.
$args = wp_parse_args(
    $args,
    array(
        'class'          => '',
        'arbitrary_data' => array(
            'foo' => 'fooval',
            'bar' => false,
        )
    )
);
?>
 
<div class="widget <?php echo esc_html_class( $args['class'] ); ?>">
    <?php echo esc_html( $args['arbitrary_data']['foo'] ); ?>
</div>
```

And `phpcs` run with the patch applied:

> ./phpcs/bin/phpcs --severity=1 --standard=WordPress-VIP-GO,PHPCompatibilityWP /tmp/file10.php

```
--------------------------------------------------------------------------------------------------------------------------------------------------------------
FOUND 1 ERROR AFFECTING 1 LINE
--------------------------------------------------------------------------------------------------------------------------------------------------------------
 17 | ERROR | All output should be run through an escaping function (see the Security sections in the WordPress Developer Handbooks), found 'esc_html_class'.
--------------------------------------------------------------------------------------------------------------------------------------------------------------
```

With the patch removed, this warning here is added to the results:

```
  6 | WARNING | Variable $args is undefined.

```

The same pattern was seen with this code here, using the same command:

```
<?php
// Example foo.php template.

if ( ! empty( $this->vars['video-id'] ) ) {
	echo '<video...></video>';
}

echo time();
```

With the patch applied, this was reported:

```
---------------------------------------------------------------------------------------------------------------------------------------------------
FOUND 1 ERROR AFFECTING 1 LINE
---------------------------------------------------------------------------------------------------------------------------------------------------
 8 | ERROR | All output should be run through an escaping function (see the Security sections in the WordPress Developer Handbooks), found 'time'.
---------------------------------------------------------------------------------------------------------------------------------------------------
```

and without the patch, this was added:

```
 4 | WARNING | Variable $this is undefined.
```
