### PR TITLE
CI: various updates

### DIFF
--- a/.github/workflows/basics.yml
+++ b/.github/workflows/basics.yml
@@ -10,6 +10,12 @@ on:
   # Allow manually triggering the workflow.
   workflow_dispatch:
 
+# Cancels all previous workflow runs for the same branch that have not yet completed.
+concurrency:
+  # The concurrency group contains the workflow name and the branch name.
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   checkcs:
     name: 'Basic CS and QA checks'

--- a/.github/workflows/basics.yml
+++ b/.github/workflows/basics.yml
@@ -46,12 +46,12 @@ jobs:
 
       - name: 'Composer: adjust dependencies'
         # Using PHPCS `master` as an early detection system for bugs upstream.
-        run: composer require --no-update --no-scripts squizlabs/php_codesniffer:"dev-master"
+        run: composer require --no-update --no-scripts squizlabs/php_codesniffer:"dev-master" --no-interaction
 
       # Install dependencies and handle caching in one go.
       # @link https://github.com/marketplace/actions/install-composer-dependencies
       - name: Install Composer dependencies
-        uses: "ramsey/composer-install@v1"
+        uses: "ramsey/composer-install@v2"
 
       - name: 'Validate XML against schema and check code style'
         run: ./bin/xml-lint

--- a/.github/workflows/quicktest.yml
+++ b/.github/workflows/quicktest.yml
@@ -10,6 +10,12 @@ on:
   # Allow manually triggering the workflow.
   workflow_dispatch:
 
+# Cancels all previous workflow runs for the same branch that have not yet completed.
+concurrency:
+  # The concurrency group contains the workflow name and the branch name.
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   #### QUICK TEST STAGE ####
   # This is a much quicker test which only runs the unit tests and linting against the low/high

--- a/.github/workflows/quicktest.yml
+++ b/.github/workflows/quicktest.yml
@@ -50,7 +50,7 @@ jobs:
           if [[ "${{ matrix.phpcs_version }}" != "dev-master" ]]; then
             echo '::set-output name=PHP_INI::error_reporting=E_ALL & ~E_DEPRECATED'
           else
-            echo '::set-output name=PHP_INI::error_reporting=E_ALL'
+            echo '::set-output name=PHP_INI::error_reporting=-1'
           fi
 
       - name: Install PHP

--- a/.github/workflows/quicktest.yml
+++ b/.github/workflows/quicktest.yml
@@ -37,12 +37,11 @@ jobs:
             phpcs_version: 'dev-master'
             wpcs_version: '2.3.*'
           - php: 'latest'
-            # PHPCS 3.5.7 is the lowest version of PHPCS which supports PHP 8.0.
-            phpcs_version: '3.5.7'
+            # PHPCS 3.6.1 is the lowest version of PHPCS which supports PHP 8.1.
+            phpcs_version: '3.6.1'
             wpcs_version: '2.3.*'
 
     name: "QTest${{ matrix.phpcs_version == 'dev-master' && ' + Lint' || '' }}: PHP ${{ matrix.php }} - PHPCS ${{ matrix.phpcs_version }}"
-
 
     steps:
       - name: Checkout code
@@ -50,10 +49,13 @@ jobs:
 
       # On stable PHPCS versions, allow for PHP deprecation notices.
       # Unit tests don't need to fail on those for stable releases where those issues won't get fixed anymore.
+      # Note: the "elif" condition is temporary and should be removed once VIPCS updates to WPCS 3.0+.
       - name: Setup ini config
         id: set_ini
         run: |
           if [[ "${{ matrix.phpcs_version }}" != "dev-master" ]]; then
+            echo '::set-output name=PHP_INI::error_reporting=E_ALL & ~E_DEPRECATED'
+          elif [[ "${{ matrix.php }}" == "latest" ]]; then
             echo '::set-output name=PHP_INI::error_reporting=E_ALL & ~E_DEPRECATED'
           else
             echo '::set-output name=PHP_INI::error_reporting=-1'
@@ -89,8 +91,13 @@ jobs:
         if: matrix.phpcs_version == 'dev-master'
         run: ./bin/php-lint
 
-      - name: Run the unit tests
+      - name: Run the unit tests - PHP 5.4 - 8.0
+        if: matrix.php != 'latest'
         run: ./bin/unit-tests
+
+      - name: Run the unit tests - PHP > 8.1
+        if: matrix.php == 'latest'
+        run: vendor/bin/phpunit --filter WordPressVIPMinimum ./vendor/squizlabs/php_codesniffer/tests/AllTests.php --no-coverage --no-configuration --bootstrap=./tests/bootstrap.php --dont-report-useless-tests
 
       - name: Run the ruleset tests
         run: ./bin/ruleset-tests

--- a/.github/workflows/quicktest.yml
+++ b/.github/workflows/quicktest.yml
@@ -70,20 +70,20 @@ jobs:
 
       - name: 'Composer: set PHPCS and WPCS versions for tests'
         run: |
-          composer require --no-update --no-scripts squizlabs/php_codesniffer:"${{ matrix.phpcs_version }}"
-          composer require --no-update --no-scripts wp-coding-standards/wpcs:"${{ matrix.wpcs_version }}"
+          composer require --no-update --no-scripts squizlabs/php_codesniffer:"${{ matrix.phpcs_version }}" --no-interaction
+          composer require --no-update --no-scripts wp-coding-standards/wpcs:"${{ matrix.wpcs_version }}" --no-interaction
 
       # Install dependencies and handle caching in one go.
       # @link https://github.com/marketplace/actions/install-composer-dependencies
       - name: Install Composer dependencies - normal
         if: ${{ startsWith( matrix.php, '8' ) == false && matrix.php != 'latest' }}
-        uses: "ramsey/composer-install@v1"
+        uses: "ramsey/composer-install@v2"
 
       # PHPUnit 7.x does not allow for installation on PHP 8, so ignore platform
       # requirements to get PHPUnit 7.x to install on nightly.
       - name: Install Composer dependencies - with ignore platform
         if: ${{ startsWith( matrix.php, '8' ) || matrix.php == 'latest' }}
-        uses: "ramsey/composer-install@v1"
+        uses: "ramsey/composer-install@v2"
         with:
           composer-options: --ignore-platform-reqs
 

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -27,15 +27,10 @@ jobs:
 
     strategy:
       matrix:
-        php: ['5.4', 'latest']
-        experimental: [false]
-
-        include:
-          - php: '8.1'
-            experimental: true
+        php: ['5.4', 'latest', '8.2']
 
     name: "Lint: PHP ${{ matrix.php }}"
-    continue-on-error: ${{ matrix.experimental }}
+    continue-on-error: ${{ matrix.php == '8.2' }}
 
     steps:
       - name: Checkout code
@@ -89,8 +84,19 @@ jobs:
             wpcs_version: '2.3.*'
             experimental: false
 
+          # Complete the matrix by adding PHP 8.1, but only test against compatible PHPCS versions.
+          - php: '8.1'
+            phpcs_version: 'dev-master'
+            wpcs_version: '2.3.*'
+            experimental: false
+          - php: '8.1'
+            # PHPCS 3.6.1 is the lowest version of PHPCS which supports PHP 8.1.
+            phpcs_version: '3.6.1'
+            wpcs_version: '2.3.*'
+            experimental: false
+
           # Experimental builds. These are allowed to fail.
-          #- php: '8.1'
+          #- php: '8.2'
           #  phpcs_version: 'dev-master'
           #  wpcs_version: '2.3.*'
           #  experimental: true
@@ -105,10 +111,13 @@ jobs:
 
       # On stable PHPCS versions, allow for PHP deprecation notices.
       # Unit tests don't need to fail on those for stable releases where those issues won't get fixed anymore.
+      # Note: the "elif" condition is temporary and should be removed once VIPCS updates to WPCS 3.0+.
       - name: Setup ini config
         id: set_ini
         run: |
           if [[ "${{ matrix.phpcs_version }}" != "dev-master" ]]; then
+            echo '::set-output name=PHP_INI::error_reporting=E_ALL & ~E_DEPRECATED'
+          elif [[ "${{ matrix.php }}" == "8.1" ]]; then
             echo '::set-output name=PHP_INI::error_reporting=E_ALL & ~E_DEPRECATED'
           else
             echo '::set-output name=PHP_INI::error_reporting=-1'
@@ -140,8 +149,13 @@ jobs:
         with:
           composer-options: --ignore-platform-reqs
 
-      - name: Run the unit tests
+      - name: Run the unit tests - PHP 5.4 - 8.0
+        if: matrix.php < '8.1'
         run: ./bin/unit-tests
+
+      - name: Run the unit tests - PHP > 8.1
+        if: matrix.php >= '8.1'
+        run: vendor/bin/phpunit --filter WordPressVIPMinimum ./vendor/squizlabs/php_codesniffer/tests/AllTests.php --no-coverage --no-configuration --bootstrap=./tests/bootstrap.php --dont-report-useless-tests
 
       - name: Run the ruleset tests
         run: ./bin/ruleset-tests

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -44,7 +44,7 @@ jobs:
           tools: cs2pr
 
       - name: Install Composer dependencies
-        uses: "ramsey/composer-install@v1"
+        uses: "ramsey/composer-install@v2"
 
       - name: Lint against parse errors
         run: ./bin/php-lint --checkstyle | cs2pr
@@ -132,20 +132,20 @@ jobs:
 
       - name: 'Composer: set PHPCS and WPCS versions for tests'
         run: |
-          composer require --no-update --no-scripts squizlabs/php_codesniffer:"${{ matrix.phpcs_version }}"
-          composer require --no-update --no-scripts wp-coding-standards/wpcs:"${{ matrix.wpcs_version }}"
+          composer require --no-update --no-scripts squizlabs/php_codesniffer:"${{ matrix.phpcs_version }}" --no-interaction
+          composer require --no-update --no-scripts wp-coding-standards/wpcs:"${{ matrix.wpcs_version }}" --no-interaction
 
       # Install dependencies and handle caching in one go.
       # @link https://github.com/marketplace/actions/install-composer-dependencies
       - name: Install Composer dependencies - normal
         if: ${{ startsWith( matrix.php, '8' ) == false }}
-        uses: "ramsey/composer-install@v1"
+        uses: "ramsey/composer-install@v2"
 
       # PHPUnit 7.x does not allow for installation on PHP 8, so ignore platform
       # requirements to get PHPUnit 7.x to install on nightly.
       - name: Install Composer dependencies - with ignore platform
         if: ${{ startsWith( matrix.php, '8' ) }}
-        uses: "ramsey/composer-install@v1"
+        uses: "ramsey/composer-install@v2"
         with:
           composer-options: --ignore-platform-reqs
 

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -105,7 +105,7 @@ jobs:
           if [[ "${{ matrix.phpcs_version }}" != "dev-master" ]]; then
             echo '::set-output name=PHP_INI::error_reporting=E_ALL & ~E_DEPRECATED'
           else
-            echo '::set-output name=PHP_INI::error_reporting=E_ALL'
+            echo '::set-output name=PHP_INI::error_reporting=-1'
           fi
 
       - name: Install PHP

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -12,6 +12,12 @@ on:
   # Allow manually triggering the workflow.
   workflow_dispatch:
 
+# Cancels all previous workflow runs for the same branch that have not yet completed.
+concurrency:
+  # The concurrency group contains the workflow name and the branch name.
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   #### PHP LINT STAGE ####
   # Linting against high/low PHP versions should catch everything.

--- a/composer.json
+++ b/composer.json
@@ -28,6 +28,11 @@
 		"phpcsstandards/phpcsdevtools": "^1.0",
 		"phpunit/phpunit": "^4 || ^5 || ^6 || ^7"
 	},
+	"config": {
+		"allow-plugins": {
+			"dealerdirect/phpcodesniffer-composer-installer": true
+		}
+	},
 	"scripts": {
 		"install-codestandards": "Dealerdirect\\Composer\\Plugin\\Installers\\PHPCodeSniffer\\Plugin::run",
 		"ruleset": "bin/ruleset-tests",


### PR DESCRIPTION
### Composer: allow the PHPCS plugin

The `dealerdirect/phpcodesniffer-composer-installer` Composer plugin is used to register external PHPCS standards with PHPCS.

As of Composer 2.2.0, Composer plugins need to be explicitly allowed to run. This adds the necessary configuration for that.

Refs:
* https://blog.packagist.com/composer-2-2/#more-secure-plugin-execution

### GH Actions: use error_reporting=-1

... for bridging differences in `E_ALL` across PHP versions.

### GH Actions: auto-cancel previous builds for same branch

Previously, in Travis, when the same branch was pushed again and the "Auto cancellation" option on the "Settings" page had been turned on (as it was for most repos), any still running builds for the same branch would be stopped in favour of starting the build for the newly pushed version of the branch.

To enable this behaviour in GH Actions, a `concurrency` configuration needs to be added to each workflow for which this should applied to.

More than anything, this is a way to be kind to GitHub by not wasting resources which they so kindly provide to us for free.

Refs:
* https://github.blog/changelog/2021-04-19-github-actions-limit-workflow-run-or-job-concurrency/
* https://docs.github.com/en/actions/learn-github-actions/workflow-syntax-for-github-actions#concurrency

### GH Actions: update for the release of PHP 8.1

PHP `latest` from SetupPHP is now PHP 8.1 and the earliest PHPCS version which is (runtime) compatible with PHP 8.1 is PHPCS 3.6.1.

This commit makes the necessary adjustments to the test matrix in both the `quicktest` and the `test` workflows to account for that.

Notes:
* Includes minor simplification of the "lint" matrix and `continue-on-error` setting.
* Linting against PHP 8.2 has been turned on (allowed to fail), testing against PHP 8.2 is still disabled for now as it's still quite far away.
* As the tests are based on the PHPCS native test framework and this framework still limits the PHPUnit versions to PHPUnit 4.x - 7.x, some tweaks are needed to get the tests running on PHP 8.1 as the reading of the PHPUnit configuration file by PHPUnit would yield a fatal error otherwise.
* The latest release of WPCS throws a few PHP deprecation notices on PHP 8.1. These have been fixed upstream already and the fixes will be included in WPCS 3.0.0.
    Until WPCS 3.0.0 has been released though, we'll need to ignore deprecation notices on PHP 8.1 as otherwise the ruleset test would fail on the notices coming from WPCS.

### 🆕 GH Actions: version update for `ramsey/composer-install`

The action used to install Composer packages and handle the caching has released a new major (and some follow-up patch releases), which means, the action reference needs to be updated to benefit from it.

Includes adding `--no-interaction` to "plain" Composer commands to potentially prevent CI hanging if, for whatever reason, interaction would be needed in the future.

Refs:
* https://github.com/ramsey/composer-install/releases/tag/2.0.0
* https://github.com/ramsey/composer-install/releases/tag/2.0.1
* https://github.com/ramsey/composer-install/releases/tag/2.0.2
