### PR TITLE
Unit tests: Support PHP >= 8.1

### DIFF
--- a/.github/workflows/quicktest.yml
+++ b/.github/workflows/quicktest.yml
@@ -96,7 +96,6 @@ jobs:
         run: ./bin/php-lint
 
       - name: Run the unit tests
-        if: matrix.php != 'latest'
         run: ./bin/unit-tests
 
       - name: Run the ruleset tests

--- a/.github/workflows/quicktest.yml
+++ b/.github/workflows/quicktest.yml
@@ -95,13 +95,9 @@ jobs:
         if: matrix.phpcs_version == 'dev-master'
         run: ./bin/php-lint
 
-      - name: Run the unit tests - PHP 5.4 - 8.0
+      - name: Run the unit tests
         if: matrix.php != 'latest'
         run: ./bin/unit-tests
-
-      - name: Run the unit tests - PHP > 8.1
-        if: matrix.php == 'latest'
-        run: vendor/bin/phpunit --filter WordPressVIPMinimum ./vendor/squizlabs/php_codesniffer/tests/AllTests.php --no-coverage --no-configuration --bootstrap=./tests/bootstrap.php --dont-report-useless-tests
 
       - name: Run the ruleset tests
         run: ./bin/ruleset-tests

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -157,7 +157,6 @@ jobs:
           custom-cache-suffix: $(date -u -d "-0 month -$(($(date +%d)-1)) days" "+%F")
 
       - name: Run the unit tests
-        if: matrix.php < '8.1'
         run: ./bin/unit-tests
 
       - name: Run the ruleset tests

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -156,13 +156,9 @@ jobs:
           composer-options: --ignore-platform-reqs
           custom-cache-suffix: $(date -u -d "-0 month -$(($(date +%d)-1)) days" "+%F")
 
-      - name: Run the unit tests - PHP 5.4 - 8.0
+      - name: Run the unit tests
         if: matrix.php < '8.1'
         run: ./bin/unit-tests
-
-      - name: Run the unit tests - PHP > 8.1
-        if: matrix.php >= '8.1'
-        run: vendor/bin/phpunit --filter WordPressVIPMinimum ./vendor/squizlabs/php_codesniffer/tests/AllTests.php --no-coverage --no-configuration --bootstrap=./tests/bootstrap.php --dont-report-useless-tests
 
       - name: Run the ruleset tests
         run: ./bin/ruleset-tests

--- a/bin/unit-tests
+++ b/bin/unit-tests
@@ -17,7 +17,7 @@
 #
 
 if [[ $(php -r 'echo PHP_VERSION_ID;') -ge 80100 ]]; then
-	"$(pwd)/vendor/bin/phpunit" --filter WordPressVIPMinimum "$(pwd)/vendor/squizlabs/php_codesniffer/tests/AllTests.php" --no-coverage --no-configuration --bootstrap=./Tests/bootstrap.php --dont-report-useless-tests $@
+	"$(pwd)/vendor/bin/phpunit" --filter WordPressVIPMinimum "$(pwd)/vendor/squizlabs/php_codesniffer/tests/AllTests.php" --no-coverage --no-configuration --bootstrap=./tests/bootstrap.php --dont-report-useless-tests $@
 else
 	"$(pwd)/vendor/bin/phpunit" --filter WordPressVIPMinimum "$(pwd)/vendor/squizlabs/php_codesniffer/tests/AllTests.php" --no-coverage $@
 fi

--- a/bin/unit-tests
+++ b/bin/unit-tests
@@ -16,4 +16,8 @@
 #   ./bin/unit-tests --filter SniffName
 #
 
-"$(pwd)/vendor/bin/phpunit" --filter WordPressVIPMinimum "$(pwd)/vendor/squizlabs/php_codesniffer/tests/AllTests.php" --no-coverage $@
+if [[ $(php -r 'echo PHP_VERSION_ID;') -ge 80100 ]]; then
+	"$(pwd)/vendor/bin/phpunit" --filter WordPressVIPMinimum "$(pwd)/vendor/squizlabs/php_codesniffer/tests/AllTests.php" --no-coverage --no-configuration --bootstrap=./Tests/bootstrap.php --dont-report-useless-tests $@
+else
+	"$(pwd)/vendor/bin/phpunit" --filter WordPressVIPMinimum "$(pwd)/vendor/squizlabs/php_codesniffer/tests/AllTests.php" --no-coverage $@
+fi


### PR DESCRIPTION
While the different logic for PHP 8.1 was in the GitHub workflow, moving it to the bin script means the GitHub workflow can be simplified, and the same Composer script can be run locally too.