### PR TITLE
Rulesets: move VariableAnalysis configuration from Go to Minimum

### DIFF
--- a/WordPress-VIP-Go/ruleset.xml
+++ b/WordPress-VIP-Go/ruleset.xml
@@ -244,14 +244,6 @@
 		<severity>0</severity>
 	</rule>
 
-	<!-- Do not report on undefined variables before require nor in file scope. -->
-	<rule ref="VariableAnalysis.CodeAnalysis.VariableAnalysis">
-		<properties>
-			<property name="allowUnusedVariablesBeforeRequire" value="true"/>
-			<property name="allowUndefinedVariablesInFileScope" value="true"/>
-		</properties>
-	</rule>
-
 	<rule ref="WordPress.DB.SlowDBQuery.slow_db_query_meta_key">
 		<!-- We are silencing this one because VIP Go has a combined index on meta_key, meta_value-->
 		<severity>0</severity>

--- a/WordPressVIPMinimum/ruleset.xml
+++ b/WordPressVIPMinimum/ruleset.xml
@@ -145,6 +145,13 @@
 
 	<!-- Include VariableAnalysis checks -->
 	<rule ref="VariableAnalysis"/>
+	<rule ref="VariableAnalysis.CodeAnalysis.VariableAnalysis">
+		<properties>
+			<!-- Do not report on unused variables before require nor usused or undefined variables in file scope. -->
+			<property name="allowUnusedVariablesBeforeRequire" value="true"/>
+			<property name="allowUndefinedVariablesInFileScope" value="true"/>
+		</properties>
+	</rule>
 
 	<!-- Prevent deprecation notice when the sniff is not explicitly included. -->
 	<rule ref="WordPressVIPMinimum.Variables.VariableAnalysis.DeprecatedSniff">


### PR DESCRIPTION
While looking into #588, I noticed something which seemed odd, so I'm addressing this with this PR.

The configuration which was added in #690 (and addressed #588) was added to the `WordPress-VIP-Go` ruleset, not the `WordPressVIPMinimum` ruleset from which the `WordPress-VIP-Go` ruleset inherits.

I can not think of any pertinent reason why the configuration should be added for one, but not the other and I couldn't find any discussion on this either, so I propose moving the configuration from the `WordPress-VIP-Go` ruleset to the `WordPressVIPMinimum` ruleset.

Ref: https://github.com/sirbrillig/phpcs-variable-analysis/releases/tag/v2.9.0