### PR TITLE
Bump VA to 2.11.1

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -17,7 +17,7 @@
 	"require": {
 		"php": ">=5.4",
 		"dealerdirect/phpcodesniffer-composer-installer": "^0.4.1 || ^0.5 || ^0.6.2 || ^0.7",
-		"sirbrillig/phpcs-variable-analysis": "^2.8.3",
+		"sirbrillig/phpcs-variable-analysis": "^2.11.1",
 		"squizlabs/php_codesniffer": "^3.5.5",
 		"wp-coding-standards/wpcs": "^2.3"
 	},


### PR DESCRIPTION
As per https://github.com/Automattic/VIP-Coding-Standards/pull/690#issuecomment-864321421, we want to bump VA to include the recent fixes.