### PR TITLE
Performance/RegexpCompare: remove redundant condition

### DIFF
--- a/WordPressVIPMinimum/Sniffs/Performance/RegexpCompareSniff.php
+++ b/WordPressVIPMinimum/Sniffs/Performance/RegexpCompareSniff.php
@@ -47,7 +47,6 @@ class RegexpCompareSniff extends AbstractArrayAssignmentRestrictionsSniff {
 	public function callback( $key, $val, $line, $group ) {
 		return ( strpos( $val, 'NOT REGEXP' ) === 0
 			|| strpos( $val, 'REGEXP' ) === 0
-			|| in_array( $val, [ 'REGEXP', 'NOT REGEXP' ], true ) === true
 		);
 	}
 }


### PR DESCRIPTION
This condition will always be `true` if one of the previous conditions is `true`, so is redundant.