### PR TITLE
RestrictedFunctions: Add Warning for filemtime()

### DIFF
--- a/WordPressVIPMinimum/Sniffs/Functions/RestrictedFunctionsSniff.php
+++ b/WordPressVIPMinimum/Sniffs/Functions/RestrictedFunctionsSniff.php
@@ -223,6 +223,13 @@ class RestrictedFunctionsSniff extends AbstractFunctionRestrictionsSniff {
 					'lchown',
 				],
 			],
+			'filemtime' => [
+				'type'      => 'warning',
+				'message'   => 'VIP discourages the use of %s(), as each time a container is created, it would result in a different value for files in that container. See https://docs.wpvip.com/technical-references/vip-platform/file-concatenation-and-minification/ for more info.',
+				'functions' => [
+					'filemtime',
+				],
+			],
 			'stats_get_csv' => [
 				'type'      => 'error',
 				'message'   => 'Using `%s` outside of Jetpack context pollutes the stats_cache entry in the wp_options table. We recommend building a custom function instead.',

--- a/WordPressVIPMinimum/Tests/Functions/RestrictedFunctionsUnitTest.inc
+++ b/WordPressVIPMinimum/Tests/Functions/RestrictedFunctionsUnitTest.inc
@@ -214,14 +214,14 @@ $c = new Foo();
 $c->create_function = 'bar' . ( 1 === 1 ?? 'foo' ); // Ok.
 $wp_random_testing = create_function2( '$a, $b', 'return ( $b / $a ); '); // Ok.
 $wp_random_testing = create_function3( '$a, $b', 'return ( $b / $a ); '); // Ok.
-
-
-
-
-
-
-
-
+filemtime(); // Warning.
+wp_register_script(
+	'script-name',
+	get_template_directory_uri() . '/js/script.js',
+	array(),
+	filemtime( get_template_directory() . '/js/script.js' ), // Warning.
+	false
+);
 wpcom_vip_get_page_by_path(); // Ok - VIP recommended version of get_page_by_path().
 get_page_by_path( $page_path ); // Warning.
 

--- a/WordPressVIPMinimum/Tests/Functions/RestrictedFunctionsUnitTest.php
+++ b/WordPressVIPMinimum/Tests/Functions/RestrictedFunctionsUnitTest.php
@@ -126,6 +126,8 @@ class RestrictedFunctionsUnitTest extends AbstractSniffUnitTest {
 			138 => 1,
 			139 => 1,
 			208 => 1,
+			217 => 1,
+			222 => 1,
 			226 => 1,
 		];
 	}


### PR DESCRIPTION
Because of the container-based infrastructure, VIP does not recommend using the function `filemtime()` to populate a value for versioning; each time a container is created, it would result in a different value.

See https://docs.wpvip.com/technical-references/vip-platform/file-concatenation-and-minification/

Closes #684.