### PR TITLE
WPCS 3.0: Fix ruleset tests

### DIFF
--- a/.github/workflows/quicktest.yml
+++ b/.github/workflows/quicktest.yml
@@ -28,14 +28,14 @@ jobs:
         include:
           - php: '5.4'
             phpcs_version: 'dev-master'
-            wpcs_version: '2.3.*'
+            wpcs_version: 'dev-develop'
           - php: '5.4'
             phpcs_version: '3.7.1'
-            wpcs_version: '2.3.*'
+            wpcs_version: 'dev-develop'
 
           - php: 'latest'
             phpcs_version: 'dev-master'
-            wpcs_version: '2.3.*'
+            wpcs_version: 'dev-develop'
 
     name: "QTest${{ matrix.phpcs_version == 'dev-master' && ' + Lint' || '' }}: PHP ${{ matrix.php }} - PHPCS ${{ matrix.phpcs_version }}"
 
@@ -50,24 +50,23 @@ jobs:
         id: set_ini
         run: |
           if [[ "${{ matrix.phpcs_version }}" != "dev-master" ]]; then
-            echo 'PHP_INI=error_reporting=E_ALL & ~E_DEPRECATED' >> $GITHUB_OUTPUT
-          elif [[ "${{ matrix.php }}" == "latest" ]]; then
-            echo 'PHP_INI=error_reporting=E_ALL & ~E_DEPRECATED' >> $GITHUB_OUTPUT
+            echo 'PHP_INI=error_reporting=E_ALL & ~E_DEPRECATED, display_errors=On' >> $GITHUB_OUTPUT
           else
-            echo 'PHP_INI=error_reporting=-1' >> $GITHUB_OUTPUT
+            echo 'PHP_INI=error_reporting=-1, display_errors=On' >> $GITHUB_OUTPUT
           fi
 
-      - name: Install PHP
+      - name: Set up PHP
         uses: shivammathur/setup-php@v2
         with:
           php-version: ${{ matrix.php }}
           ini-values: ${{ steps.set_ini.outputs.PHP_INI }}
           coverage: none
 
-      - name: 'Composer: set PHPCS and WPCS versions for tests'
-        run: |
-          composer require --no-update --no-scripts squizlabs/php_codesniffer:"${{ matrix.phpcs_version }}" --no-interaction
-          composer require --no-update --no-scripts wp-coding-standards/wpcs:"${{ matrix.wpcs_version }}" --no-interaction
+      - name: 'Composer: set PHPCS version for tests'
+        run: composer require squizlabs/php_codesniffer:"${{ matrix.phpcs_version }}" --no-update --no-scripts --no-interaction
+
+      - name: 'Composer: set WPCS version for tests'
+        run: composer require wp-coding-standards/wpcs:"${{ matrix.wpcs_version }}" --no-update --no-scripts --no-interaction
 
       # Install dependencies and handle caching in one go.
       # @link https://github.com/marketplace/actions/install-composer-dependencies

--- a/.github/workflows/quicktest.yml
+++ b/.github/workflows/quicktest.yml
@@ -87,6 +87,9 @@ jobs:
           composer-options: --ignore-platform-reqs
           custom-cache-suffix: $(date -u -d "-0 month -$(($(date +%d)-1)) days" "+%F")
 
+      - name: Display PHPCS installed standards
+        run: ./vendor/bin/phpcs -i
+
       - name: Lint against parse errors
         if: matrix.phpcs_version == 'dev-master'
         run: ./bin/php-lint

--- a/.github/workflows/quicktest.yml
+++ b/.github/workflows/quicktest.yml
@@ -30,15 +30,11 @@ jobs:
             phpcs_version: 'dev-master'
             wpcs_version: '2.3.*'
           - php: '5.4'
-            phpcs_version: '3.5.5'
+            phpcs_version: '3.7.1'
             wpcs_version: '2.3.*'
 
           - php: 'latest'
             phpcs_version: 'dev-master'
-            wpcs_version: '2.3.*'
-          - php: 'latest'
-            # PHPCS 3.6.1 is the lowest version of PHPCS which supports PHP 8.1.
-            phpcs_version: '3.6.1'
             wpcs_version: '2.3.*'
 
     name: "QTest${{ matrix.phpcs_version == 'dev-master' && ' + Lint' || '' }}: PHP ${{ matrix.php }} - PHPCS ${{ matrix.phpcs_version }}"

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -71,7 +71,7 @@ jobs:
       # - experimental: Whether the build is "allowed to fail".
       matrix:
         php: ['5.4', '5.5', '5.6', '7.0', '7.1', '7.2', '7.3', '7.4']
-        phpcs_version: ['3.5.5', 'dev-master']
+        phpcs_version: ['3.7.1', 'dev-master']
         wpcs_version: ['2.3.*']
         experimental: [false]
 

--- a/.github/workflows/unit-tests.yml
+++ b/.github/workflows/unit-tests.yml
@@ -109,10 +109,11 @@ jobs:
           ini-values: ${{ steps.set_ini.outputs.PHP_INI }}
           coverage: none
 
-      - name: 'Composer: set PHPCS and WPCS versions for tests'
-        run: |
-          composer require squizlabs/php_codesniffer:"${{ matrix.phpcs_version }}" --no-update --no-scripts --no-interaction
-          composer require wp-coding-standards/wpcs:"${{ matrix.wpcs_version }}" --no-update --no-scripts --no-interaction
+      - name: 'Composer: set PHPCS version for tests'
+        run: composer require squizlabs/php_codesniffer:"${{ matrix.phpcs_version }}" --no-update --no-scripts --no-interaction
+
+      - name: 'Composer: set WPCS version for tests'
+        run: composer require wp-coding-standards/wpcs:"${{ matrix.wpcs_version }}" --no-update --no-scripts --no-interaction
 
       # Install dependencies and handle caching in one go.
       # @link https://github.com/marketplace/actions/install-composer-dependencies

--- a/.github/workflows/unit-tests.yml
+++ b/.github/workflows/unit-tests.yml
@@ -141,5 +141,5 @@ jobs:
         if: ${{ matrix.php >= '8.1' }}
         run: vendor/bin/phpunit --filter WordPressVIPMinimum ./vendor/squizlabs/php_codesniffer/tests/AllTests.php --no-coverage --no-configuration --bootstrap=./tests/bootstrap.php --dont-report-useless-tests
 
-      #- name: Run the ruleset tests
-      #  run: ./bin/ruleset-tests
+      - name: Run the ruleset tests
+        run: ./bin/ruleset-tests

--- a/.github/workflows/unit-tests.yml
+++ b/.github/workflows/unit-tests.yml
@@ -141,5 +141,5 @@ jobs:
         if: ${{ matrix.php >= '8.1' }}
         run: vendor/bin/phpunit --filter WordPressVIPMinimum ./vendor/squizlabs/php_codesniffer/tests/AllTests.php --no-coverage --no-configuration --bootstrap=./tests/bootstrap.php --dont-report-useless-tests
 
-      - name: Run the ruleset tests
-        run: ./bin/ruleset-tests
+      #- name: Run the ruleset tests
+      #  run: ./bin/ruleset-tests

--- a/.github/workflows/unit-tests.yml
+++ b/.github/workflows/unit-tests.yml
@@ -1,4 +1,4 @@
-name: Test
+name: Unit Tests
 
 on:
   # Run on pushes to `master` and on all pull requests.
@@ -27,10 +27,10 @@ jobs:
 
     strategy:
       matrix:
-        php: ['5.4', 'latest', '8.2']
+        php: ['5.4', 'latest', '8.3']
 
     name: "Lint: PHP ${{ matrix.php }}"
-    continue-on-error: ${{ matrix.php == '8.2' }}
+    continue-on-error: ${{ matrix.php == '8.3' }}
 
     steps:
       - name: Checkout code
@@ -46,8 +46,8 @@ jobs:
       - name: Install Composer dependencies
         uses: "ramsey/composer-install@v2"
         with:
-          # Bust the cache at least once a month - output format: YYYY-MM-DD.
-          custom-cache-suffix: $(date -u -d "-0 month -$(($(date +%d)-1)) days" "+%F")
+          # Bust the cache at least once a month - output format: YYYY-MM.
+          custom-cache-suffix: $(date -u "+%Y-%m")
 
       - name: Lint against parse errors
         run: ./bin/php-lint --checkstyle | cs2pr
@@ -70,41 +70,19 @@ jobs:
       #   no additional versions are included in the array.
       # - experimental: Whether the build is "allowed to fail".
       matrix:
-        php: ['5.4', '5.5', '5.6', '7.0', '7.1', '7.2', '7.3', '7.4']
+        php: ['5.4', '5.5', '5.6', '7.0', '7.1', '7.2', '7.3', '7.4', '8.0', '8.1', '8.2']
         phpcs_version: ['3.7.1', 'dev-master']
-        wpcs_version: ['2.3.*']
+        wpcs_version: ['dev-develop']
         experimental: [false]
 
         include:
-          # Complete the matrix by adding PHP 8.0, but only test against compatible PHPCS versions.
-          - php: '8.0'
-            phpcs_version: 'dev-master'
-            wpcs_version: '2.3.*'
-            experimental: false
-          - php: '8.0'
-            # PHPCS 3.5.7 is the lowest version of PHPCS which supports PHP 8.0.
-            phpcs_version: '3.5.7'
-            wpcs_version: '2.3.*'
-            experimental: false
-
-          # Complete the matrix by adding PHP 8.1, but only test against compatible PHPCS versions.
-          - php: '8.1'
-            phpcs_version: 'dev-master'
-            wpcs_version: '2.3.*'
-            experimental: false
-          - php: '8.1'
-            # PHPCS 3.6.1 is the lowest version of PHPCS which supports PHP 8.1.
-            phpcs_version: '3.6.1'
-            wpcs_version: '2.3.*'
-            experimental: false
-
           # Experimental builds. These are allowed to fail.
-          #- php: '8.2'
-          #  phpcs_version: 'dev-master'
-          #  wpcs_version: '2.3.*'
-          #  experimental: true
+          - php: '8.3'
+            phpcs_version: 'dev-master'
+            wpcs_version: 'dev-develop'
+            experimental: true
 
-    name: "Test: PHP ${{ matrix.php }} - PHPCS ${{ matrix.phpcs_version }} - WPCS ${{ matrix.wpcs_version }}"
+    name: "PHP ${{ matrix.php }} on PHPCS ${{ matrix.phpcs_version }}"
 
     continue-on-error: ${{ matrix.experimental }}
 
@@ -119,14 +97,12 @@ jobs:
         id: set_ini
         run: |
           if [[ "${{ matrix.phpcs_version }}" != "dev-master" ]]; then
-            echo 'PHP_INI=error_reporting=E_ALL & ~E_DEPRECATED' >> $GITHUB_OUTPUT
-          elif [[ "${{ matrix.php }}" == "8.1" ]]; then
-            echo 'PHP_INI=error_reporting=E_ALL & ~E_DEPRECATED' >> $GITHUB_OUTPUT
+            echo 'PHP_INI=error_reporting=E_ALL & ~E_DEPRECATED, display_errors=On' >> $GITHUB_OUTPUT
           else
-            echo 'PHP_INI=error_reporting=-1' >> $GITHUB_OUTPUT
+            echo 'PHP_INI=error_reporting=-1, display_errors=On' >> $GITHUB_OUTPUT
           fi
 
-      - name: Install PHP
+      - name: Set up PHP
         uses: shivammathur/setup-php@v2
         with:
           php-version: ${{ matrix.php }}
@@ -135,33 +111,34 @@ jobs:
 
       - name: 'Composer: set PHPCS and WPCS versions for tests'
         run: |
-          composer require --no-update --no-scripts squizlabs/php_codesniffer:"${{ matrix.phpcs_version }}" --no-interaction
-          composer require --no-update --no-scripts wp-coding-standards/wpcs:"${{ matrix.wpcs_version }}" --no-interaction
+          composer require squizlabs/php_codesniffer:"${{ matrix.phpcs_version }}" --no-update --no-scripts --no-interaction
+          composer require wp-coding-standards/wpcs:"${{ matrix.wpcs_version }}" --no-update --no-scripts --no-interaction
 
       # Install dependencies and handle caching in one go.
       # @link https://github.com/marketplace/actions/install-composer-dependencies
-      - name: Install Composer dependencies - normal
-        if: ${{ startsWith( matrix.php, '8' ) == false }}
-        uses: "ramsey/composer-install@v2"
+      - name: Install Composer dependencies (PHP < 8.0 )
+        if: ${{ matrix.php < 8.0 }}
+        uses: ramsey/composer-install@v2
         with:
-          # Bust the cache at least once a month - output format: YYYY-MM-DD.
-          custom-cache-suffix: $(date -u -d "-0 month -$(($(date +%d)-1)) days" "+%F")
+          # Bust the cache at least once a month - output format: YYYY-MM.
+          custom-cache-suffix: $(date -u "+%Y-%m")
 
       # PHPUnit 7.x does not allow for installation on PHP 8, so ignore platform
       # requirements to get PHPUnit 7.x to install on nightly.
-      - name: Install Composer dependencies - with ignore platform
-        if: ${{ startsWith( matrix.php, '8' ) }}
-        uses: "ramsey/composer-install@v2"
+      - name: Install Composer dependencies (PHP >= 8.0)
+        if: ${{ matrix.php >= 8.0 }}
+        uses: ramsey/composer-install@v2
         with:
           composer-options: --ignore-platform-reqs
-          custom-cache-suffix: $(date -u -d "-0 month -$(($(date +%d)-1)) days" "+%F")
+          custom-cache-suffix: $(date -u "+%Y-%m")
 
-      - name: Run the unit tests - PHP 5.4 - 8.0
-        if: matrix.php < '8.1'
+      # Simplify these next two down once bin/unit-tests.yml contains the condition (#735).
+      - name: Run the unit tests - PHP 5.4 — 8.0
+        if: ${{ matrix.php < '8.1' }}
         run: ./bin/unit-tests
 
-      - name: Run the unit tests - PHP > 8.1
-        if: matrix.php >= '8.1'
+      - name: Run the unit tests - PHP >= 8.1
+        if: ${{ matrix.php >= '8.1' }}
         run: vendor/bin/phpunit --filter WordPressVIPMinimum ./vendor/squizlabs/php_codesniffer/tests/AllTests.php --no-coverage --no-configuration --bootstrap=./tests/bootstrap.php --dont-report-useless-tests
 
       - name: Run the ruleset tests

--- a/.phpcs.xml.dist
+++ b/.phpcs.xml.dist
@@ -19,7 +19,7 @@
 	<rule ref="WordPress-Extra">
 		<exclude name="WordPress.Files.FileName"/>
 		<exclude name="WordPress.NamingConventions.ValidVariableName"/>
-		<exclude name="Generic.Arrays.DisallowShortArraySyntax"/>
+		<exclude name="Universal.Arrays.DisallowShortArraySyntax"/>
 		<exclude name="WordPress.PHP.YodaConditions"/>
 	</rule>
 

--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ Go to https://docs.wpvip.com/technical-references/code-review/phpcs-report/ to l
 ## Minimal requirements
 
 * PHP 5.4+
-* [PHPCS 3.5.5+](https://github.com/squizlabs/PHP_CodeSniffer/releases)
+* [PHPCS 3.7.1+](https://github.com/squizlabs/PHP_CodeSniffer/releases)
 * [WPCS 2.3.0+](https://github.com/WordPress-Coding-Standards/WordPress-Coding-Standards/releases)
 * [VariableAnalysis 2.11.1+](https://github.com/sirbrillig/phpcs-variable-analysis/releases)
 

--- a/WordPress-VIP-Go/ruleset-test.inc
+++ b/WordPress-VIP-Go/ruleset-test.inc
@@ -165,7 +165,7 @@ rawurlencode(); // Ok.
 extract( array( 'a' => 1 ) ); // Error.
 $obj->extract(); // Ok.
 
-// WordPress.PHP.StrictComparisons.LooseComparison
+// Universal.Operators.StrictComparisons.LooseComparison
 true == $true; // Warning.
 false === $true; // Ok.
 
@@ -546,7 +546,7 @@ str_replace( 'foo', array( 'bar', 'foo' ), 'foobar' ); // Error.
 
 // WordPressVIPMinimum.Security.Underscorejs
 echo "<script>
- _.templateSettings = { 
+ _.templateSettings = {
 	interpolate: /\{\{(.+?)\}\}/g" . // Warning.
 "};
  </script>";

--- a/WordPress-VIP-Go/ruleset.xml
+++ b/WordPress-VIP-Go/ruleset.xml
@@ -109,7 +109,7 @@
 		 This includes potential security holes as well as functions that may bring down sites for performance reasons.
 	 -->
 	<!-- Should fix all of them but it doesn't need a manual review -->
-	<rule ref="WordPress.WP.AlternativeFunctions.file_system_read_fopen">
+	<rule ref="WordPress.WP.AlternativeFunctions.file_system_operations_fopen">
 		<message>File system operations only work on the `/tmp/` and `wp-content/uploads/` directories. To avoid unexpected results, please use helper functions like `get_temp_dir()`  or `wp_get_upload_dir()` to get the proper directory path when using functions such as %s(). For more details, please see: https://docs.wpvip.com/technical-references/vip-go-files-system/local-file-operations/</message>
 	</rule>
 	<rule ref="WordPressVIPMinimum.Performance.FetchingRemoteData.FileGetContentsUnknown">
@@ -193,7 +193,7 @@
 	<rule ref="WordPress.PHP.DontExtract">
 		<severity>3</severity>
 	</rule>
-	<rule ref="WordPress.PHP.StrictComparisons.LooseComparison">
+	<rule ref="Universal.Operators.StrictComparisons.LooseComparison">
 		<severity>3</severity>
 	</rule>
 	<rule ref="WordPress.PHP.StrictInArray.MissingTrueStrict">
@@ -263,10 +263,10 @@
 	<rule ref="Generic.PHP.DisallowShortOpenTag.EchoFound">
 		<severity>0</severity>
 	</rule>
-	<rule ref="WordPress.WP.AlternativeFunctions.file_system_read_readfile">
+	<rule ref="WordPress.WP.AlternativeFunctions.file_system_operations_readfile">
 		<severity>0</severity>
 	</rule>
-	<rule ref="WordPress.WP.AlternativeFunctions.file_system_read_fclose">
+	<rule ref="WordPress.WP.AlternativeFunctions.file_system_operations_fclose">
 		<severity>0</severity>
 	</rule>
 

--- a/WordPressVIPMinimum/Sniffs/AbstractVariableRestrictionsSniff.php
+++ b/WordPressVIPMinimum/Sniffs/AbstractVariableRestrictionsSniff.php
@@ -200,11 +200,13 @@ abstract class AbstractVariableRestrictionsSniff extends Sniff {
 				continue;
 			}
 
-			$this->addMessage(
+			$code = MessageHelper::stringToErrorcode( $groupName . '_' . $match[1] );
+			MessageHelper::addMessage(
+				$this->phpcsFile,
 				$group['message'],
 				$stackPtr,
 				$group['type'] === 'error',
-				$this->string_to_errorcode( $groupName . '_' . $match[1] ),
+				$code,
 				[ $var ]
 			);
 

--- a/WordPressVIPMinimum/Sniffs/AbstractVariableRestrictionsSniff.php
+++ b/WordPressVIPMinimum/Sniffs/AbstractVariableRestrictionsSniff.php
@@ -9,7 +9,7 @@
 
 namespace WordPressVIPMinimum\Sniffs;
 
-use WordPressVIPMinimum\Sniffs\Sniff;
+use PHPCSUtils\Utils\MessageHelper;
 
 /**
  * Restricts usage of some variables.

--- a/WordPressVIPMinimum/Sniffs/Classes/DeclarationCompatibilitySniff.php
+++ b/WordPressVIPMinimum/Sniffs/Classes/DeclarationCompatibilitySniff.php
@@ -291,7 +291,7 @@ class DeclarationCompatibilitySniff extends AbstractScopeSniff {
 					return;
 				}
 			}
-			$i++;
+			++$i;
 		}
 	}
 

--- a/WordPressVIPMinimum/Sniffs/Compatibility/ZoninatorSniff.php
+++ b/WordPressVIPMinimum/Sniffs/Compatibility/ZoninatorSniff.php
@@ -80,11 +80,11 @@ class ZoninatorSniff extends Sniff {
 	/**
 	 * Removes the quotation marks around T_CONSTANT_ENCAPSED_STRING.
 	 *
-	 * @param string $string T_CONSTANT_ENCAPSED_STRING containing wrapping quotation marks.
+	 * @param string $text_string T_CONSTANT_ENCAPSED_STRING containing wrapping quotation marks.
 	 *
 	 * @return string String w/o wrapping quotation marks.
 	 */
-	public function remove_wrapping_quotation_marks( $string ) {
-		return trim( str_replace( '"', "'", $string ), "'" );
+	public function remove_wrapping_quotation_marks( $text_string ) {
+		return trim( str_replace( '"', "'", $text_string ), "'" );
 	}
 }

--- a/WordPressVIPMinimum/Sniffs/Constants/ConstantStringSniff.php
+++ b/WordPressVIPMinimum/Sniffs/Constants/ConstantStringSniff.php
@@ -8,8 +8,9 @@
 
 namespace WordPressVIPMinimum\Sniffs\Constants;
 
-use WordPressVIPMinimum\Sniffs\Sniff;
 use PHP_CodeSniffer\Util\Tokens;
+use PHPCSUtils\Utils\PassedParameters;
+use WordPressVIPMinimum\Sniffs\Sniff;
 
 /**
  * Sniff for properly using constant name when checking whether a constant is defined.
@@ -55,7 +56,7 @@ class ConstantStringSniff extends Sniff {
 			return;
 		}
 
-		$param = $this->get_function_call_parameter( $stackPtr, 1 );
+		$param = PassedParameters::getParameter( $this->phpcsFile, $stackPtr, 1 );
 		if ( $param === false ) {
 			// Target parameter not found.
 			return;

--- a/WordPressVIPMinimum/Sniffs/Functions/DynamicCallsSniff.php
+++ b/WordPressVIPMinimum/Sniffs/Functions/DynamicCallsSniff.php
@@ -8,6 +8,7 @@
 namespace WordPressVIPMinimum\Sniffs\Functions;
 
 use PHP_CodeSniffer\Util\Tokens;
+use PHPCSUtils\Utils\TextStrings;
 use WordPressVIPMinimum\Sniffs\Sniff;
 
 /**
@@ -139,7 +140,7 @@ class DynamicCallsSniff extends Sniff {
 		 * If we reached the end of the loop and the $value_ptr was set, we know for sure
 		 * this was a plain text string variable assignment.
 		 */
-		$current_var_value = $this->strip_quotes( $this->tokens[ $value_ptr ]['content'] );
+		$current_var_value = TextStrings::stripQuotes( $this->tokens[ $value_ptr ]['content'] );
 
 		if ( isset( $this->disallowed_functions[ $current_var_value ] ) === false ) {
 			// Text string is not one of the ones we're looking for.

--- a/WordPressVIPMinimum/Sniffs/Hooks/AlwaysReturnInFilterSniff.php
+++ b/WordPressVIPMinimum/Sniffs/Hooks/AlwaysReturnInFilterSniff.php
@@ -7,8 +7,9 @@
 
 namespace WordPressVIPMinimum\Sniffs\Hooks;
 
-use WordPressVIPMinimum\Sniffs\Sniff;
 use PHP_CodeSniffer\Util\Tokens;
+use PHPCSUtils\Utils\Arrays;
+use WordPressVIPMinimum\Sniffs\Sniff;
 
 /**
  * This sniff validates that filters always return a value
@@ -94,7 +95,7 @@ class AlwaysReturnInFilterSniff extends Sniff {
 	 */
 	private function processArray( $stackPtr ) {
 
-		$open_close = $this->find_array_open_close( $stackPtr );
+		$open_close = Arrays::getOpenClose( $this->phpcsFile, $stackPtr );
 		if ( $open_close === false ) {
 			return;
 		}

--- a/WordPressVIPMinimum/Sniffs/Hooks/AlwaysReturnInFilterSniff.php
+++ b/WordPressVIPMinimum/Sniffs/Hooks/AlwaysReturnInFilterSniff.php
@@ -218,9 +218,9 @@ class AlwaysReturnInFilterSniff extends Sniff {
 
 		while ( $returnTokenPtr ) {
 			if ( $this->isInsideIfConditonal( $returnTokenPtr ) ) {
-				$insideIfConditionalReturn++;
+				++$insideIfConditionalReturn;
 			} else {
-				$outsideConditionalReturn++;
+				++$outsideConditionalReturn;
 			}
 			if ( $this->isReturningVoid( $returnTokenPtr ) ) {
 				$message = 'Please, make sure that a callback to `%s` filter is returning void intentionally.';

--- a/WordPressVIPMinimum/Sniffs/Hooks/PreGetPostsSniff.php
+++ b/WordPressVIPMinimum/Sniffs/Hooks/PreGetPostsSniff.php
@@ -7,8 +7,9 @@
 
 namespace WordPressVIPMinimum\Sniffs\Hooks;
 
-use WordPressVIPMinimum\Sniffs\Sniff;
 use PHP_CodeSniffer\Util\Tokens;
+use PHPCSUtils\Utils\Arrays;
+use WordPressVIPMinimum\Sniffs\Sniff;
 
 /**
  * This sniff validates a proper usage of pre_get_posts action callback.
@@ -95,7 +96,7 @@ class PreGetPostsSniff extends Sniff {
 	 */
 	private function processArray( $stackPtr ) {
 
-		$open_close = $this->find_array_open_close( $stackPtr );
+		$open_close = Arrays::getOpenClose( $this->phpcsFile, $stackPtr );
 		if ( $open_close === false ) {
 			return;
 		}

--- a/WordPressVIPMinimum/Sniffs/Performance/LowExpiryCacheTimeSniff.php
+++ b/WordPressVIPMinimum/Sniffs/Performance/LowExpiryCacheTimeSniff.php
@@ -8,6 +8,7 @@
 namespace WordPressVIPMinimum\Sniffs\Performance;
 
 use PHP_CodeSniffer\Util\Tokens;
+use PHPCSUtils\Utils\TextStrings;
 use WordPressCS\WordPress\AbstractFunctionParameterSniff;
 
 /**
@@ -147,7 +148,7 @@ class LowExpiryCacheTimeSniff extends AbstractFunctionParameterSniff {
 			}
 
 			if ( $this->tokens[ $i ]['code'] === T_CONSTANT_ENCAPSED_STRING ) {
-				$content = $this->strip_quotes( $this->tokens[ $i ]['content'] );
+				$content = TextStrings::stripQuotes( $this->tokens[ $i ]['content'] );
 				if ( is_numeric( $content ) === true ) {
 					$tokensAsString .= $content;
 					continue;

--- a/WordPressVIPMinimum/Sniffs/Security/ProperEscapingFunctionSniff.php
+++ b/WordPressVIPMinimum/Sniffs/Security/ProperEscapingFunctionSniff.php
@@ -8,8 +8,9 @@
 
 namespace WordPressVIPMinimum\Sniffs\Security;
 
-use WordPressVIPMinimum\Sniffs\Sniff;
 use PHP_CodeSniffer\Util\Tokens;
+use PHPCSUtils\Utils\TextStrings;
+use WordPressVIPMinimum\Sniffs\Sniff;
 
 /**
  * Checks whether proper escaping function is used.
@@ -182,7 +183,7 @@ class ProperEscapingFunctionSniff extends Sniff {
 
 		$content = $this->tokens[ $html ]['content'];
 		if ( isset( Tokens::$stringTokens[ $this->tokens[ $html ]['code'] ] ) === true ) {
-			$content = Sniff::strip_quotes( $content );
+			$content = TextStrings::stripQuotes( $content );
 		}
 
 		$escaping_type = $this->escaping_functions[ $function_name ];

--- a/WordPressVIPMinimum/Sniffs/Security/UnderscorejsSniff.php
+++ b/WordPressVIPMinimum/Sniffs/Security/UnderscorejsSniff.php
@@ -9,6 +9,7 @@
 namespace WordPressVIPMinimum\Sniffs\Security;
 
 use PHP_CodeSniffer\Util\Tokens;
+use PHPCSUtils\Utils\TextStrings;
 use WordPressVIPMinimum\Sniffs\Sniff;
 
 /**
@@ -72,7 +73,7 @@ class UnderscorejsSniff extends Sniff {
 		/*
 		 * Ignore Gruntfile.js files as they are configuration, not code.
 		 */
-		$file_name = $this->strip_quotes( $this->phpcsFile->getFileName() );
+		$file_name = TextStrings::stripQuotes( $this->phpcsFile->getFileName() );
 		$file_name = strtolower( basename( $file_name ) );
 
 		if ( $file_name === 'gruntfile.js' ) {
@@ -120,7 +121,7 @@ class UnderscorejsSniff extends Sniff {
 			return;
 		}
 
-		$content = $this->strip_quotes( $this->tokens[ $stackPtr ]['content'] );
+		$content = TextStrings::stripQuotes( $this->tokens[ $stackPtr ]['content'] );
 
 		$match_count = preg_match_all( self::UNESCAPED_INTERPOLATE_REGEX, $content, $matches );
 		if ( $match_count > 0 ) {

--- a/WordPressVIPMinimum/Sniffs/Sniff.php
+++ b/WordPressVIPMinimum/Sniffs/Sniff.php
@@ -39,8 +39,8 @@ abstract class Sniff extends \WordPressCS\WordPress\Sniff {
 	 *                      Defaults to true.
 	 * @return array
 	 */
-	protected static function merge_custom_array( $custom, $base = array(), $flip = true ) {
-		if ( true === $flip ) {
+	public static function merge_custom_array( $custom, $base = [], $flip = true ) {
+		if ( $flip === true ) {
 			$base = array_filter( $base );
 		}
 
@@ -48,7 +48,7 @@ abstract class Sniff extends \WordPressCS\WordPress\Sniff {
 			return $base;
 		}
 
-		if ( true === $flip ) {
+		if ( $flip === true ) {
 			$custom = array_fill_keys( $custom, false );
 		}
 

--- a/WordPressVIPMinimum/Sniffs/Sniff.php
+++ b/WordPressVIPMinimum/Sniffs/Sniff.php
@@ -17,4 +17,45 @@ namespace WordPressVIPMinimum\Sniffs;
  * @package VIPCS\WordPressVIPMinimum
  */
 abstract class Sniff extends \WordPressCS\WordPress\Sniff {
+	/**
+	 * Merge a pre-set array with a ruleset-provided array.
+	 *
+	 * - By default flips custom lists to allow for using `isset()` instead
+	 *   of `in_array()`.
+	 * - When `$flip` is true:
+	 *   * Presumes the base array is in a `'value' => true` format.
+	 *   * Any custom items will be given the value `false` to be able to
+	 *     distinguish them from pre-set (base array) values.
+	 *   * Will filter previously added custom items out from the base array
+	 *     before merging/returning to allow for resetting to the base array.
+	 *
+	 * {@internal Function is static as it doesn't use any of the properties or others
+	 * methods anyway.}
+	 *
+	 * @param array $custom Custom list as provided via a ruleset.
+	 * @param array $base   Optional. Base list. Defaults to an empty array.
+	 *                      Expects `value => true` format when `$flip` is true.
+	 * @param bool  $flip   Optional. Whether or not to flip the custom list.
+	 *                      Defaults to true.
+	 * @return array
+	 */
+	protected static function merge_custom_array( $custom, $base = array(), $flip = true ) {
+		if ( true === $flip ) {
+			$base = array_filter( $base );
+		}
+
+		if ( empty( $custom ) || ! \is_array( $custom ) ) {
+			return $base;
+		}
+
+		if ( true === $flip ) {
+			$custom = array_fill_keys( $custom, false );
+		}
+
+		if ( empty( $base ) ) {
+			return $custom;
+		}
+
+		return array_merge( $base, $custom );
+	}
 }

--- a/WordPressVIPMinimum/Sniffs/UserExperience/AdminBarRemovalSniff.php
+++ b/WordPressVIPMinimum/Sniffs/UserExperience/AdminBarRemovalSniff.php
@@ -9,6 +9,7 @@
 
 namespace WordPressVIPMinimum\Sniffs\UserExperience;
 
+use PHPCSUtils\Utils\TextStrings;
 use WordPressCS\WordPress\AbstractFunctionParameterSniff;
 use PHP_CodeSniffer\Util\Tokens;
 
@@ -207,13 +208,13 @@ class AdminBarRemovalSniff extends AbstractFunctionParameterSniff {
 				break;
 
 			case 'add_filter':
-				$filter_name = $this->strip_quotes( $parameters[1]['raw'] );
+				$filter_name = TextStrings::stripQuotes( $parameters[1]['raw'] );
 				if ( $filter_name !== 'show_admin_bar' ) {
 					break;
 				}
 
 				$error = true;
-				if ( $this->remove_only === true && isset( $parameters[2]['raw'] ) && $this->strip_quotes( $parameters[2]['raw'] ) === '__return_true' ) {
+				if ( $this->remove_only === true && isset( $parameters[2]['raw'] ) && TextStrings::stripQuotes( $parameters[2]['raw'] ) === '__return_true' ) {
 					$error = false;
 				}
 				break;

--- a/WordPressVIPMinimum/ruleset-test.inc
+++ b/WordPressVIPMinimum/ruleset-test.inc
@@ -72,7 +72,7 @@ new WP_Query( array(
 // WordPress.WP.GlobalVariablesOverride
 $GLOBALS['wpdb'] = 'test'; // Error.
 
-// WordPress.PHP.StrictComparisons
+// Universal.Operators.StrictComparisons
 if ( true == $true ) { // Warning.
 }
 
@@ -555,7 +555,7 @@ str_replace( 'foo', array( 'bar', 'foo' ), 'foobar' ); // Error.
 
 // WordPressVIPMinimum.Security.Underscorejs
 echo "<script>
- _.templateSettings = { 
+ _.templateSettings = {
 	interpolate: /\{\{(.+?)\}\}/g" . // Warning.
 "};
  </script>";

--- a/WordPressVIPMinimum/ruleset.xml
+++ b/WordPressVIPMinimum/ruleset.xml
@@ -26,7 +26,9 @@
 	<rule ref="WordPress.DB.DirectDatabaseQuery"/>
 	<rule ref="WordPress.DB.SlowDBQuery"/>
 	<rule ref="WordPress.WP.GlobalVariablesOverride"/>
-	<rule ref="WordPress.PHP.StrictComparisons"/>
+	<rule ref="Universal.Operators.StrictComparisons" phpcs-only="true">
+		<type>warning</type>
+	</rule>
 	<rule ref="WordPress.CodeAnalysis.AssignmentInCondition"/>
 	<rule ref="WordPress.PHP.StrictInArray"/>
 	<rule ref="WordPress.PHP.DontExtract"/>
@@ -123,9 +125,31 @@
 		<!-- This is already covered in WordPressVIPMinimum.Functions.StripTags.StripTagsOneParameter -->
 		<exclude name="WordPress.WP.AlternativeFunctions.strip_tags_strip_tags"/>
 		<!-- This is already covered in WordPressVIPMinimum.Functions.RestrictedFunctions.file_ops_fwrite -->
-		<exclude name="WordPress.WP.AlternativeFunctions.file_system_read_fwrite"/>
+		<exclude name="WordPress.WP.AlternativeFunctions.file_system_operations_fwrite"/>
 		<!-- This is already covered in WordPressVIPMinimum.Functions.RestrictedFunctions.file_ops_file_put_contents -->
-		<exclude name="WordPress.WP.AlternativeFunctions.file_system_read_file_put_contents"/>
+		<exclude name="WordPress.WP.AlternativeFunctions.file_system_operations_file_put_contents"/>
+		<!-- This is already covered in WordPressVIPMinimum.Functions.RestrictedFunctions.file_ops_fputs -->
+		<exclude name="WordPress.WP.AlternativeFunctions.file_system_operations_fputs"/>
+		<!-- This is already covered in WordPressVIPMinimum.Functions.RestrictedFunctions.file_ops_is_writable -->
+		<exclude name="WordPress.WP.AlternativeFunctions.file_system_operations_is_writable"/>
+		<!-- This is already covered in WordPressVIPMinimum.Functions.RestrictedFunctions.file_ops_is_writeable -->
+		<exclude name="WordPress.WP.AlternativeFunctions.file_system_operations_is_writeable"/>
+		<!-- This is already covered in WordPressVIPMinimum.Functions.RestrictedFunctions.file_ops_touch -->
+		<exclude name="WordPress.WP.AlternativeFunctions.file_system_operations_touch"/>
+		<!-- This is already covered in WordPressVIPMinimum.Functions.RestrictedFunctions.directory_mkdir -->
+		<exclude name="WordPress.WP.AlternativeFunctions.file_system_operations_mkdir"/>
+		<!-- This is already covered in WordPressVIPMinimum.Functions.RestrictedFunctions.directory_rmdir -->
+		<exclude name="WordPress.WP.AlternativeFunctions.file_system_operations_rmdir"/>
+		<!-- This is already covered in WordPressVIPMinimum.Functions.RestrictedFunctions.chmod_chgrp -->
+		<exclude name="WordPress.WP.AlternativeFunctions.file_system_operations_chgrp"/>
+		<!-- This is already covered in WordPressVIPMinimum.Functions.RestrictedFunctions.chmod_chmod -->
+		<exclude name="WordPress.WP.AlternativeFunctions.file_system_operations_chmod"/>
+		<!-- This is already covered in WordPressVIPMinimum.Functions.RestrictedFunctions.chmod_chown -->
+		<exclude name="WordPress.WP.AlternativeFunctions.file_system_operations_chown"/>
+		<!-- This is already covered in WordPressVIPMinimum.Functions.RestrictedFunctions.file_ops_rename -->
+		<exclude name="WordPress.WP.AlternativeFunctions.rename_rename"/>
+		<!-- This is already covered in WordPressVIPMinimum.Functions.RestrictedFunctions.file_ops_unlink -->
+		<exclude name="WordPress.WP.AlternativeFunctions.unlink_unlink"/>
 	</rule>
 	<!-- VIP recommends other functions -->
 	<rule ref="WordPress.WP.AlternativeFunctions.curl_curl_init">

--- a/composer.json
+++ b/composer.json
@@ -23,6 +23,7 @@
 	"require": {
 		"php": ">=5.4",
 		"dealerdirect/phpcodesniffer-composer-installer": "^0.4.1 || ^0.5 || ^0.6.2 || ^0.7",
+		"phpcsstandards/phpcsutils": "^1.0",
 		"sirbrillig/phpcs-variable-analysis": "^2.11.1",
 		"squizlabs/php_codesniffer": "^3.7.1",
 		"wp-coding-standards/wpcs": "dev-develop"

--- a/composer.json
+++ b/composer.json
@@ -23,6 +23,7 @@
 	"require": {
 		"php": ">=5.4",
 		"dealerdirect/phpcodesniffer-composer-installer": "^0.4.1 || ^0.5 || ^0.6.2 || ^0.7",
+		"phpcsstandards/phpcsextra": "^1.0",
 		"phpcsstandards/phpcsutils": "^1.0",
 		"sirbrillig/phpcs-variable-analysis": "^2.11.1",
 		"squizlabs/php_codesniffer": "^3.7.1",

--- a/composer.json
+++ b/composer.json
@@ -47,7 +47,8 @@
 			"@lint",
 			"@check-cs",
 			"@run-tests",
-			"@check-complete-strict"
+			"@run-ruleset-tests",
+			"@check-complete"
 		],
 		"check-complete": [
 			"@php ./vendor/phpcsstandards/phpcsdevtools/bin/phpcs-check-feature-completeness -q ./WordPressVIPMinimum"
@@ -60,7 +61,7 @@
 			"bin/php-lint",
 			"bin/xml-lint"
 		],
-		"ruleset": "bin/ruleset-tests",
+		"run-ruleset-tests": "bin/ruleset-tests",
 		"run-tests": "bin/unit-tests",
 		"run-tests-coverage": "bin/unit-tests-coverage"
 	},

--- a/composer.json
+++ b/composer.json
@@ -35,25 +35,27 @@
 		}
 	},
 	"scripts": {
-		"install-codestandards": "Dealerdirect\\Composer\\Plugin\\Installers\\PHPCodeSniffer\\Plugin::run",
-		"ruleset": "bin/ruleset-tests",
+		"check-all": [
+			"@lint",
+			"@check-cs",
+			"@run-tests",
+			"@check-complete-strict",
+			"@ruleset"
+		],
+		"check-complete": [
+			"@php ./vendor/phpcsstandards/phpcsdevtools/bin/phpcs-check-feature-completeness -q ./WordPressVIPMinimum"
+		],
+		"check-complete-strict": [
+			"@php ./vendor/phpcsstandards/phpcsdevtools/bin/phpcs-check-feature-completeness ./WordPressVIPMinimum"
+		],
+		"check-cs": "bin/phpcs",
 		"lint": [
 			"bin/php-lint",
 			"bin/xml-lint"
 		],
-		"phpcs": "bin/phpcs",
-		"phpunit": "bin/unit-tests",
-		"coverage": "bin/unit-tests-coverage",
-		"check-complete": [
-			"@php ./vendor/phpcsstandards/phpcsdevtools/bin/phpcs-check-feature-completeness -q ./WordPressVIPMinimum"
-		],
-		"test": [
-			"@lint",
-			"@ruleset",
-			"@phpunit",
-			"@phpcs",
-			"@check-complete"
-		]
+		"ruleset": "bin/ruleset-tests",
+		"run-tests": "bin/unit-tests",
+		"run-tests-coverage": "bin/unit-tests-coverage"
 	},
 	"support": {
 		"issues": "https://github.com/Automattic/VIP-Coding-Standards/issues",

--- a/composer.json
+++ b/composer.json
@@ -47,8 +47,7 @@
 			"@lint",
 			"@check-cs",
 			"@run-tests",
-			"@check-complete-strict",
-			"@ruleset"
+			"@check-complete-strict"
 		],
 		"check-complete": [
 			"@php ./vendor/phpcsstandards/phpcsdevtools/bin/phpcs-check-feature-completeness -q ./WordPressVIPMinimum"

--- a/composer.json
+++ b/composer.json
@@ -57,6 +57,14 @@
 		"run-tests": "bin/unit-tests",
 		"run-tests-coverage": "bin/unit-tests-coverage"
 	},
+	"scripts-descriptions": {
+		"check-all": "Run all checks (lint, phpcs, feature completeness) and tests.",
+		"check-complete": "Check if all the sniffs have tests.",
+		"check-complete-strict": "Check if all the sniffs have unit tests and XML documentation.",
+		"check-cs": "Run the PHPCS script against the entire codebase.",
+		"lint": "Lint PHP files against parse errors.",
+		"run-tests": "Run all the unit tests for the VIP Coding Standards sniffs."
+	},
 	"support": {
 		"issues": "https://github.com/Automattic/VIP-Coding-Standards/issues",
 		"wiki": "https://github.com/Automattic/VIP-Coding-Standards/wiki",

--- a/composer.json
+++ b/composer.json
@@ -19,7 +19,7 @@
 		"php": ">=5.4",
 		"dealerdirect/phpcodesniffer-composer-installer": "^0.4.1 || ^0.5 || ^0.6.2 || ^0.7",
 		"sirbrillig/phpcs-variable-analysis": "^2.11.1",
-		"squizlabs/php_codesniffer": "^3.5.5",
+		"squizlabs/php_codesniffer": "^3.7.1",
 		"wp-coding-standards/wpcs": "^2.3"
 	},
 	"require-dev": {

--- a/composer.json
+++ b/composer.json
@@ -1,20 +1,25 @@
 {
 	"name": "automattic/vipwpcs",
-	"type": "phpcodesniffer-standard",
 	"description": "PHP_CodeSniffer rules (sniffs) to enforce WordPress VIP minimum coding conventions",
+	"license": "MIT",
+	"type": "phpcodesniffer-standard",
 	"keywords": [
 		"phpcs",
 		"static analysis",
 		"standards",
 		"WordPress"
 	],
-	"license": "MIT",
 	"authors": [
 		{
 			"name": "Contributors",
 			"homepage": "https://github.com/Automattic/VIP-Coding-Standards/graphs/contributors"
 		}
 	],
+	"support": {
+		"issues": "https://github.com/Automattic/VIP-Coding-Standards/issues",
+		"wiki": "https://github.com/Automattic/VIP-Coding-Standards/wiki",
+		"source": "https://github.com/Automattic/VIP-Coding-Standards"
+	},
 	"require": {
 		"php": ">=5.4",
 		"dealerdirect/phpcodesniffer-composer-installer": "^0.4.1 || ^0.5 || ^0.6.2 || ^0.7",
@@ -23,8 +28,8 @@
 		"wp-coding-standards/wpcs": "dev-develop"
 	},
 	"require-dev": {
-		"php-parallel-lint/php-parallel-lint": "^1.3.2",
 		"php-parallel-lint/php-console-highlighter": "^1.0.0",
+		"php-parallel-lint/php-parallel-lint": "^1.3.2",
 		"phpcompatibility/php-compatibility": "^9",
 		"phpcsstandards/phpcsdevtools": "^1.0",
 		"phpunit/phpunit": "^4 || ^5 || ^6 || ^7"
@@ -66,10 +71,5 @@
 		"check-cs": "Run the PHPCS script against the entire codebase.",
 		"lint": "Lint PHP files against parse errors.",
 		"run-tests": "Run all the unit tests for the VIP Coding Standards sniffs."
-	},
-	"support": {
-		"issues": "https://github.com/Automattic/VIP-Coding-Standards/issues",
-		"wiki": "https://github.com/Automattic/VIP-Coding-Standards/wiki",
-		"source": "https://github.com/Automattic/VIP-Coding-Standards"
 	}
 }

--- a/composer.json
+++ b/composer.json
@@ -20,7 +20,7 @@
 		"dealerdirect/phpcodesniffer-composer-installer": "^0.4.1 || ^0.5 || ^0.6.2 || ^0.7",
 		"sirbrillig/phpcs-variable-analysis": "^2.11.1",
 		"squizlabs/php_codesniffer": "^3.7.1",
-		"wp-coding-standards/wpcs": "^2.3"
+		"wp-coding-standards/wpcs": "dev-develop"
 	},
 	"require-dev": {
 		"php-parallel-lint/php-parallel-lint": "^1.3.2",
@@ -29,6 +29,8 @@
 		"phpcsstandards/phpcsdevtools": "^1.0",
 		"phpunit/phpunit": "^4 || ^5 || ^6 || ^7"
 	},
+	"minimum-stability": "dev",
+	"prefer-stable": true,
 	"config": {
 		"allow-plugins": {
 			"dealerdirect/phpcodesniffer-composer-installer": true

--- a/tests/RulesetTest.php
+++ b/tests/RulesetTest.php
@@ -98,6 +98,9 @@ class RulesetTest {
 			$this->phpcs_bin = realpath( $phpcs_bin );
 		}
 
+		// phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped
+		printf( 'Testing ' . $this->ruleset . ' ruleset.' . PHP_EOL );
+
 		$output = $this->collect_phpcs_result();
 
 		if ( ! is_object( $output ) || empty( $output ) ) {
@@ -148,6 +151,7 @@ class RulesetTest {
 			$this->phpcs_bin,
 			$this->ruleset
 		);
+
 		// phpcs:ignore WordPress.PHP.DiscouragedPHPFunctions.system_calls_shell_exec -- This is test code, not production.
 		$output = shell_exec( $shell );
 

--- a/tests/RulesetTest.php
+++ b/tests/RulesetTest.php
@@ -99,7 +99,7 @@ class RulesetTest {
 		}
 
 		// phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped
-		printf( 'Testing ' . $this->ruleset . ' ruleset.' . PHP_EOL );
+		printf( 'Testing the ' . $this->ruleset . ' ruleset.' . PHP_EOL );
 
 		$output = $this->collect_phpcs_result();
 
@@ -147,7 +147,7 @@ class RulesetTest {
 
 		$shell = sprintf(
 			'%1$s%2$s --severity=1 --standard=%3$s --report=json ./%3$s/ruleset-test.inc',
-			$php, // Current PHP executable if avaiable.
+			$php, // Current PHP executable if available.
 			$this->phpcs_bin,
 			$this->ruleset
 		);


### PR DESCRIPTION
Once #734 has been merged, this can be rebased to just show the ruleset tests changes.

----

### Ruleset tests: update for WPCS 3.0

The ruleset tests were failing mainly due to the [renaming of some violation codes](https://github.com/WordPress/WordPress-Coding-Standards/pull/2108) that we were excluding.

The other change to account for was the [replacement of a WPCS StrictComparisons sniff with a PHPCSExtras Universal sniff](https://github.com/WordPress/WordPress-Coding-Standards/pull/1919). The sniff in PHPCSExtra contains a fixer. As this is a risky fixer, this fixer is turned off for WPCS. The sniff in PHPCSExtra will provide metrics about loose versus strict comparisons.

### Ruleset tests: Add label before test runs

Make it clear which ruleset being tested, even on a test failure.

### Enable ruleset tests

Now the issues have been address, these can be enabled again in `composer check-all` and a Github workflow.