### PR TITLE
Composer: up the minimum PHPCS version to 3.7.1

### DIFF
--- a/.github/workflows/basics.yml
+++ b/.github/workflows/basics.yml
@@ -7,6 +7,7 @@ on:
     paths-ignore:
       - '**.md'
   pull_request:
+
   # Allow manually triggering the workflow.
   workflow_dispatch:
 

--- a/.github/workflows/quicktest.yml
+++ b/.github/workflows/quicktest.yml
@@ -30,15 +30,14 @@ jobs:
             phpcs_version: 'dev-master'
             wpcs_version: '2.3.*'
           - php: '5.4'
-            phpcs_version: '3.5.5'
+            phpcs_version: '3.7.1'
             wpcs_version: '2.3.*'
 
           - php: 'latest'
             phpcs_version: 'dev-master'
             wpcs_version: '2.3.*'
           - php: 'latest'
-            # PHPCS 3.6.1 is the lowest version of PHPCS which supports PHP 8.1.
-            phpcs_version: '3.6.1'
+            phpcs_version: '3.7.1'
             wpcs_version: '2.3.*'
 
     name: "QTest${{ matrix.phpcs_version == 'dev-master' && ' + Lint' || '' }}: PHP ${{ matrix.php }} - PHPCS ${{ matrix.phpcs_version }}"

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -9,6 +9,7 @@ on:
     paths-ignore:
       - '**.md'
   pull_request:
+
   # Allow manually triggering the workflow.
   workflow_dispatch:
 
@@ -64,45 +65,17 @@ jobs:
       # - phpcs_version: The PHPCS versions to test against.
       #   IMPORTANT: test runs shouldn't fail because of PHPCS being incompatible with a PHP version.
       #   - PHPCS will run without errors on PHP 5.4 - 7.4 on any supported version.
-      #   - PHP 8.0 needs PHPCS 3.5.7+ to run without errors.
+      #   - PHP 8.0 needs PHPCS 3.5.7+ to run without errors, and we require a higher minimum version.
+      #   - PHP 8.1 needs PHPCS 3.6.1+ to run without errors, but works best with 3.7.1+, and we require at least this minimum version.
       # - The `wpcs_version` key is added to allow additional test builds when multiple WPCS versions
       #   would be supported. As, at this time, only the latest stable release of WPCS is supported,
       #   no additional versions are included in the array.
       # - experimental: Whether the build is "allowed to fail".
       matrix:
-        php: ['5.4', '5.5', '5.6', '7.0', '7.1', '7.2', '7.3', '7.4']
-        phpcs_version: ['3.5.5', 'dev-master']
+        php: ['5.4', '5.5', '5.6', '7.0', '7.1', '7.2', '7.3', '7.4', '8.0', '8.1']
+        phpcs_version: ['3.7.1', 'dev-master']
         wpcs_version: ['2.3.*']
         experimental: [false]
-
-        include:
-          # Complete the matrix by adding PHP 8.0, but only test against compatible PHPCS versions.
-          - php: '8.0'
-            phpcs_version: 'dev-master'
-            wpcs_version: '2.3.*'
-            experimental: false
-          - php: '8.0'
-            # PHPCS 3.5.7 is the lowest version of PHPCS which supports PHP 8.0.
-            phpcs_version: '3.5.7'
-            wpcs_version: '2.3.*'
-            experimental: false
-
-          # Complete the matrix by adding PHP 8.1, but only test against compatible PHPCS versions.
-          - php: '8.1'
-            phpcs_version: 'dev-master'
-            wpcs_version: '2.3.*'
-            experimental: false
-          - php: '8.1'
-            # PHPCS 3.6.1 is the lowest version of PHPCS which supports PHP 8.1.
-            phpcs_version: '3.6.1'
-            wpcs_version: '2.3.*'
-            experimental: false
-
-          # Experimental builds. These are allowed to fail.
-          #- php: '8.2'
-          #  phpcs_version: 'dev-master'
-          #  wpcs_version: '2.3.*'
-          #  experimental: true
 
     name: "Test: PHP ${{ matrix.php }} - PHPCS ${{ matrix.phpcs_version }} - WPCS ${{ matrix.wpcs_version }}"
 

--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ Go to https://docs.wpvip.com/technical-references/code-review/phpcs-report/ to l
 ## Minimal requirements
 
 * PHP 5.4+
-* [PHPCS 3.5.5+](https://github.com/squizlabs/PHP_CodeSniffer/releases)
+* [PHPCS 3.7.1+](https://github.com/squizlabs/PHP_CodeSniffer/releases)
 * [WPCS 2.3.0+](https://github.com/WordPress-Coding-Standards/WordPress-Coding-Standards/releases)
 * [VariableAnalysis 2.11.1+](https://github.com/sirbrillig/phpcs-variable-analysis/releases)
 

--- a/composer.json
+++ b/composer.json
@@ -19,7 +19,7 @@
 		"php": ">=5.4",
 		"dealerdirect/phpcodesniffer-composer-installer": "^0.4.1 || ^0.5 || ^0.6.2 || ^0.7 || ^1.0",
 		"sirbrillig/phpcs-variable-analysis": "^2.11.1",
-		"squizlabs/php_codesniffer": "^3.5.5",
+		"squizlabs/php_codesniffer": "^3.7.1",
 		"wp-coding-standards/wpcs": "^2.3"
 	},
 	"require-dev": {


### PR DESCRIPTION
Add support for PHP 8.1 features, including fixing a retokenization of reserved keywords bug in PHPCS 3.7.0.

With a new minimum version of PHPCS, this allows consolidation and simplification of the testing matrix in the `test.yml` workflow.

I'd like to get this into 2.3.4, but this may be semantically better for 3.0.0?