### PR TITLE
GH Actions: update the xmllint-problem-matcher

### DIFF
--- a/.github/workflows/basics.yml
+++ b/.github/workflows/basics.yml
@@ -39,7 +39,7 @@ jobs:
 
       # Show XML violations inline in the file diff.
       # @link https://github.com/marketplace/actions/xmllint-problem-matcher
-      - uses: korelstar/xmllint-problem-matcher@v1
+      - uses: korelstar/xmllint-problem-matcher@v1.1
 
       # Validate the composer.json file.
       # @link https://getcomposer.org/doc/03-cli.md#validate


### PR DESCRIPTION
The `xmllint-problem-matcher` action runner has released a new version which updates it to use node 16. This gets rid of a warning which was shown in the action logs.

Note: I've [suggested to the author to use long-running branches for the action runner instead](https://github.com/korelstar/xmllint-problem-matcher/pull/7), which would make this update redundant, but no telling if or when they'll respond to that, let alone if they will follow my suggestion.

Refs:
* https://github.com/korelstar/xmllint-problem-matcher/releases/tag/v1.1