### PR TITLE
PHPCS: enable caching

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@ composer.lock
 phpcs.xml
 .phpcs.xml
 phpunit.xml
+phpcs.cache

--- a/.phpcs.xml.dist
+++ b/.phpcs.xml.dist
@@ -13,6 +13,9 @@
 	<arg name="extensions" value="php"/>
 	<arg name="parallel" value="50"/>
 
+	<!-- Cache the results between runs. -->
+	<arg name="cache" value="./phpcs.cache"/>
+
 	<rule ref="WordPress-Extra">
 		<exclude name="WordPress.Files.FileName"/>
 		<exclude name="WordPress.NamingConventions.ValidVariableName"/>


### PR DESCRIPTION
... to allow for faster scan results when scanning the VIPCS repo code itself.

The cache will automatically be invalidated when anything which is relevant changes.