### PR TITLE
GH Actions: various tweaks

### DIFF
--- a/.github/workflows/basics.yml
+++ b/.github/workflows/basics.yml
@@ -60,10 +60,11 @@ jobs:
 
       # Check the code-style consistency of the PHP files.
       - name: Check PHP code style
-        continue-on-error: true
+        id: phpcs
         run: vendor/bin/phpcs --report-full --report-checkstyle=./phpcs-report.xml
 
       - name: Show PHPCS results in PR
+        if: ${{ always() && steps.phpcs.outcome == 'failure' }}
         run: cs2pr ./phpcs-report.xml
 
       # Check that the sniffs available are feature complete.

--- a/.github/workflows/basics.yml
+++ b/.github/workflows/basics.yml
@@ -39,7 +39,7 @@ jobs:
 
       # Show XML violations inline in the file diff.
       # @link https://github.com/marketplace/actions/xmllint-problem-matcher
-      - uses: korelstar/xmllint-problem-matcher@v1.1
+      - uses: korelstar/xmllint-problem-matcher@v1
 
       # Validate the composer.json file.
       # @link https://getcomposer.org/doc/03-cli.md#validate


### PR DESCRIPTION
### GH Actions/basics: revert to xmllint-problem-matcher v1

As the `korelstar/xmllint-problem-matcher` repo now has a long-running `v1` branch, this update which was included in PR #725 is no longer needed (and would necessitate more frequent updates if it would remain).

Ref:
* korelstar/xmllint-problem-matcher#7

### GH Actions: harden the workflow against PHPCS ruleset errors

If there is a ruleset error, the `cs2pr` action doesn't receive an `xml` report and exits with a `0` error code, even though the PHPCS run failed (though not on CS errors, but on a ruleset error).

This changes the GH Actions workflow to allow for that situation and still fail the build in that case.