### PR TITLE
Update composer.json keywords

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -4,6 +4,7 @@
 	"description": "PHP_CodeSniffer rules (sniffs) to enforce WordPress VIP minimum coding conventions",
 	"keywords": [
 		"phpcs",
+		"static analysis",
 		"standards",
 		"WordPress"
 	],


### PR DESCRIPTION
As per https://getcomposer.org/doc/04-schema.md#keywords by including "static analysis", then later versions of Composer will prompt users if the package is installed with `composer require` instead of `composer require-dev`.