### PR TITLE
README: update for Composer 2.2

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,13 +22,23 @@ Go to https://docs.wpvip.com/technical-references/code-review/phpcs-report/ to l
 
 ## Installation
 
-`composer require automattic/vipwpcs`, or `composer g require automattic/vipwpcs` if installing globally. 
+To install the VIP Coding Standards, run:
+```bash
+composer config allow-plugins.dealerdirect/phpcodesniffer-composer-installer true
+composer require automattic/vipwpcs
+```
+
+or if installing globally:
+```bash
+composer g config allow-plugins.dealerdirect/phpcodesniffer-composer-installer true
+composer g require automattic/vipwpcs
+```
 
 This will install the latest compatible versions of PHPCS, WPCS and VariableAnalysis and register the external standards with PHP_CodeSniffer.
 
 Please refer to the [installation instructions for installing PHP_CodeSniffer for WordPress.com VIP](https://docs.wpvip.com/how-tos/code-review/php_codesniffer/) for more details.
 
-As of VIPCS version 2.3.0, there is no need to `require` the [PHP_CodeSniffer Standards Composer Installer Plugin](https://github.com/Dealerdirect/phpcodesniffer-composer-installer) anymore as it is now a requirement of VIPCS itself.
+As of VIPCS version 2.3.0, there is no need to `require` the [PHP_CodeSniffer Standards Composer Installer Plugin](https://github.com/Dealerdirect/phpcodesniffer-composer-installer) anymore as it is now a requirement of VIPCS itself. Permission to run the plugin will still need to be granted though when using Composer 2.2 or higher.
 
 ## Contribution
 


### PR DESCRIPTION
The `dealerdirect/phpcodesniffer-composer-installer` Composer plugin is a non-dev requirement for VIPCS.

As of Composer 2.2.0, Composer plugins need to be explicitly allowed to run.

This commit adds the CLI command to set those permissions to the installation instructions.

Refs:
* https://blog.packagist.com/composer-2-2/#more-secure-plugin-execution