### PR TITLE
Composer: update PHP Parallel Lint and Console Highlighter

### DIFF
--- a/bin/php-lint
+++ b/bin/php-lint
@@ -7,4 +7,4 @@
 #   ./bin/php-lint
 #
 
-"$(pwd)/vendor/bin/parallel-lint" . -e php --exclude vendor --exclude .git $@
+"$(pwd)/vendor/bin/parallel-lint" . -e php --show-deprecated --exclude vendor --exclude .git $@

--- a/composer.json
+++ b/composer.json
@@ -22,8 +22,8 @@
 		"wp-coding-standards/wpcs": "^2.3"
 	},
 	"require-dev": {
-		"php-parallel-lint/php-parallel-lint": "^1.0",
-		"php-parallel-lint/php-console-highlighter": "^0.5",
+		"php-parallel-lint/php-parallel-lint": "^1.3.2",
+		"php-parallel-lint/php-console-highlighter": "^1.0.0",
 		"phpcompatibility/php-compatibility": "^9",
 		"phpcsstandards/phpcsdevtools": "^1.0",
 		"phpunit/phpunit": "^4 || ^5 || ^6 || ^7"


### PR DESCRIPTION
### Composer: update PHP Parallel Lint and Console Highlighter

PHP Console Highlighter has released version `1.0.0` and PHP Parallel Lint version `1.3.2` is the first PHP Parallel Lint version which supports PHP Console Highlighter `1.0.0`.

As the minimum supported PHP version is still PHP 5.3 for both, we can safely update both dependency requirements.

Refs:
* https://github.com/php-parallel-lint/PHP-Console-Highlighter/releases/tag/v1.0.0
* https://github.com/php-parallel-lint/PHP-Parallel-Lint/releases/tag/v1.3.2

### GH Actions: show deprecations when linting

While rare, there are some deprecations which PHP can show when a file is being linted.
By default these are ignored by PHP-Parallel-Lint.

Apparently though, there is an option to show them (wasn't documented until recently), so let's turn that option on.