### PR TITLE
Composer: update VariableAnalysis dependency

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ Go to https://docs.wpvip.com/technical-references/code-review/phpcs-report/ to l
 * PHP 5.4+
 * [PHPCS 3.7.1+](https://github.com/squizlabs/PHP_CodeSniffer/releases)
 * [WPCS 2.3.0+](https://github.com/WordPress-Coding-Standards/WordPress-Coding-Standards/releases)
-* [VariableAnalysis 2.11.1+](https://github.com/sirbrillig/phpcs-variable-analysis/releases)
+* [VariableAnalysis 2.11.17+](https://github.com/sirbrillig/phpcs-variable-analysis/releases)
 
 ## Installation
 

--- a/composer.json
+++ b/composer.json
@@ -18,7 +18,7 @@
 	"require": {
 		"php": ">=5.4",
 		"dealerdirect/phpcodesniffer-composer-installer": "^0.4.1 || ^0.5 || ^0.6.2 || ^0.7 || ^1.0",
-		"sirbrillig/phpcs-variable-analysis": "^2.11.1",
+		"sirbrillig/phpcs-variable-analysis": "^2.11.17",
 		"squizlabs/php_codesniffer": "^3.7.1",
 		"wp-coding-standards/wpcs": "^2.3"
 	},


### PR DESCRIPTION
At this time, the minimum supported VA dependency is set at `2.11.1` after PR #691, which was included in VIPCS 2.3.3.

Since then, there have been a bunch of new releases. While the minimum supported version doesn't necessarily have to be updated each time, there is one reason why I believe it would be a good idea to update it:
* v 2.11.10 widened the allowed versions for the Composer PHPCS installer plugin. Without this fix, the Composer plugin cannot update to v 1.0.0 as VA blocks the update.

And if we're updating VA anyway, I suggest we go straight to the latest & greatest as quite a few bugs, most to do with modern PHP support, have been fixed in the mean time.

Refs: https://github.com/sirbrillig/phpcs-variable-analysis/releases