### PR TITLE
WPCS 3.0: Fix coding standards of VIPCS sniffs

### DIFF
--- a/WordPressVIPMinimum/Sniffs/Classes/DeclarationCompatibilitySniff.php
+++ b/WordPressVIPMinimum/Sniffs/Classes/DeclarationCompatibilitySniff.php
@@ -291,7 +291,7 @@ class DeclarationCompatibilitySniff extends AbstractScopeSniff {
 					return;
 				}
 			}
-			$i++;
+			++$i;
 		}
 	}
 

--- a/WordPressVIPMinimum/Sniffs/Compatibility/ZoninatorSniff.php
+++ b/WordPressVIPMinimum/Sniffs/Compatibility/ZoninatorSniff.php
@@ -80,11 +80,11 @@ class ZoninatorSniff extends Sniff {
 	/**
 	 * Removes the quotation marks around T_CONSTANT_ENCAPSED_STRING.
 	 *
-	 * @param string $string T_CONSTANT_ENCAPSED_STRING containing wrapping quotation marks.
+	 * @param string $text_string T_CONSTANT_ENCAPSED_STRING containing wrapping quotation marks.
 	 *
 	 * @return string String w/o wrapping quotation marks.
 	 */
-	public function remove_wrapping_quotation_marks( $string ) {
-		return trim( str_replace( '"', "'", $string ), "'" );
+	public function remove_wrapping_quotation_marks( $text_string ) {
+		return trim( str_replace( '"', "'", $text_string ), "'" );
 	}
 }

--- a/WordPressVIPMinimum/Sniffs/Hooks/AlwaysReturnInFilterSniff.php
+++ b/WordPressVIPMinimum/Sniffs/Hooks/AlwaysReturnInFilterSniff.php
@@ -218,9 +218,9 @@ class AlwaysReturnInFilterSniff extends Sniff {
 
 		while ( $returnTokenPtr ) {
 			if ( $this->isInsideIfConditonal( $returnTokenPtr ) ) {
-				$insideIfConditionalReturn++;
+				++$insideIfConditionalReturn;
 			} else {
-				$outsideConditionalReturn++;
+				++$outsideConditionalReturn;
 			}
 			if ( $this->isReturningVoid( $returnTokenPtr ) ) {
 				$message = 'Please, make sure that a callback to `%s` filter is returning void intentionally.';


### PR DESCRIPTION
~**Once #732 has been merged, this can be rebased** to just show coding standards changes.~

----

Update the VIPCS sniffs to fix the coding standards changes with WPCS 3.0.

### CS: Use pre-increment over post-increment

Slightly better performance.

### CS: Avoid reserved keyword for function param name

Using named parameters with a variable named `$string` is unfavourable.

### ~CS: Update WordPress-Extra exclusions~

~WordPress-Extra will no longer use the `Generic.Arrays.DisallowShortArraySyntax` rule, but does use the improved `Universal.Arrays.DisallowShortArraySyntax` from PHPCSExtra instead, so whilst we have short array syntax being used in the VIPCS sniffs, let's continue to exclude the rule.~