### PR TITLE
AdminBarRemovalUnitTest: Ensure final reset is read

### DIFF
--- a/WordPressVIPMinimum/Tests/UserExperience/AdminBarRemovalUnitTest.inc
+++ b/WordPressVIPMinimum/Tests/UserExperience/AdminBarRemovalUnitTest.inc
@@ -105,4 +105,5 @@ EOT;
 		opacity: 1; /* Bad. */
 	}
 </style>
+<?php
 /* phpcs:set WordPressVIPMinimum.UserExperience.AdminBarRemoval remove_only true */


### PR DESCRIPTION
The `// phpcs:set` comment should be a PHP comment, but the PHP opening delimiter was missing.