### PR TITLE
Open wpcs composer dependency to allow vsprint fixed tag

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -20,7 +20,7 @@
 		"dealerdirect/phpcodesniffer-composer-installer": "^0.4.1 || ^0.5 || ^0.6.2 || ^0.7",
 		"sirbrillig/phpcs-variable-analysis": "^2.11.1",
 		"squizlabs/php_codesniffer": "^3.5.5",
-		"wp-coding-standards/wpcs": "^2.3"
+		"wp-coding-standards/wpcs": "^2.3 || dev-master#2.3.0-fix-vsprintf"
 	},
 	"require-dev": {
 		"php-parallel-lint/php-parallel-lint": "^1.3.2",


### PR DESCRIPTION
Related to #727 , I think this change should allow a project to use https://github.com/WordPress/WordPress-Coding-Standards/releases/tag/2.3.0-fix-vsprintf without also pulling the unrelated (and possibly breaking) changes from wpcs@develop.