### PR TITLE
WPCS 3.0: Composer updates

### DIFF
--- a/.github/workflows/quicktest.yml
+++ b/.github/workflows/quicktest.yml
@@ -30,15 +30,11 @@ jobs:
             phpcs_version: 'dev-master'
             wpcs_version: '2.3.*'
           - php: '5.4'
-            phpcs_version: '3.5.5'
+            phpcs_version: '3.7.1'
             wpcs_version: '2.3.*'
 
           - php: 'latest'
             phpcs_version: 'dev-master'
-            wpcs_version: '2.3.*'
-          - php: 'latest'
-            # PHPCS 3.6.1 is the lowest version of PHPCS which supports PHP 8.1.
-            phpcs_version: '3.6.1'
             wpcs_version: '2.3.*'
 
     name: "QTest${{ matrix.phpcs_version == 'dev-master' && ' + Lint' || '' }}: PHP ${{ matrix.php }} - PHPCS ${{ matrix.phpcs_version }}"

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -71,7 +71,7 @@ jobs:
       # - experimental: Whether the build is "allowed to fail".
       matrix:
         php: ['5.4', '5.5', '5.6', '7.0', '7.1', '7.2', '7.3', '7.4']
-        phpcs_version: ['3.5.5', 'dev-master']
+        phpcs_version: ['3.7.1', 'dev-master']
         wpcs_version: ['2.3.*']
         experimental: [false]
 

--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ Go to https://docs.wpvip.com/technical-references/code-review/phpcs-report/ to l
 ## Minimal requirements
 
 * PHP 5.4+
-* [PHPCS 3.5.5+](https://github.com/squizlabs/PHP_CodeSniffer/releases)
+* [PHPCS 3.7.1+](https://github.com/squizlabs/PHP_CodeSniffer/releases)
 * [WPCS 2.3.0+](https://github.com/WordPress-Coding-Standards/WordPress-Coding-Standards/releases)
 * [VariableAnalysis 2.11.1+](https://github.com/sirbrillig/phpcs-variable-analysis/releases)
 

--- a/composer.json
+++ b/composer.json
@@ -66,7 +66,7 @@
 	},
 	"scripts-descriptions": {
 		"check-all": "Run all checks (lint, phpcs, feature completeness) and tests.",
-		"check-complete": "Check if all the sniffs have tests.",
+		"check-complete": "Check if all the sniffs have unit tests.",
 		"check-complete-strict": "Check if all the sniffs have unit tests and XML documentation.",
 		"check-cs": "Run the PHPCS script against the entire codebase.",
 		"lint": "Lint PHP files against parse errors.",

--- a/composer.json
+++ b/composer.json
@@ -35,25 +35,27 @@
 		}
 	},
 	"scripts": {
-		"install-codestandards": "Dealerdirect\\Composer\\Plugin\\Installers\\PHPCodeSniffer\\Plugin::run",
-		"ruleset": "bin/ruleset-tests",
+		"check-all": [
+			"@lint",
+			"@check-cs",
+			"@run-tests",
+			"@check-complete-strict",
+			"@ruleset"
+		],
+		"check-complete": [
+			"@php ./vendor/phpcsstandards/phpcsdevtools/bin/phpcs-check-feature-completeness -q ./WordPressVIPMinimum"
+		],
+		"check-complete-strict": [
+			"@php ./vendor/phpcsstandards/phpcsdevtools/bin/phpcs-check-feature-completeness ./WordPressVIPMinimum"
+		],
+		"check-cs": "bin/phpcs",
 		"lint": [
 			"bin/php-lint",
 			"bin/xml-lint"
 		],
-		"phpcs": "bin/phpcs",
-		"phpunit": "bin/unit-tests",
-		"coverage": "bin/unit-tests-coverage",
-		"check-complete": [
-			"@php ./vendor/phpcsstandards/phpcsdevtools/bin/phpcs-check-feature-completeness -q ./WordPressVIPMinimum"
-		],
-		"test": [
-			"@lint",
-			"@ruleset",
-			"@phpunit",
-			"@phpcs",
-			"@check-complete"
-		]
+		"ruleset": "bin/ruleset-tests",
+		"run-tests": "bin/unit-tests",
+		"run-tests-coverage": "bin/unit-tests-coverage"
 	},
 	"support": {
 		"issues": "https://github.com/Automattic/VIP-Coding-Standards/issues",

--- a/composer.json
+++ b/composer.json
@@ -57,6 +57,14 @@
 		"run-tests": "bin/unit-tests",
 		"run-tests-coverage": "bin/unit-tests-coverage"
 	},
+	"scripts-descriptions": {
+		"check-all": "Run all checks (lint, phpcs, feature completeness) and tests.",
+		"check-complete": "Check if all the sniffs have tests.",
+		"check-complete-strict": "Check if all the sniffs have unit tests and XML documentation.",
+		"check-cs": "Run the PHPCS script against the entire codebase.",
+		"lint": "Lint PHP files against parse errors.",
+		"run-tests": "Run all the unit tests for the VIP Coding Standards sniffs."
+	},
 	"support": {
 		"issues": "https://github.com/Automattic/VIP-Coding-Standards/issues",
 		"wiki": "https://github.com/Automattic/VIP-Coding-Standards/wiki",

--- a/composer.json
+++ b/composer.json
@@ -68,7 +68,7 @@
 		"check-all": "Run all checks (lint, phpcs, feature completeness) and tests.",
 		"check-complete": "Check if all the sniffs have unit tests.",
 		"check-complete-strict": "Check if all the sniffs have unit tests and XML documentation.",
-		"check-cs": "Run the PHPCS script against the entire codebase.",
+		"check-cs": "Check the code style and code quality of the codebase via PHPCS.",
 		"lint": "Lint PHP files against parse errors.",
 		"run-tests": "Run all the unit tests for the VIP Coding Standards sniffs."
 	}

--- a/composer.json
+++ b/composer.json
@@ -19,7 +19,7 @@
 		"php": ">=5.4",
 		"dealerdirect/phpcodesniffer-composer-installer": "^0.4.1 || ^0.5 || ^0.6.2 || ^0.7",
 		"sirbrillig/phpcs-variable-analysis": "^2.11.1",
-		"squizlabs/php_codesniffer": "^3.5.5",
+		"squizlabs/php_codesniffer": "^3.7.1",
 		"wp-coding-standards/wpcs": "^2.3"
 	},
 	"require-dev": {

--- a/composer.json
+++ b/composer.json
@@ -1,20 +1,25 @@
 {
 	"name": "automattic/vipwpcs",
-	"type": "phpcodesniffer-standard",
 	"description": "PHP_CodeSniffer rules (sniffs) to enforce WordPress VIP minimum coding conventions",
+	"license": "MIT",
+	"type": "phpcodesniffer-standard",
 	"keywords": [
 		"phpcs",
 		"static analysis",
 		"standards",
 		"WordPress"
 	],
-	"license": "MIT",
 	"authors": [
 		{
 			"name": "Contributors",
 			"homepage": "https://github.com/Automattic/VIP-Coding-Standards/graphs/contributors"
 		}
 	],
+	"support": {
+		"issues": "https://github.com/Automattic/VIP-Coding-Standards/issues",
+		"wiki": "https://github.com/Automattic/VIP-Coding-Standards/wiki",
+		"source": "https://github.com/Automattic/VIP-Coding-Standards"
+	},
 	"require": {
 		"php": ">=5.4",
 		"dealerdirect/phpcodesniffer-composer-installer": "^0.4.1 || ^0.5 || ^0.6.2 || ^0.7",
@@ -23,8 +28,8 @@
 		"wp-coding-standards/wpcs": "dev-develop"
 	},
 	"require-dev": {
-		"php-parallel-lint/php-parallel-lint": "^1.3.2",
 		"php-parallel-lint/php-console-highlighter": "^1.0.0",
+		"php-parallel-lint/php-parallel-lint": "^1.3.2",
 		"phpcompatibility/php-compatibility": "^9",
 		"phpcsstandards/phpcsdevtools": "^1.0",
 		"phpunit/phpunit": "^4 || ^5 || ^6 || ^7"
@@ -66,10 +71,5 @@
 		"check-cs": "Run the PHPCS script against the entire codebase.",
 		"lint": "Lint PHP files against parse errors.",
 		"run-tests": "Run all the unit tests for the VIP Coding Standards sniffs."
-	},
-	"support": {
-		"issues": "https://github.com/Automattic/VIP-Coding-Standards/issues",
-		"wiki": "https://github.com/Automattic/VIP-Coding-Standards/wiki",
-		"source": "https://github.com/Automattic/VIP-Coding-Standards"
 	}
 }

--- a/composer.json
+++ b/composer.json
@@ -20,7 +20,7 @@
 		"dealerdirect/phpcodesniffer-composer-installer": "^0.4.1 || ^0.5 || ^0.6.2 || ^0.7",
 		"sirbrillig/phpcs-variable-analysis": "^2.11.1",
 		"squizlabs/php_codesniffer": "^3.7.1",
-		"wp-coding-standards/wpcs": "^2.3"
+		"wp-coding-standards/wpcs": "dev-develop"
 	},
 	"require-dev": {
 		"php-parallel-lint/php-parallel-lint": "^1.3.2",
@@ -29,6 +29,8 @@
 		"phpcsstandards/phpcsdevtools": "^1.0",
 		"phpunit/phpunit": "^4 || ^5 || ^6 || ^7"
 	},
+	"minimum-stability": "dev",
+	"prefer-stable": true,
 	"config": {
 		"allow-plugins": {
 			"dealerdirect/phpcodesniffer-composer-installer": true


### PR DESCRIPTION
We need VIPCS to be compatible with WPCS 3.0, so this is the first of a few PRs to address the known compatibility issues. 

### Composer: up the minimum PHPCS version to 3.7.1

PHPCS 3.7.1 adds support for PHP 8.1 features, including fixing a retokenization of reserved keywords bug in PHPCS 3.7.0. Amends a couple of GitHub workflows for this change too.

### Composer: rename scripts

Brings them more in line with the Composer scripts in WPCS.

### Composer: add script descriptions

Displayed for `composer list`.

### Composer: use develop branch of WPCS

VIPCS must be compatible with WordPress Coding Standards 3.0.0, currently in development on its `develop` branch. WPCS now uses some extra dependencies, which are also in development, so we need to allow for a `minimum-stability` of `dev`. Run `composer update -W` to pull those extra dependencies in.

### Composer: Normalize the order

Uses the composer-normalize plugin to keep a consistent order.

**Note:** GitHub Actions may report failures whilst this and the next few PRs go through, but I don't want to bundle all the changes into big PRs.