### PR TITLE
Updated Docs link for ORDER BY RAND()

### DIFF
--- a/WordPressVIPMinimum/Sniffs/Performance/OrderByRandSniff.php
+++ b/WordPressVIPMinimum/Sniffs/Performance/OrderByRandSniff.php
@@ -14,7 +14,7 @@ use WordPressCS\WordPress\AbstractArrayAssignmentRestrictionsSniff;
 /**
  * Flag using orderby => rand.
  *
- * @link https://docs.wpvip.com/technical-references/code-review/#order-by-rand
+ * @link https://docs.wpvip.com/technical-references/code-review/vip-errors/#h-order-by-rand
  *
  * @package VIPCS\WordPressVIPMinimum
  *


### PR DESCRIPTION
This updates an outdated link to VIP's Documentation related errors reported by the use of `ORDER BY RAND()`. 
This issue was [reported in Slack](https://a8c.slack.com/archives/C245KEKF1/p1663012529865339). 