### PR TITLE
CS: Remove extra line at end of classes

### DIFF
--- a/WordPressVIPMinimum/Sniffs/AbstractVariableRestrictionsSniff.php
+++ b/WordPressVIPMinimum/Sniffs/AbstractVariableRestrictionsSniff.php
@@ -227,5 +227,4 @@ abstract class AbstractVariableRestrictionsSniff extends Sniff {
 		);
 		return $pattern;
 	}
-
 }

--- a/WordPressVIPMinimum/Sniffs/Constants/ConstantStringSniff.php
+++ b/WordPressVIPMinimum/Sniffs/Constants/ConstantStringSniff.php
@@ -76,5 +76,4 @@ class ConstantStringSniff extends Sniff {
 		$data    = [ $this->tokens[ $stackPtr ]['content'] ];
 		$this->phpcsFile->addError( $message, $tstring_token, 'NotCheckingConstantName', $data );
 	}
-
 }

--- a/WordPressVIPMinimum/Sniffs/Files/IncludingNonPHPFileSniff.php
+++ b/WordPressVIPMinimum/Sniffs/Files/IncludingNonPHPFileSniff.php
@@ -101,5 +101,4 @@ class IncludingNonPHPFileSniff extends Sniff {
 
 		} while ( $curStackPtr > $stackPtr );
 	}
-
 }

--- a/WordPressVIPMinimum/Sniffs/Functions/CheckReturnValueSniff.php
+++ b/WordPressVIPMinimum/Sniffs/Functions/CheckReturnValueSniff.php
@@ -311,5 +311,4 @@ class CheckReturnValueSniff extends Sniff {
 		$data    = [ $variableName, $callee ];
 		$this->phpcsFile->addError( $message, $stackPtr, 'NonCheckedVariable', $data );
 	}
-
 }

--- a/WordPressVIPMinimum/Sniffs/JS/DangerouslySetInnerHTMLSniff.php
+++ b/WordPressVIPMinimum/Sniffs/JS/DangerouslySetInnerHTMLSniff.php
@@ -69,5 +69,4 @@ class DangerouslySetInnerHTMLSniff extends Sniff {
 		$data    = [ $this->tokens[ $stackPtr ]['content'] ];
 		$this->phpcsFile->addError( $message, $stackPtr, 'Found', $data );
 	}
-
 }

--- a/WordPressVIPMinimum/Sniffs/JS/HTMLExecutingFunctionsSniff.php
+++ b/WordPressVIPMinimum/Sniffs/JS/HTMLExecutingFunctionsSniff.php
@@ -130,5 +130,4 @@ class HTMLExecutingFunctionsSniff extends Sniff {
 			}
 		}
 	}
-
 }

--- a/WordPressVIPMinimum/Sniffs/JS/InnerHTMLSniff.php
+++ b/WordPressVIPMinimum/Sniffs/JS/InnerHTMLSniff.php
@@ -83,5 +83,4 @@ class InnerHTMLSniff extends Sniff {
 			$this->phpcsFile->addWarning( $message, $stackPtr, 'Found', $data );
 		}
 	}
-
 }

--- a/WordPressVIPMinimum/Sniffs/JS/StringConcatSniff.php
+++ b/WordPressVIPMinimum/Sniffs/JS/StringConcatSniff.php
@@ -72,5 +72,4 @@ class StringConcatSniff extends Sniff {
 		$message = 'HTML string concatenation detected, this is a security risk, use DOM node construction or a templating language instead: %s.';
 		$this->phpcsFile->addError( $message, $stackPtr, 'Found', $data );
 	}
-
 }

--- a/WordPressVIPMinimum/Sniffs/JS/StrippingTagsSniff.php
+++ b/WordPressVIPMinimum/Sniffs/JS/StrippingTagsSniff.php
@@ -72,5 +72,4 @@ class StrippingTagsSniff extends Sniff {
 			$this->phpcsFile->addError( $message, $stackPtr, 'VulnerableTagStripping' );
 		}
 	}
-
 }

--- a/WordPressVIPMinimum/Sniffs/JS/WindowSniff.php
+++ b/WordPressVIPMinimum/Sniffs/JS/WindowSniff.php
@@ -127,5 +127,4 @@ class WindowSniff extends Sniff {
 		$message = 'Data from JS global "%s" may contain user-supplied values and should be sanitized before output to prevent XSS.';
 		$this->phpcsFile->addError( $message, $stackPtr, $nextNextToken, $data );
 	}
-
 }

--- a/WordPressVIPMinimum/Sniffs/Performance/CacheValueOverrideSniff.php
+++ b/WordPressVIPMinimum/Sniffs/Performance/CacheValueOverrideSniff.php
@@ -142,5 +142,4 @@ class CacheValueOverrideSniff extends Sniff {
 
 		return $previous;
 	}
-
 }

--- a/WordPressVIPMinimum/Sniffs/Performance/FetchingRemoteDataSniff.php
+++ b/WordPressVIPMinimum/Sniffs/Performance/FetchingRemoteDataSniff.php
@@ -57,5 +57,4 @@ class FetchingRemoteDataSniff extends Sniff {
 			$this->phpcsFile->addWarning( $message, $stackPtr, 'FileGetContentsRemoteFile', $data );
 		}
 	}
-
 }

--- a/WordPressVIPMinimum/Sniffs/Performance/NoPagingSniff.php
+++ b/WordPressVIPMinimum/Sniffs/Performance/NoPagingSniff.php
@@ -57,5 +57,4 @@ class NoPagingSniff extends AbstractArrayAssignmentRestrictionsSniff {
 
 		return false;
 	}
-
 }

--- a/WordPressVIPMinimum/Sniffs/Performance/OrderByRandSniff.php
+++ b/WordPressVIPMinimum/Sniffs/Performance/OrderByRandSniff.php
@@ -55,5 +55,4 @@ class OrderByRandSniff extends AbstractArrayAssignmentRestrictionsSniff {
 
 		return false;
 	}
-
 }

--- a/WordPressVIPMinimum/Sniffs/Performance/RegexpCompareSniff.php
+++ b/WordPressVIPMinimum/Sniffs/Performance/RegexpCompareSniff.php
@@ -61,5 +61,4 @@ class RegexpCompareSniff extends AbstractArrayAssignmentRestrictionsSniff {
 			return 'Detected regular expression comparison. `%s` is set to `%s`.';
 		}
 	}
-
 }

--- a/WordPressVIPMinimum/Sniffs/Performance/RemoteRequestTimeoutSniff.php
+++ b/WordPressVIPMinimum/Sniffs/Performance/RemoteRequestTimeoutSniff.php
@@ -57,5 +57,4 @@ class RemoteRequestTimeoutSniff extends AbstractArrayAssignmentRestrictionsSniff
 			return 'Detected high remote request timeout. `%s` is set to `%d`.';
 		}
 	}
-
 }

--- a/WordPressVIPMinimum/Sniffs/Performance/WPQueryParamsSniff.php
+++ b/WordPressVIPMinimum/Sniffs/Performance/WPQueryParamsSniff.php
@@ -100,5 +100,4 @@ class WPQueryParamsSniff extends AbstractArrayAssignmentRestrictionsSniff {
 	public function callback( $key, $val, $line, $group ) {
 		return true;
 	}
-
 }

--- a/WordPressVIPMinimum/Sniffs/Security/EscapingVoidReturnFunctionsSniff.php
+++ b/WordPressVIPMinimum/Sniffs/Security/EscapingVoidReturnFunctionsSniff.php
@@ -66,5 +66,4 @@ class EscapingVoidReturnFunctionsSniff extends Sniff {
 			return;
 		}
 	}
-
 }

--- a/WordPressVIPMinimum/Sniffs/Security/MustacheSniff.php
+++ b/WordPressVIPMinimum/Sniffs/Security/MustacheSniff.php
@@ -73,5 +73,4 @@ class MustacheSniff extends Sniff {
 			$this->phpcsFile->addWarning( $message, $stackPtr, 'SafeString' );
 		}
 	}
-
 }

--- a/WordPressVIPMinimum/Sniffs/Security/TwigSniff.php
+++ b/WordPressVIPMinimum/Sniffs/Security/TwigSniff.php
@@ -58,5 +58,4 @@ class TwigSniff extends Sniff {
 			$this->phpcsFile->addWarning( $message, $stackPtr, 'RawFound' );
 		}
 	}
-
 }

--- a/WordPressVIPMinimum/Sniffs/Security/UnderscorejsSniff.php
+++ b/WordPressVIPMinimum/Sniffs/Security/UnderscorejsSniff.php
@@ -158,5 +158,4 @@ class UnderscorejsSniff extends Sniff {
 			$this->phpcsFile->addWarning( $message, $stackPtr, 'InterpolateFound' );
 		}
 	}
-
 }

--- a/WordPressVIPMinimum/Sniffs/Security/VuejsSniff.php
+++ b/WordPressVIPMinimum/Sniffs/Security/VuejsSniff.php
@@ -51,5 +51,4 @@ class VuejsSniff extends Sniff {
 			$this->phpcsFile->addWarning( $message, $stackPtr, 'RawHTMLDirectiveFound' );
 		}
 	}
-
 }

--- a/WordPressVIPMinimum/Sniffs/UserExperience/AdminBarRemovalSniff.php
+++ b/WordPressVIPMinimum/Sniffs/UserExperience/AdminBarRemovalSniff.php
@@ -425,5 +425,4 @@ class AdminBarRemovalSniff extends AbstractFunctionParameterSniff {
 
 		return $content !== null && strpos( $content, '<' . $tag_name ) !== false;
 	}
-
 }

--- a/WordPressVIPMinimum/Sniffs/Variables/RestrictedVariablesSniff.php
+++ b/WordPressVIPMinimum/Sniffs/Variables/RestrictedVariablesSniff.php
@@ -66,5 +66,4 @@ class RestrictedVariablesSniff extends AbstractVariableRestrictionsSniff {
 			],
 		];
 	}
-
 }

--- a/WordPressVIPMinimum/Sniffs/Variables/ServerVariablesSniff.php
+++ b/WordPressVIPMinimum/Sniffs/Variables/ServerVariablesSniff.php
@@ -71,5 +71,4 @@ class ServerVariablesSniff extends Sniff {
 			$this->phpcsFile->addError( $message, $stackPtr, 'UserControlledHeaders', $data );
 		}
 	}
-
 }

--- a/WordPressVIPMinimum/Tests/Classes/DeclarationCompatibilityUnitTest.php
+++ b/WordPressVIPMinimum/Tests/Classes/DeclarationCompatibilityUnitTest.php
@@ -60,5 +60,4 @@ class DeclarationCompatibilityUnitTest extends AbstractSniffUnitTest {
 	public function getWarningList() {
 		return [];
 	}
-
 }

--- a/WordPressVIPMinimum/Tests/Classes/RestrictedExtendClassesUnitTest.php
+++ b/WordPressVIPMinimum/Tests/Classes/RestrictedExtendClassesUnitTest.php
@@ -40,5 +40,4 @@ class RestrictedExtendClassesUnitTest extends AbstractSniffUnitTest {
 			12 => 1,
 		];
 	}
-
 }

--- a/WordPressVIPMinimum/Tests/Compatibility/ZoninatorUnitTest.php
+++ b/WordPressVIPMinimum/Tests/Compatibility/ZoninatorUnitTest.php
@@ -40,5 +40,4 @@ class ZoninatorUnitTest extends AbstractSniffUnitTest {
 			6 => 1,
 		];
 	}
-
 }

--- a/WordPressVIPMinimum/Tests/Constants/ConstantStringUnitTest.php
+++ b/WordPressVIPMinimum/Tests/Constants/ConstantStringUnitTest.php
@@ -38,5 +38,4 @@ class ConstantStringUnitTest extends AbstractSniffUnitTest {
 	public function getWarningList() {
 		return [];
 	}
-
 }

--- a/WordPressVIPMinimum/Tests/Constants/RestrictedConstantsUnitTest.php
+++ b/WordPressVIPMinimum/Tests/Constants/RestrictedConstantsUnitTest.php
@@ -42,5 +42,4 @@ class RestrictedConstantsUnitTest extends AbstractSniffUnitTest {
 			7 => 2,
 		];
 	}
-
 }

--- a/WordPressVIPMinimum/Tests/Files/IncludingFileUnitTest.php
+++ b/WordPressVIPMinimum/Tests/Files/IncludingFileUnitTest.php
@@ -48,5 +48,4 @@ class IncludingFileUnitTest extends AbstractSniffUnitTest {
 			33 => 1,
 		];
 	}
-
 }

--- a/WordPressVIPMinimum/Tests/Files/IncludingNonPHPFileUnitTest.php
+++ b/WordPressVIPMinimum/Tests/Files/IncludingNonPHPFileUnitTest.php
@@ -59,5 +59,4 @@ class IncludingNonPHPFileUnitTest extends AbstractSniffUnitTest {
 	public function getWarningList() {
 		return [];
 	}
-
 }

--- a/WordPressVIPMinimum/Tests/Functions/CheckReturnValueUnitTest.php
+++ b/WordPressVIPMinimum/Tests/Functions/CheckReturnValueUnitTest.php
@@ -41,5 +41,4 @@ class CheckReturnValueUnitTest extends AbstractSniffUnitTest {
 	public function getWarningList() {
 		return [];
 	}
-
 }

--- a/WordPressVIPMinimum/Tests/Functions/DynamicCallsUnitTest.php
+++ b/WordPressVIPMinimum/Tests/Functions/DynamicCallsUnitTest.php
@@ -39,5 +39,4 @@ class DynamicCallsUnitTest extends AbstractSniffUnitTest {
 	public function getWarningList() {
 		return [];
 	}
-
 }

--- a/WordPressVIPMinimum/Tests/Functions/RestrictedFunctionsUnitTest.php
+++ b/WordPressVIPMinimum/Tests/Functions/RestrictedFunctionsUnitTest.php
@@ -129,5 +129,4 @@ class RestrictedFunctionsUnitTest extends AbstractSniffUnitTest {
 			226 => 1,
 		];
 	}
-
 }

--- a/WordPressVIPMinimum/Tests/Functions/StripTagsUnitTest.php
+++ b/WordPressVIPMinimum/Tests/Functions/StripTagsUnitTest.php
@@ -41,5 +41,4 @@ class StripTagsUnitTest extends AbstractSniffUnitTest {
 			13 => 1,
 		];
 	}
-
 }

--- a/WordPressVIPMinimum/Tests/Hooks/AlwaysReturnInFilterUnitTest.php
+++ b/WordPressVIPMinimum/Tests/Hooks/AlwaysReturnInFilterUnitTest.php
@@ -47,5 +47,4 @@ class AlwaysReturnInFilterUnitTest extends AbstractSniffUnitTest {
 			180 => 1,
 		];
 	}
-
 }

--- a/WordPressVIPMinimum/Tests/Hooks/PreGetPostsUnitTest.php
+++ b/WordPressVIPMinimum/Tests/Hooks/PreGetPostsUnitTest.php
@@ -45,5 +45,4 @@ class PreGetPostsUnitTest extends AbstractSniffUnitTest {
 			133 => 1,
 		];
 	}
-
 }

--- a/WordPressVIPMinimum/Tests/Hooks/RestrictedHooksUnitTest.php
+++ b/WordPressVIPMinimum/Tests/Hooks/RestrictedHooksUnitTest.php
@@ -52,5 +52,4 @@ class RestrictedHooksUnitTest extends AbstractSniffUnitTest {
 			23 => 1,
 		];
 	}
-
 }

--- a/WordPressVIPMinimum/Tests/JS/DangerouslySetInnerHTMLUnitTest.php
+++ b/WordPressVIPMinimum/Tests/JS/DangerouslySetInnerHTMLUnitTest.php
@@ -37,5 +37,4 @@ class DangerouslySetInnerHTMLUnitTest extends AbstractSniffUnitTest {
 	public function getWarningList() {
 		return [];
 	}
-
 }

--- a/WordPressVIPMinimum/Tests/JS/HTMLExecutingFunctionsUnitTest.php
+++ b/WordPressVIPMinimum/Tests/JS/HTMLExecutingFunctionsUnitTest.php
@@ -62,5 +62,4 @@ class HTMLExecutingFunctionsUnitTest extends AbstractSniffUnitTest {
 			48 => 1,
 		];
 	}
-
 }

--- a/WordPressVIPMinimum/Tests/JS/InnerHTMLUnitTest.php
+++ b/WordPressVIPMinimum/Tests/JS/InnerHTMLUnitTest.php
@@ -37,5 +37,4 @@ class InnerHTMLUnitTest extends AbstractSniffUnitTest {
 			5 => 1,
 		];
 	}
-
 }

--- a/WordPressVIPMinimum/Tests/JS/StringConcatUnitTest.php
+++ b/WordPressVIPMinimum/Tests/JS/StringConcatUnitTest.php
@@ -37,5 +37,4 @@ class StringConcatUnitTest extends AbstractSniffUnitTest {
 	public function getWarningList() {
 		return [];
 	}
-
 }

--- a/WordPressVIPMinimum/Tests/JS/StrippingTagsUnitTest.php
+++ b/WordPressVIPMinimum/Tests/JS/StrippingTagsUnitTest.php
@@ -37,5 +37,4 @@ class StrippingTagsUnitTest extends AbstractSniffUnitTest {
 	public function getWarningList() {
 		return [];
 	}
-
 }

--- a/WordPressVIPMinimum/Tests/JS/WindowUnitTest.php
+++ b/WordPressVIPMinimum/Tests/JS/WindowUnitTest.php
@@ -57,5 +57,4 @@ class WindowUnitTest extends AbstractSniffUnitTest {
 			10 => 1,
 		];
 	}
-
 }

--- a/WordPressVIPMinimum/Tests/Performance/BatcacheWhitelistedParamsUnitTest.php
+++ b/WordPressVIPMinimum/Tests/Performance/BatcacheWhitelistedParamsUnitTest.php
@@ -38,5 +38,4 @@ class BatcacheWhitelistedParamsUnitTest extends AbstractSniffUnitTest {
 			7 => 1,
 		];
 	}
-
 }

--- a/WordPressVIPMinimum/Tests/Performance/CacheValueOverrideUnitTest.php
+++ b/WordPressVIPMinimum/Tests/Performance/CacheValueOverrideUnitTest.php
@@ -37,5 +37,4 @@ class CacheValueOverrideUnitTest extends AbstractSniffUnitTest {
 	public function getWarningList() {
 		return [];
 	}
-
 }

--- a/WordPressVIPMinimum/Tests/Performance/FetchingRemoteDataUnitTest.php
+++ b/WordPressVIPMinimum/Tests/Performance/FetchingRemoteDataUnitTest.php
@@ -37,5 +37,4 @@ class FetchingRemoteDataUnitTest extends AbstractSniffUnitTest {
 			7 => 1,
 		];
 	}
-
 }

--- a/WordPressVIPMinimum/Tests/Performance/NoPagingUnitTest.php
+++ b/WordPressVIPMinimum/Tests/Performance/NoPagingUnitTest.php
@@ -40,5 +40,4 @@ class NoPagingUnitTest extends AbstractSniffUnitTest {
 	public function getWarningList() {
 		return [];
 	}
-
 }

--- a/WordPressVIPMinimum/Tests/Performance/OrderByRandUnitTest.php
+++ b/WordPressVIPMinimum/Tests/Performance/OrderByRandUnitTest.php
@@ -44,5 +44,4 @@ class OrderByRandUnitTest extends AbstractSniffUnitTest {
 	public function getWarningList() {
 		return [];
 	}
-
 }

--- a/WordPressVIPMinimum/Tests/Performance/RegexpCompareUnitTest.php
+++ b/WordPressVIPMinimum/Tests/Performance/RegexpCompareUnitTest.php
@@ -40,5 +40,4 @@ class RegexpCompareUnitTest extends AbstractSniffUnitTest {
 	public function getWarningList() {
 		return [];
 	}
-
 }

--- a/WordPressVIPMinimum/Tests/Performance/RemoteRequestTimeoutUnitTest.php
+++ b/WordPressVIPMinimum/Tests/Performance/RemoteRequestTimeoutUnitTest.php
@@ -37,5 +37,4 @@ class RemoteRequestTimeoutUnitTest extends AbstractSniffUnitTest {
 	public function getWarningList() {
 		return [];
 	}
-
 }

--- a/WordPressVIPMinimum/Tests/Performance/TaxonomyMetaInOptionsUnitTest.php
+++ b/WordPressVIPMinimum/Tests/Performance/TaxonomyMetaInOptionsUnitTest.php
@@ -42,5 +42,4 @@ class TaxonomyMetaInOptionsUnitTest extends AbstractSniffUnitTest {
 			8 => 1,
 		];
 	}
-
 }

--- a/WordPressVIPMinimum/Tests/Performance/WPQueryParamsUnitTest.php
+++ b/WordPressVIPMinimum/Tests/Performance/WPQueryParamsUnitTest.php
@@ -42,5 +42,4 @@ class WPQueryParamsUnitTest extends AbstractSniffUnitTest {
 			21 => 1,
 		];
 	}
-
 }

--- a/WordPressVIPMinimum/Tests/Security/EscapingVoidReturnFunctionsUnitTest.php
+++ b/WordPressVIPMinimum/Tests/Security/EscapingVoidReturnFunctionsUnitTest.php
@@ -37,5 +37,4 @@ class EscapingVoidReturnFunctionsUnitTest extends AbstractSniffUnitTest {
 	public function getWarningList() {
 		return [];
 	}
-
 }

--- a/WordPressVIPMinimum/Tests/Security/ExitAfterRedirectUnitTest.php
+++ b/WordPressVIPMinimum/Tests/Security/ExitAfterRedirectUnitTest.php
@@ -38,5 +38,4 @@ class ExitAfterRedirectUnitTest extends AbstractSniffUnitTest {
 	public function getWarningList() {
 		return [];
 	}
-
 }

--- a/WordPressVIPMinimum/Tests/Security/MustacheUnitTest.php
+++ b/WordPressVIPMinimum/Tests/Security/MustacheUnitTest.php
@@ -42,5 +42,4 @@ class MustacheUnitTest extends AbstractSniffUnitTest {
 			18 => 1,
 		];
 	}
-
 }

--- a/WordPressVIPMinimum/Tests/Security/PHPFilterFunctionsUnitTest.php
+++ b/WordPressVIPMinimum/Tests/Security/PHPFilterFunctionsUnitTest.php
@@ -48,5 +48,4 @@ class PHPFilterFunctionsUnitTest extends AbstractSniffUnitTest {
 			29 => 1,
 		];
 	}
-
 }

--- a/WordPressVIPMinimum/Tests/Security/ProperEscapingFunctionUnitTest.php
+++ b/WordPressVIPMinimum/Tests/Security/ProperEscapingFunctionUnitTest.php
@@ -76,5 +76,4 @@ class ProperEscapingFunctionUnitTest extends AbstractSniffUnitTest {
 	public function getWarningList() {
 		return [];
 	}
-
 }

--- a/WordPressVIPMinimum/Tests/Security/StaticStrreplaceUnitTest.php
+++ b/WordPressVIPMinimum/Tests/Security/StaticStrreplaceUnitTest.php
@@ -38,5 +38,4 @@ class StaticStrreplaceUnitTest extends AbstractSniffUnitTest {
 	public function getWarningList() {
 		return [];
 	}
-
 }

--- a/WordPressVIPMinimum/Tests/Security/TwigUnitTest.php
+++ b/WordPressVIPMinimum/Tests/Security/TwigUnitTest.php
@@ -38,5 +38,4 @@ class TwigUnitTest extends AbstractSniffUnitTest {
 			10 => 1,
 		];
 	}
-
 }

--- a/WordPressVIPMinimum/Tests/Security/UnderscorejsUnitTest.php
+++ b/WordPressVIPMinimum/Tests/Security/UnderscorejsUnitTest.php
@@ -84,5 +84,4 @@ class UnderscorejsUnitTest extends AbstractSniffUnitTest {
 				return [];
 		}
 	}
-
 }

--- a/WordPressVIPMinimum/Tests/Security/VuejsUnitTest.php
+++ b/WordPressVIPMinimum/Tests/Security/VuejsUnitTest.php
@@ -37,5 +37,4 @@ class VuejsUnitTest extends AbstractSniffUnitTest {
 			5 => 1,
 		];
 	}
-
 }

--- a/WordPressVIPMinimum/Tests/Variables/RestrictedVariablesUnitTest.php
+++ b/WordPressVIPMinimum/Tests/Variables/RestrictedVariablesUnitTest.php
@@ -48,5 +48,4 @@ class RestrictedVariablesUnitTest extends AbstractSniffUnitTest {
 			28 => 1,
 		];
 	}
-
 }

--- a/WordPressVIPMinimum/Tests/Variables/ServerVariablesUnitTest.php
+++ b/WordPressVIPMinimum/Tests/Variables/ServerVariablesUnitTest.php
@@ -40,5 +40,4 @@ class ServerVariablesUnitTest extends AbstractSniffUnitTest {
 	public function getWarningList() {
 		return [];
 	}
-
 }

--- a/WordPressVIPMinimum/Tests/Variables/VariableAnalysisUnitTest.php
+++ b/WordPressVIPMinimum/Tests/Variables/VariableAnalysisUnitTest.php
@@ -38,5 +38,4 @@ class VariableAnalysisUnitTest extends AbstractSniffUnitTest {
 			5 => 2,
 		];
 	}
-
 }


### PR DESCRIPTION
Per https://github.com/WordPress/WordPress-Coding-Standards/issues/2254, the VIPCS classes need fixes for `PSR2.Classes.ClassDeclaration.CloseBraceAfterBody`. This allows our `composer cs` check to pass when using the `develop` branch of WPCS.