### PR TITLE
Some simplifications of sniffs extending the WPCS `AbstractArrayAssignmentRestrictionsSniff`

### DIFF
--- a/WordPressVIPMinimum/Sniffs/Performance/NoPagingSniff.php
+++ b/WordPressVIPMinimum/Sniffs/Performance/NoPagingSniff.php
@@ -30,8 +30,9 @@ class NoPagingSniff extends AbstractArrayAssignmentRestrictionsSniff {
 	public function getGroups() {
 		return [
 			'nopaging' => [
-				'type' => 'error',
-				'keys' => [
+				'type'    => 'error',
+				'message' => 'Disabling pagination is prohibited in VIP context, do not set `%s` to `%s` ever.',
+				'keys'    => [
 					'nopaging',
 				],
 			],
@@ -45,16 +46,12 @@ class NoPagingSniff extends AbstractArrayAssignmentRestrictionsSniff {
 	 * @param  mixed  $val   Assigned value.
 	 * @param  int    $line  Token line.
 	 * @param  array  $group Group definition.
-	 * @return mixed         FALSE if no match, TRUE if matches, STRING if matches
-	 *                       with custom error message passed to ->process().
+	 *
+	 * @return bool FALSE if no match, TRUE if matches.
 	 */
 	public function callback( $key, $val, $line, $group ) {
 		$key = strtolower( $key );
 
-		if ( $key === 'nopaging' && ( $val === 'true' || $val === 1 ) ) {
-			return 'Disabling pagination is prohibited in VIP context, do not set `%s` to `%s` ever.';
-		}
-
-		return false;
+		return ( $key === 'nopaging' && ( $val === 'true' || $val === 1 ) );
 	}
 }

--- a/WordPressVIPMinimum/Sniffs/Performance/OrderByRandSniff.php
+++ b/WordPressVIPMinimum/Sniffs/Performance/OrderByRandSniff.php
@@ -41,7 +41,6 @@ class OrderByRandSniff extends AbstractArrayAssignmentRestrictionsSniff {
 
 	/**
 	 * Callback to process each confirmed key, to check value
-	 * This must be extended to add the logic to check assignment value
 	 *
 	 * @param  string $key   Array index / key.
 	 * @param  mixed  $val   Assigned value.

--- a/WordPressVIPMinimum/Sniffs/Performance/OrderByRandSniff.php
+++ b/WordPressVIPMinimum/Sniffs/Performance/OrderByRandSniff.php
@@ -30,8 +30,9 @@ class OrderByRandSniff extends AbstractArrayAssignmentRestrictionsSniff {
 	public function getGroups() {
 		return [
 			'orderby' => [
-				'type' => 'error',
-				'keys' => [
+				'type'    => 'error',
+				'message' => 'Detected forbidden query_var "%s" of "%s". Use vip_get_random_posts() instead.',
+				'keys'    => [
 					'orderby',
 				],
 			],
@@ -46,13 +47,10 @@ class OrderByRandSniff extends AbstractArrayAssignmentRestrictionsSniff {
 	 * @param  mixed  $val   Assigned value.
 	 * @param  int    $line  Token line.
 	 * @param  array  $group Group definition.
-	 * @return mixed         FALSE if no match, TRUE if matches, STRING if matches with custom error message passed to ->process().
+	 *
+	 * @return bool FALSE if no match, TRUE if matches.
 	 */
 	public function callback( $key, $val, $line, $group ) {
-		if ( strtolower( $val ) === 'rand' ) {
-			return 'Detected forbidden query_var "%s" of "%s". Use vip_get_random_posts() instead.';
-		}
-
-		return false;
+		return strtolower( $val ) === 'rand';
 	}
 }

--- a/WordPressVIPMinimum/Sniffs/Performance/RegexpCompareSniff.php
+++ b/WordPressVIPMinimum/Sniffs/Performance/RegexpCompareSniff.php
@@ -33,8 +33,9 @@ class RegexpCompareSniff extends AbstractArrayAssignmentRestrictionsSniff {
 	public function getGroups() {
 		return [
 			'compare' => [
-				'type' => 'error',
-				'keys' => [
+				'type'    => 'error',
+				'message' => 'Detected regular expression comparison. `%s` is set to `%s`.',
+				'keys'    => [
 					'compare',
 					'meta_compare',
 				],
@@ -50,15 +51,13 @@ class RegexpCompareSniff extends AbstractArrayAssignmentRestrictionsSniff {
 	 * @param  mixed  $val   Assigned value.
 	 * @param  int    $line  Token line.
 	 * @param  array  $group Group definition.
-	 * @return mixed         FALSE if no match, TRUE if matches, STRING if matches
-	 *                       with custom error message passed to ->process().
+	 *
+	 * @return bool FALSE if no match, TRUE if matches.
 	 */
 	public function callback( $key, $val, $line, $group ) {
-		if ( strpos( $val, 'NOT REGEXP' ) === 0
+		return ( strpos( $val, 'NOT REGEXP' ) === 0
 			|| strpos( $val, 'REGEXP' ) === 0
 			|| in_array( $val, [ 'REGEXP', 'NOT REGEXP' ], true ) === true
-		) {
-			return 'Detected regular expression comparison. `%s` is set to `%s`.';
-		}
+		);
 	}
 }

--- a/WordPressVIPMinimum/Sniffs/Performance/RegexpCompareSniff.php
+++ b/WordPressVIPMinimum/Sniffs/Performance/RegexpCompareSniff.php
@@ -19,15 +19,6 @@ class RegexpCompareSniff extends AbstractArrayAssignmentRestrictionsSniff {
 	/**
 	 * Groups of variables to restrict.
 	 *
-	 * Example: groups => array(
-	 *  'groupname' => array(
-	 *      'type'     => 'error' | 'warning',
-	 *      'message'  => 'Dont use this one please!',
-	 *      'keys'     => array( 'key1', 'another_key' ),
-	 *      'callback' => array( 'class', 'method' ), // Optional.
-	 *  )
-	 * )
-	 *
 	 * @return array
 	 */
 	public function getGroups() {
@@ -45,7 +36,6 @@ class RegexpCompareSniff extends AbstractArrayAssignmentRestrictionsSniff {
 
 	/**
 	 * Callback to process each confirmed key, to check value.
-	 * This must be extended to add the logic to check assignment value.
 	 *
 	 * @param  string $key   Array index / key.
 	 * @param  mixed  $val   Assigned value.

--- a/WordPressVIPMinimum/Sniffs/Performance/RemoteRequestTimeoutSniff.php
+++ b/WordPressVIPMinimum/Sniffs/Performance/RemoteRequestTimeoutSniff.php
@@ -33,8 +33,9 @@ class RemoteRequestTimeoutSniff extends AbstractArrayAssignmentRestrictionsSniff
 	public function getGroups() {
 		return [
 			'timeout' => [
-				'type' => 'error',
-				'keys' => [
+				'type'    => 'error',
+				'message' => 'Detected high remote request timeout. `%s` is set to `%d`.',
+				'keys'    => [
 					'timeout',
 				],
 			],
@@ -49,12 +50,10 @@ class RemoteRequestTimeoutSniff extends AbstractArrayAssignmentRestrictionsSniff
 	 * @param  mixed  $val   Assigned value.
 	 * @param  int    $line  Token line.
 	 * @param  array  $group Group definition.
-	 * @return mixed         FALSE if no match, TRUE if matches, STRING if matches
-	 *                       with custom error message passed to ->process().
+	 *
+	 * @return bool FALSE if no match, TRUE if matches.
 	 */
 	public function callback( $key, $val, $line, $group ) {
-		if ( (int) $val > 3 ) {
-			return 'Detected high remote request timeout. `%s` is set to `%d`.';
-		}
+		return (int) $val > 3;
 	}
 }

--- a/WordPressVIPMinimum/Sniffs/Performance/RemoteRequestTimeoutSniff.php
+++ b/WordPressVIPMinimum/Sniffs/Performance/RemoteRequestTimeoutSniff.php
@@ -19,15 +19,6 @@ class RemoteRequestTimeoutSniff extends AbstractArrayAssignmentRestrictionsSniff
 	/**
 	 * Groups of variables to restrict.
 	 *
-	 * Example: groups => array(
-	 *  'groupname' => array(
-	 *      'type'     => 'error' | 'warning',
-	 *      'message'  => 'Dont use this one please!',
-	 *      'keys'     => array( 'key1', 'another_key' ),
-	 *      'callback' => array( 'class', 'method' ), // Optional.
-	 *  )
-	 * )
-	 *
 	 * @return array
 	 */
 	public function getGroups() {
@@ -44,7 +35,6 @@ class RemoteRequestTimeoutSniff extends AbstractArrayAssignmentRestrictionsSniff
 
 	/**
 	 * Callback to process each confirmed key, to check value.
-	 * This must be extended to add the logic to check assignment value.
 	 *
 	 * @param  string $key   Array index / key.
 	 * @param  mixed  $val   Assigned value.

--- a/WordPressVIPMinimum/Sniffs/Performance/WPQueryParamsSniff.php
+++ b/WordPressVIPMinimum/Sniffs/Performance/WPQueryParamsSniff.php
@@ -94,8 +94,8 @@ class WPQueryParamsSniff extends AbstractArrayAssignmentRestrictionsSniff {
 	 * @param  mixed  $val   Assigned value.
 	 * @param  int    $line  Token line.
 	 * @param  array  $group Group definition.
-	 * @return mixed         FALSE if no match, TRUE if matches, STRING if matches
-	 *                       with custom error message passed to ->process().
+	 *
+	 * @return bool FALSE if no match, TRUE if matches.
 	 */
 	public function callback( $key, $val, $line, $group ) {
 		return true;

--- a/WordPressVIPMinimum/Sniffs/Performance/WPQueryParamsSniff.php
+++ b/WordPressVIPMinimum/Sniffs/Performance/WPQueryParamsSniff.php
@@ -34,16 +34,6 @@ class WPQueryParamsSniff extends AbstractArrayAssignmentRestrictionsSniff {
 
 	/**
 	 * Groups of variables to restrict.
-	 * This should be overridden in extending classes.
-	 *
-	 * Example: groups => array(
-	 *  'groupname' => array(
-	 *      'type'     => 'error' | 'warning',
-	 *      'message'  => 'Dont use this one please!',
-	 *      'keys'     => array( 'key1', 'another_key' ),
-	 *      'callback' => array( 'class', 'method' ), // Optional.
-	 *  )
-	 * )
 	 *
 	 * @return array
 	 */


### PR DESCRIPTION
### Some simplifications of sniffs extending the WPCS `AbstractArrayAssignmentRestrictionsSniff`

The WPCS `AbstractArrayAssignmentRestrictionsSniff` expects an array from `getGroups()` which includes a `'message'` key.
The `callback()` method subsequently allows to override that message with a higher priority message if needed in specific circumstances.

None of these sniffs, however, have a need to override the message, so the `callback()` method can just use the default behaviour of returning `true` or `false` and use the `'message'` as declared in the group.

### Remove some extraneous comments

... from these same sniffs. These comments are copy/paste documentation from the abstract and not specific to the actual sniff.