### PR TITLE
Classes/DeclarationCompatibility: remove redundant code

### DIFF
--- a/WordPressVIPMinimum/Sniffs/Classes/DeclarationCompatibilitySniff.php
+++ b/WordPressVIPMinimum/Sniffs/Classes/DeclarationCompatibilitySniff.php
@@ -25,13 +25,6 @@ class DeclarationCompatibilitySniff extends AbstractScopeSniff {
 	private $currentClass = '';
 
 	/**
-	 * A list of functions in the current class.
-	 *
-	 * @var string[]
-	 */
-	private $functionList = [];
-
-	/**
 	 * A list of classes and methods to check.
 	 *
 	 * @var string[]
@@ -211,7 +204,6 @@ class DeclarationCompatibilitySniff extends AbstractScopeSniff {
 		$className = $phpcsFile->getDeclarationName( $currScope );
 
 		if ( $className !== $this->currentClass ) {
-			$this->loadFunctionNamesInScope( $phpcsFile, $currScope );
 			$this->currentClass = $className;
 		}
 
@@ -356,28 +348,6 @@ class DeclarationCompatibilitySniff extends AbstractScopeSniff {
 		}
 
 		return $paramList;
-	}
-
-	/**
-	 * Extracts all the function names found in the given scope.
-	 *
-	 * @param File $phpcsFile The current file being scanned.
-	 * @param int  $currScope A pointer to the start of the scope.
-	 *
-	 * @return void
-	 */
-	protected function loadFunctionNamesInScope( File $phpcsFile, $currScope ) {
-		$this->functionList = [];
-		$tokens             = $phpcsFile->getTokens();
-
-		for ( $i = ( $tokens[ $currScope ]['scope_opener'] + 1 ); $i < $tokens[ $currScope ]['scope_closer']; $i++ ) {
-			if ( $tokens[ $i ]['code'] !== T_FUNCTION ) {
-				continue;
-			}
-
-			$next                 = $phpcsFile->findNext( T_STRING, $i );
-			$this->functionList[] = trim( $tokens[ $next ]['content'] );
-		}
 	}
 
 	/**


### PR DESCRIPTION
The `$functionList` property is only ever written to, never _read_, so all that work walking all the tokens in the complete class scope is redundant (and was done in a highly inefficient way in the first place).

So, removing all code related to the property should improve performance of the sniff a little.