### PR TITLE
Docs: various @var/@param/@return tag improvements

### DIFF
--- a/WordPressVIPMinimum/Sniffs/Classes/DeclarationCompatibilitySniff.php
+++ b/WordPressVIPMinimum/Sniffs/Classes/DeclarationCompatibilitySniff.php
@@ -34,7 +34,7 @@ class DeclarationCompatibilitySniff extends AbstractScopeSniff {
 	/**
 	 * A list of classes and methods to check.
 	 *
-	 * @var string[]
+	 * @var array<string, array<string, array<string, mixed>>>
 	 */
 	public $checkClasses = [
 		'WP_Widget' => [
@@ -176,7 +176,7 @@ class DeclarationCompatibilitySniff extends AbstractScopeSniff {
 	/**
 	 * List of grouped classes with same methods (as they extend the same parent class)
 	 *
-	 * @var string[]
+	 * @var array<string, string[]>
 	 */
 	public $checkClassesGroups = [
 		'Walker' => [

--- a/WordPressVIPMinimum/Sniffs/Classes/RestrictedExtendClassesSniff.php
+++ b/WordPressVIPMinimum/Sniffs/Classes/RestrictedExtendClassesSniff.php
@@ -39,8 +39,9 @@ class RestrictedExtendClassesSniff extends AbstractClassRestrictionsSniff {
 	 * Process a matched token.
 	 *
 	 * @param int    $stackPtr        The position of the current token in the stack.
-	 * @param array  $group_name      The name of the group which was matched.
-	 * @param string $matched_content The token content (class name) which was matched.
+	 * @param string $group_name      The name of the group which was matched.
+	 * @param string $matched_content The token content (class name) which was matched
+	 *                                in lowercase.
 	 *
 	 * @return void
 	 */

--- a/WordPressVIPMinimum/Sniffs/Functions/CheckReturnValueSniff.php
+++ b/WordPressVIPMinimum/Sniffs/Functions/CheckReturnValueSniff.php
@@ -112,7 +112,7 @@ class CheckReturnValueSniff extends Sniff {
 	 *
 	 * @param int $stackPtr The position of the current token in the stack passed in $tokens.
 	 *
-	 * @return bool
+	 * @return int|false
 	 */
 	private function isVariableAssignment( $stackPtr ) {
 
@@ -290,8 +290,8 @@ class CheckReturnValueSniff extends Sniff {
 	/**
 	 * Function used as as callback for the array_reduce call.
 	 *
-	 * @param string $carry The final string.
-	 * @param array  $item  Processed item.
+	 * @param string|null $carry The final string.
+	 * @param mixed       $item  Processed item.
 	 *
 	 * @return string
 	 */

--- a/WordPressVIPMinimum/Sniffs/Functions/CheckReturnValueSniff.php
+++ b/WordPressVIPMinimum/Sniffs/Functions/CheckReturnValueSniff.php
@@ -140,6 +140,8 @@ class CheckReturnValueSniff extends Sniff {
 	 * Find instances in which a function call is directly passed to another one w/o checking the return type
 	 *
 	 * @param int $stackPtr The position of the current token in the stack passed in $tokens.
+	 *
+	 * @return void
 	 */
 	public function findDirectFunctionCalls( $stackPtr ) {
 
@@ -305,6 +307,8 @@ class CheckReturnValueSniff extends Sniff {
 	 * @param int    $stackPtr     The position in the stack where the token was found.
 	 * @param string $variableName Variable name.
 	 * @param string $callee       Function name.
+	 *
+	 * @return void
 	 */
 	private function addNonCheckedVariableError( $stackPtr, $variableName, $callee ) {
 		$message = 'Type of `%s` must be checked before calling `%s()` using that variable.';

--- a/WordPressVIPMinimum/Sniffs/Functions/StripTagsSniff.php
+++ b/WordPressVIPMinimum/Sniffs/Functions/StripTagsSniff.php
@@ -41,9 +41,11 @@ class StripTagsSniff extends AbstractFunctionParameterSniff {
 	 * Process the parameters of a matched function.
 	 *
 	 * @param int    $stackPtr        The position of the current token in the stack.
-	 * @param array  $group_name      The name of the group which was matched.
-	 * @param string $matched_content The token content (function name) which was matched.
+	 * @param string $group_name      The name of the group which was matched.
+	 * @param string $matched_content The token content (function name) which was matched
+	 *                                in lowercase.
 	 * @param array  $parameters      Array with information about the parameters.
+	 *
 	 * @return int|void Integer stack pointer to skip forward or void to continue
 	 *                  normal file processing.
 	 */

--- a/WordPressVIPMinimum/Sniffs/Hooks/AlwaysReturnInFilterSniff.php
+++ b/WordPressVIPMinimum/Sniffs/Hooks/AlwaysReturnInFilterSniff.php
@@ -91,6 +91,8 @@ class AlwaysReturnInFilterSniff extends Sniff {
 	 * Process array.
 	 *
 	 * @param int $stackPtr The position in the stack where the token was found.
+	 *
+	 * @return void
 	 */
 	private function processArray( $stackPtr ) {
 
@@ -124,6 +126,8 @@ class AlwaysReturnInFilterSniff extends Sniff {
 	 * @param int $stackPtr The position in the stack where the token was found.
 	 * @param int $start    The start of the token.
 	 * @param int $end      The end of the token.
+	 *
+	 * @return void
 	 */
 	private function processString( $stackPtr, $start = 0, $end = null ) {
 
@@ -151,6 +155,8 @@ class AlwaysReturnInFilterSniff extends Sniff {
 	 * @param int $stackPtr The position in the stack where the token was found.
 	 * @param int $start    The start of the token.
 	 * @param int $end      The end of the token.
+	 *
+	 * @return void
 	 */
 	private function processFunction( $stackPtr, $start = 0, $end = null ) {
 
@@ -172,6 +178,8 @@ class AlwaysReturnInFilterSniff extends Sniff {
 	 * Process function's body
 	 *
 	 * @param int $stackPtr The position in the stack where the token was found.
+	 *
+	 * @return void
 	 */
 	private function processFunctionBody( $stackPtr ) {
 

--- a/WordPressVIPMinimum/Sniffs/Hooks/PreGetPostsSniff.php
+++ b/WordPressVIPMinimum/Sniffs/Hooks/PreGetPostsSniff.php
@@ -362,8 +362,8 @@ class PreGetPostsSniff extends Sniff {
 	/**
 	 * Is the current code a WP_Query call?
 	 *
-	 * @param int  $stackPtr The position in the stack where the token was found.
-	 * @param null $method   Method.
+	 * @param int         $stackPtr The position in the stack where the token was found.
+	 * @param string|null $method   Method.
 	 *
 	 * @return bool
 	 */

--- a/WordPressVIPMinimum/Sniffs/Hooks/PreGetPostsSniff.php
+++ b/WordPressVIPMinimum/Sniffs/Hooks/PreGetPostsSniff.php
@@ -92,6 +92,8 @@ class PreGetPostsSniff extends Sniff {
 	 * Process array.
 	 *
 	 * @param int $stackPtr The position in the stack where the token was found.
+	 *
+	 * @return void
 	 */
 	private function processArray( $stackPtr ) {
 
@@ -114,6 +116,8 @@ class PreGetPostsSniff extends Sniff {
 	 * Process string.
 	 *
 	 * @param int $stackPtr The position in the stack where the token was found.
+	 *
+	 * @return void
 	 */
 	private function processString( $stackPtr ) {
 
@@ -139,6 +143,8 @@ class PreGetPostsSniff extends Sniff {
 	 * Process function.
 	 *
 	 * @param int $stackPtr The position in the stack where the token was found.
+	 *
+	 * @return void
 	 */
 	private function processFunction( $stackPtr ) {
 
@@ -172,6 +178,8 @@ class PreGetPostsSniff extends Sniff {
 	 * Process closure.
 	 *
 	 * @param int $stackPtr The position in the stack where the token was found.
+	 *
+	 * @return void
 	 */
 	private function processClosure( $stackPtr ) {
 
@@ -197,6 +205,8 @@ class PreGetPostsSniff extends Sniff {
 	 *
 	 * @param int    $stackPtr     The position in the stack where the token was found.
 	 * @param string $variableName Variable name.
+	 *
+	 * @return void
 	 */
 	private function processFunctionBody( $stackPtr, $variableName ) {
 
@@ -236,6 +246,8 @@ class PreGetPostsSniff extends Sniff {
 	 * Consolidated violation.
 	 *
 	 * @param int $stackPtr The position in the stack where the token was found.
+	 *
+	 * @return void
 	 */
 	private function addPreGetPostsWarning( $stackPtr ) {
 		$message = 'Main WP_Query is being modified without `$query->is_main_query()` check. Needs manual inspection.';

--- a/WordPressVIPMinimum/Sniffs/Hooks/RestrictedHooksSniff.php
+++ b/WordPressVIPMinimum/Sniffs/Hooks/RestrictedHooksSniff.php
@@ -76,9 +76,11 @@ class RestrictedHooksSniff extends AbstractFunctionParameterSniff {
 	 * Process the parameters of a matched function.
 	 *
 	 * @param int    $stackPtr        The position of the current token in the stack.
-	 * @param array  $group_name      The name of the group which was matched.
-	 * @param string $matched_content The token content (function name) which was matched.
+	 * @param string $group_name      The name of the group which was matched.
+	 * @param string $matched_content The token content (function name) which was matched
+	 *                                in lowercase.
 	 * @param array  $parameters      Array with information about the parameters.
+	 *
 	 * @return int|void Integer stack pointer to skip forward or void to continue
 	 *                  normal file processing.
 	 */
@@ -97,6 +99,7 @@ class RestrictedHooksSniff extends AbstractFunctionParameterSniff {
 	 * Normalize hook name parameter.
 	 *
 	 * @param array $parameter Array with information about a parameter.
+	 *
 	 * @return string Normalized hook name.
 	 */
 	private function normalize_hook_name_from_parameter( $parameter ) {

--- a/WordPressVIPMinimum/Sniffs/JS/StringConcatSniff.php
+++ b/WordPressVIPMinimum/Sniffs/JS/StringConcatSniff.php
@@ -67,6 +67,8 @@ class StringConcatSniff extends Sniff {
 	 *
 	 * @param int   $stackPtr The position of the current token in the stack passed in $tokens.
 	 * @param array $data     Replacements for the error message.
+	 *
+	 * @return void
 	 */
 	private function addFoundError( $stackPtr, array $data ) {
 		$message = 'HTML string concatenation detected, this is a security risk, use DOM node construction or a templating language instead: %s.';

--- a/WordPressVIPMinimum/Sniffs/Performance/CacheValueOverrideSniff.php
+++ b/WordPressVIPMinimum/Sniffs/Performance/CacheValueOverrideSniff.php
@@ -119,7 +119,7 @@ class CacheValueOverrideSniff extends Sniff {
 	 *
 	 * @param int $stackPtr The position of the current token in the stack.
 	 *
-	 * @return bool
+	 * @return int|false
 	 */
 	private function isVariableAssignment( $stackPtr ) {
 

--- a/WordPressVIPMinimum/Sniffs/Performance/LowExpiryCacheTimeSniff.php
+++ b/WordPressVIPMinimum/Sniffs/Performance/LowExpiryCacheTimeSniff.php
@@ -60,9 +60,11 @@ class LowExpiryCacheTimeSniff extends AbstractFunctionParameterSniff {
 	 * Process the parameters of a matched function.
 	 *
 	 * @param int    $stackPtr        The position of the current token in the stack.
-	 * @param array  $group_name      The name of the group which was matched.
-	 * @param string $matched_content The token content (function name) which was matched.
+	 * @param string $group_name      The name of the group which was matched.
+	 * @param string $matched_content The token content (function name) which was matched
+	 *                                in lowercase.
 	 * @param array  $parameters      Array with information about the parameters.
+	 *
 	 * @return int|void Integer stack pointer to skip forward or void to continue
 	 *                  normal file processing.
 	 */

--- a/WordPressVIPMinimum/Sniffs/Security/PHPFilterFunctionsSniff.php
+++ b/WordPressVIPMinimum/Sniffs/Security/PHPFilterFunctionsSniff.php
@@ -54,9 +54,11 @@ class PHPFilterFunctionsSniff extends AbstractFunctionParameterSniff {
 	 * Process the parameters of a matched function.
 	 *
 	 * @param int    $stackPtr        The position of the current token in the stack.
-	 * @param array  $group_name      The name of the group which was matched.
-	 * @param string $matched_content The token content (function name) which was matched.
+	 * @param string $group_name      The name of the group which was matched.
+	 * @param string $matched_content The token content (function name) which was matched
+	 *                                in lowercase.
 	 * @param array  $parameters      Array with information about the parameters.
+	 *
 	 * @return int|void Integer stack pointer to skip forward or void to continue
 	 *                  normal file processing.
 	 */

--- a/WordPressVIPMinimum/Sniffs/UserExperience/AdminBarRemovalSniff.php
+++ b/WordPressVIPMinimum/Sniffs/UserExperience/AdminBarRemovalSniff.php
@@ -190,8 +190,9 @@ class AdminBarRemovalSniff extends AbstractFunctionParameterSniff {
 	 * Process the parameters of a matched function.
 	 *
 	 * @param int    $stackPtr        The position of the current token in the stack.
-	 * @param array  $group_name      The name of the group which was matched.
-	 * @param string $matched_content The token content (function name) which was matched.
+	 * @param string $group_name      The name of the group which was matched.
+	 * @param string $matched_content The token content (function name) which was matched
+	 *                                in lowercase.
 	 * @param array  $parameters      Array with information about the parameters.
 	 *
 	 * @return void

--- a/WordPressVIPMinimum/Sniffs/UserExperience/AdminBarRemovalSniff.php
+++ b/WordPressVIPMinimum/Sniffs/UserExperience/AdminBarRemovalSniff.php
@@ -372,6 +372,8 @@ class AdminBarRemovalSniff extends AbstractFunctionParameterSniff {
 	 * Consolidated violation.
 	 *
 	 * @param int $stackPtr The position of the current token in the stack passed in $tokens.
+	 *
+	 * @return void
 	 */
 	private function addHidingDetectedError( $stackPtr ) {
 		$message = 'Hiding of the admin bar is not allowed.';

--- a/WordPressVIPMinimum/Tests/Classes/DeclarationCompatibilityUnitTest.php
+++ b/WordPressVIPMinimum/Tests/Classes/DeclarationCompatibilityUnitTest.php
@@ -21,7 +21,7 @@ class DeclarationCompatibilityUnitTest extends AbstractSniffUnitTest {
 	/**
 	 * Returns the lines where errors should occur.
 	 *
-	 * @return array <int line number> => <int number of errors>
+	 * @return array<int, int> Key is the line number, value is the number of expected errors.
 	 */
 	public function getErrorList() {
 		return [
@@ -55,7 +55,7 @@ class DeclarationCompatibilityUnitTest extends AbstractSniffUnitTest {
 	/**
 	 * Returns the lines where warnings should occur.
 	 *
-	 * @return array <int line number> => <int number of warnings>
+	 * @return array<int, int> Key is the line number, value is the number of expected warnings.
 	 */
 	public function getWarningList() {
 		return [];

--- a/WordPressVIPMinimum/Tests/Classes/RestrictedExtendClassesUnitTest.php
+++ b/WordPressVIPMinimum/Tests/Classes/RestrictedExtendClassesUnitTest.php
@@ -21,7 +21,7 @@ class RestrictedExtendClassesUnitTest extends AbstractSniffUnitTest {
 	/**
 	 * Returns the lines where errors should occur.
 	 *
-	 * @return array <int line number> => <int number of errors>
+	 * @return array<int, int> Key is the line number, value is the number of expected errors.
 	 */
 	public function getErrorList() {
 		return [];
@@ -30,7 +30,7 @@ class RestrictedExtendClassesUnitTest extends AbstractSniffUnitTest {
 	/**
 	 * Returns the lines where warnings should occur.
 	 *
-	 * @return array <int line number> => <int number of warnings>
+	 * @return array<int, int> Key is the line number, value is the number of expected warnings.
 	 */
 	public function getWarningList() {
 		return [

--- a/WordPressVIPMinimum/Tests/Constants/ConstantStringUnitTest.php
+++ b/WordPressVIPMinimum/Tests/Constants/ConstantStringUnitTest.php
@@ -21,7 +21,7 @@ class ConstantStringUnitTest extends AbstractSniffUnitTest {
 	/**
 	 * Returns the lines where errors should occur.
 	 *
-	 * @return array <int line number> => <int number of errors>
+	 * @return array<int, int> Key is the line number, value is the number of expected errors.
 	 */
 	public function getErrorList() {
 		return [
@@ -33,7 +33,7 @@ class ConstantStringUnitTest extends AbstractSniffUnitTest {
 	/**
 	 * Returns the lines where warnings should occur.
 	 *
-	 * @return array <int line number> => <int number of warnings>
+	 * @return array<int, int> Key is the line number, value is the number of expected warnings.
 	 */
 	public function getWarningList() {
 		return [];

--- a/WordPressVIPMinimum/Tests/Constants/RestrictedConstantsUnitTest.php
+++ b/WordPressVIPMinimum/Tests/Constants/RestrictedConstantsUnitTest.php
@@ -21,7 +21,7 @@ class RestrictedConstantsUnitTest extends AbstractSniffUnitTest {
 	/**
 	 * Returns the lines where errors should occur.
 	 *
-	 * @return array <int line number> => <int number of errors>
+	 * @return array<int, int> Key is the line number, value is the number of expected errors.
 	 */
 	public function getErrorList() {
 		return [
@@ -34,7 +34,7 @@ class RestrictedConstantsUnitTest extends AbstractSniffUnitTest {
 	/**
 	 * Returns the lines where warnings should occur.
 	 *
-	 * @return array <int line number> => <int number of warnings>
+	 * @return array<int, int> Key is the line number, value is the number of expected warnings.
 	 */
 	public function getWarningList() {
 		return [

--- a/WordPressVIPMinimum/Tests/Files/IncludingFileUnitTest.php
+++ b/WordPressVIPMinimum/Tests/Files/IncludingFileUnitTest.php
@@ -20,7 +20,7 @@ class IncludingFileUnitTest extends AbstractSniffUnitTest {
 	/**
 	 * Returns the lines where errors should occur.
 	 *
-	 * @return array <int line number> => <int number of errors>
+	 * @return array<int, int> Key is the line number, value is the number of expected errors.
 	 */
 	public function getErrorList() {
 		return [
@@ -36,7 +36,7 @@ class IncludingFileUnitTest extends AbstractSniffUnitTest {
 	/**
 	 * Returns the lines where warnings should occur.
 	 *
-	 * @return array <int line number> => <int number of warnings>
+	 * @return array<int, int> Key is the line number, value is the number of expected warnings.
 	 */
 	public function getWarningList() {
 		return [

--- a/WordPressVIPMinimum/Tests/Files/IncludingNonPHPFileUnitTest.php
+++ b/WordPressVIPMinimum/Tests/Files/IncludingNonPHPFileUnitTest.php
@@ -21,7 +21,7 @@ class IncludingNonPHPFileUnitTest extends AbstractSniffUnitTest {
 	/**
 	 * Returns the lines where errors should occur.
 	 *
-	 * @return array <int line number> => <int number of errors>
+	 * @return array<int, int> Key is the line number, value is the number of expected errors.
 	 */
 	public function getErrorList() {
 		return [
@@ -54,7 +54,7 @@ class IncludingNonPHPFileUnitTest extends AbstractSniffUnitTest {
 	/**
 	 * Returns the lines where warnings should occur.
 	 *
-	 * @return array <int line number> => <int number of warnings>
+	 * @return array<int, int> Key is the line number, value is the number of expected warnings.
 	 */
 	public function getWarningList() {
 		return [];

--- a/WordPressVIPMinimum/Tests/Functions/CheckReturnValueUnitTest.php
+++ b/WordPressVIPMinimum/Tests/Functions/CheckReturnValueUnitTest.php
@@ -21,7 +21,7 @@ class CheckReturnValueUnitTest extends AbstractSniffUnitTest {
 	/**
 	 * Returns the lines where errors should occur.
 	 *
-	 * @return array <int line number> => <int number of errors>
+	 * @return array<int, int> Key is the line number, value is the number of expected errors.
 	 */
 	public function getErrorList() {
 		return [
@@ -36,7 +36,7 @@ class CheckReturnValueUnitTest extends AbstractSniffUnitTest {
 	/**
 	 * Returns the lines where warnings should occur.
 	 *
-	 * @return array <int line number> => <int number of warnings>
+	 * @return array<int, int> Key is the line number, value is the number of expected warnings.
 	 */
 	public function getWarningList() {
 		return [];

--- a/WordPressVIPMinimum/Tests/Functions/DynamicCallsUnitTest.php
+++ b/WordPressVIPMinimum/Tests/Functions/DynamicCallsUnitTest.php
@@ -21,7 +21,7 @@ class DynamicCallsUnitTest extends AbstractSniffUnitTest {
 	/**
 	 * Returns the lines where errors should occur.
 	 *
-	 * @return array <int line number> => <int number of errors>
+	 * @return array<int, int> Key is the line number, value is the number of expected errors.
 	 */
 	public function getErrorList() {
 		return [
@@ -34,7 +34,7 @@ class DynamicCallsUnitTest extends AbstractSniffUnitTest {
 	/**
 	 * Returns the lines where warnings should occur.
 	 *
-	 * @return array <int line number> => <int number of warnings>
+	 * @return array<int, int> Key is the line number, value is the number of expected warnings.
 	 */
 	public function getWarningList() {
 		return [];

--- a/WordPressVIPMinimum/Tests/Functions/RestrictedFunctionsUnitTest.php
+++ b/WordPressVIPMinimum/Tests/Functions/RestrictedFunctionsUnitTest.php
@@ -21,7 +21,7 @@ class RestrictedFunctionsUnitTest extends AbstractSniffUnitTest {
 	/**
 	 * Returns the lines where errors should occur.
 	 *
-	 * @return array <int line number> => <int number of errors>
+	 * @return array<int, int> Key is the line number, value is the number of expected errors.
 	 */
 	public function getErrorList() {
 		return [
@@ -107,7 +107,7 @@ class RestrictedFunctionsUnitTest extends AbstractSniffUnitTest {
 	/**
 	 * Returns the lines where warnings should occur.
 	 *
-	 * @return array <int line number> => <int number of warnings>
+	 * @return array<int, int> Key is the line number, value is the number of expected warnings.
 	 */
 	public function getWarningList() {
 		return [

--- a/WordPressVIPMinimum/Tests/Functions/StripTagsUnitTest.php
+++ b/WordPressVIPMinimum/Tests/Functions/StripTagsUnitTest.php
@@ -21,7 +21,7 @@ class StripTagsUnitTest extends AbstractSniffUnitTest {
 	/**
 	 * Returns the lines where errors should occur.
 	 *
-	 * @return array <int line number> => <int number of errors>
+	 * @return array<int, int> Key is the line number, value is the number of expected errors.
 	 */
 	public function getErrorList() {
 		return [];
@@ -30,7 +30,7 @@ class StripTagsUnitTest extends AbstractSniffUnitTest {
 	/**
 	 * Returns the lines where warnings should occur.
 	 *
-	 * @return array <int line number> => <int number of warnings>
+	 * @return array<int, int> Key is the line number, value is the number of expected warnings.
 	 */
 	public function getWarningList() {
 		return [

--- a/WordPressVIPMinimum/Tests/Hooks/AlwaysReturnInFilterUnitTest.php
+++ b/WordPressVIPMinimum/Tests/Hooks/AlwaysReturnInFilterUnitTest.php
@@ -22,7 +22,7 @@ class AlwaysReturnInFilterUnitTest extends AbstractSniffUnitTest {
 	/**
 	 * Returns the lines where errors should occur.
 	 *
-	 * @return array <int line number> => <int number of errors>
+	 * @return array<int, int> Key is the line number, value is the number of expected errors.
 	 */
 	public function getErrorList() {
 		return [
@@ -40,7 +40,7 @@ class AlwaysReturnInFilterUnitTest extends AbstractSniffUnitTest {
 	/**
 	 * Returns the lines where warnings should occur.
 	 *
-	 * @return array <int line number> => <int number of warnings>
+	 * @return array<int, int> Key is the line number, value is the number of expected warnings.
 	 */
 	public function getWarningList() {
 		return [

--- a/WordPressVIPMinimum/Tests/Hooks/PreGetPostsUnitTest.php
+++ b/WordPressVIPMinimum/Tests/Hooks/PreGetPostsUnitTest.php
@@ -21,7 +21,7 @@ class PreGetPostsUnitTest extends AbstractSniffUnitTest {
 	/**
 	 * Returns the lines where errors should occur.
 	 *
-	 * @return array <int line number> => <int number of errors>
+	 * @return array<int, int> Key is the line number, value is the number of expected errors.
 	 */
 	public function getErrorList() {
 		return [];
@@ -30,7 +30,7 @@ class PreGetPostsUnitTest extends AbstractSniffUnitTest {
 	/**
 	 * Returns the lines where warnings should occur.
 	 *
-	 * @return array <int line number> => <int number of warnings>
+	 * @return array<int, int> Key is the line number, value is the number of expected warnings.
 	 */
 	public function getWarningList() {
 		return [

--- a/WordPressVIPMinimum/Tests/Hooks/RestrictedHooksUnitTest.php
+++ b/WordPressVIPMinimum/Tests/Hooks/RestrictedHooksUnitTest.php
@@ -22,7 +22,7 @@ class RestrictedHooksUnitTest extends AbstractSniffUnitTest {
 	/**
 	 * Returns the lines where errors should occur.
 	 *
-	 * @return array <int line number> => <int number of errors>
+	 * @return array<int, int> Key is the line number, value is the number of expected errors.
 	 */
 	public function getErrorList() {
 		return [];
@@ -31,7 +31,7 @@ class RestrictedHooksUnitTest extends AbstractSniffUnitTest {
 	/**
 	 * Returns the lines where warnings should occur.
 	 *
-	 * @return array <int line number> => <int number of warnings>
+	 * @return array<int, int> Key is the line number, value is the number of expected warnings.
 	 */
 	public function getWarningList() {
 		return [

--- a/WordPressVIPMinimum/Tests/JS/DangerouslySetInnerHTMLUnitTest.php
+++ b/WordPressVIPMinimum/Tests/JS/DangerouslySetInnerHTMLUnitTest.php
@@ -21,7 +21,7 @@ class DangerouslySetInnerHTMLUnitTest extends AbstractSniffUnitTest {
 	/**
 	 * Returns the lines where errors should occur.
 	 *
-	 * @return array <int line number> => <int number of errors>
+	 * @return array<int, int> Key is the line number, value is the number of expected errors.
 	 */
 	public function getErrorList() {
 		return [
@@ -32,7 +32,7 @@ class DangerouslySetInnerHTMLUnitTest extends AbstractSniffUnitTest {
 	/**
 	 * Returns the lines where warnings should occur.
 	 *
-	 * @return array <int line number> => <int number of warnings>
+	 * @return array<int, int> Key is the line number, value is the number of expected warnings.
 	 */
 	public function getWarningList() {
 		return [];

--- a/WordPressVIPMinimum/Tests/JS/HTMLExecutingFunctionsUnitTest.php
+++ b/WordPressVIPMinimum/Tests/JS/HTMLExecutingFunctionsUnitTest.php
@@ -21,7 +21,7 @@ class HTMLExecutingFunctionsUnitTest extends AbstractSniffUnitTest {
 	/**
 	 * Returns the lines where errors should occur.
 	 *
-	 * @return array <int line number> => <int number of errors>
+	 * @return array<int, int> Key is the line number, value is the number of expected errors.
 	 */
 	public function getErrorList() {
 		return [];
@@ -30,7 +30,7 @@ class HTMLExecutingFunctionsUnitTest extends AbstractSniffUnitTest {
 	/**
 	 * Returns the lines where warnings should occur.
 	 *
-	 * @return array <int line number> => <int number of warnings>
+	 * @return array<int, int> Key is the line number, value is the number of expected warnings.
 	 */
 	public function getWarningList() {
 		return [

--- a/WordPressVIPMinimum/Tests/JS/InnerHTMLUnitTest.php
+++ b/WordPressVIPMinimum/Tests/JS/InnerHTMLUnitTest.php
@@ -21,7 +21,7 @@ class InnerHTMLUnitTest extends AbstractSniffUnitTest {
 	/**
 	 * Returns the lines where errors should occur.
 	 *
-	 * @return array <int line number> => <int number of errors>
+	 * @return array<int, int> Key is the line number, value is the number of expected errors.
 	 */
 	public function getErrorList() {
 		return [];
@@ -30,7 +30,7 @@ class InnerHTMLUnitTest extends AbstractSniffUnitTest {
 	/**
 	 * Returns the lines where warnings should occur.
 	 *
-	 * @return array <int line number> => <int number of warnings>
+	 * @return array<int, int> Key is the line number, value is the number of expected warnings.
 	 */
 	public function getWarningList() {
 		return [

--- a/WordPressVIPMinimum/Tests/JS/StringConcatUnitTest.php
+++ b/WordPressVIPMinimum/Tests/JS/StringConcatUnitTest.php
@@ -21,7 +21,7 @@ class StringConcatUnitTest extends AbstractSniffUnitTest {
 	/**
 	 * Returns the lines where errors should occur.
 	 *
-	 * @return array <int line number> => <int number of errors>
+	 * @return array<int, int> Key is the line number, value is the number of expected errors.
 	 */
 	public function getErrorList() {
 		return [
@@ -32,7 +32,7 @@ class StringConcatUnitTest extends AbstractSniffUnitTest {
 	/**
 	 * Returns the lines where warnings should occur.
 	 *
-	 * @return array <int line number> => <int number of warnings>
+	 * @return array<int, int> Key is the line number, value is the number of expected warnings.
 	 */
 	public function getWarningList() {
 		return [];

--- a/WordPressVIPMinimum/Tests/JS/StrippingTagsUnitTest.php
+++ b/WordPressVIPMinimum/Tests/JS/StrippingTagsUnitTest.php
@@ -21,7 +21,7 @@ class StrippingTagsUnitTest extends AbstractSniffUnitTest {
 	/**
 	 * Returns the lines where errors should occur.
 	 *
-	 * @return array <int line number> => <int number of errors>
+	 * @return array<int, int> Key is the line number, value is the number of expected errors.
 	 */
 	public function getErrorList() {
 		return [
@@ -32,7 +32,7 @@ class StrippingTagsUnitTest extends AbstractSniffUnitTest {
 	/**
 	 * Returns the lines where warnings should occur.
 	 *
-	 * @return array <int line number> => <int number of warnings>
+	 * @return array<int, int> Key is the line number, value is the number of expected warnings.
 	 */
 	public function getWarningList() {
 		return [];

--- a/WordPressVIPMinimum/Tests/JS/WindowUnitTest.php
+++ b/WordPressVIPMinimum/Tests/JS/WindowUnitTest.php
@@ -21,7 +21,7 @@ class WindowUnitTest extends AbstractSniffUnitTest {
 	/**
 	 * Returns the lines where errors should occur.
 	 *
-	 * @return array <int line number> => <int number of errors>
+	 * @return array<int, int> Key is the line number, value is the number of expected errors.
 	 */
 	public function getErrorList() {
 		return [
@@ -49,7 +49,7 @@ class WindowUnitTest extends AbstractSniffUnitTest {
 	/**
 	 * Returns the lines where warnings should occur.
 	 *
-	 * @return array <int line number> => <int number of warnings>
+	 * @return array<int, int> Key is the line number, value is the number of expected warnings.
 	 */
 	public function getWarningList() {
 		return [

--- a/WordPressVIPMinimum/Tests/Performance/CacheValueOverrideUnitTest.php
+++ b/WordPressVIPMinimum/Tests/Performance/CacheValueOverrideUnitTest.php
@@ -21,7 +21,7 @@ class CacheValueOverrideUnitTest extends AbstractSniffUnitTest {
 	/**
 	 * Returns the lines where errors should occur.
 	 *
-	 * @return array <int line number> => <int number of errors>
+	 * @return array<int, int> Key is the line number, value is the number of expected errors.
 	 */
 	public function getErrorList() {
 		return [
@@ -32,7 +32,7 @@ class CacheValueOverrideUnitTest extends AbstractSniffUnitTest {
 	/**
 	 * Returns the lines where warnings should occur.
 	 *
-	 * @return array <int line number> => <int number of warnings>
+	 * @return array<int, int> Key is the line number, value is the number of expected warnings.
 	 */
 	public function getWarningList() {
 		return [];

--- a/WordPressVIPMinimum/Tests/Performance/FetchingRemoteDataUnitTest.php
+++ b/WordPressVIPMinimum/Tests/Performance/FetchingRemoteDataUnitTest.php
@@ -21,7 +21,7 @@ class FetchingRemoteDataUnitTest extends AbstractSniffUnitTest {
 	/**
 	 * Returns the lines where errors should occur.
 	 *
-	 * @return array <int line number> => <int number of errors>
+	 * @return array<int, int> Key is the line number, value is the number of expected errors.
 	 */
 	public function getErrorList() {
 		return [];
@@ -30,7 +30,7 @@ class FetchingRemoteDataUnitTest extends AbstractSniffUnitTest {
 	/**
 	 * Returns the lines where warnings should occur.
 	 *
-	 * @return array <int line number> => <int number of warnings>
+	 * @return array<int, int> Key is the line number, value is the number of expected warnings.
 	 */
 	public function getWarningList() {
 		return [

--- a/WordPressVIPMinimum/Tests/Performance/LowExpiryCacheTimeUnitTest.php
+++ b/WordPressVIPMinimum/Tests/Performance/LowExpiryCacheTimeUnitTest.php
@@ -21,7 +21,7 @@ class LowExpiryCacheTimeUnitTest extends AbstractSniffUnitTest {
 	/**
 	 * Returns the lines where errors should occur.
 	 *
-	 * @return array <int line number> => <int number of errors>
+	 * @return array<int, int> Key is the line number, value is the number of expected errors.
 	 */
 	public function getErrorList() {
 		return [];
@@ -30,7 +30,7 @@ class LowExpiryCacheTimeUnitTest extends AbstractSniffUnitTest {
 	/**
 	 * Returns the lines where warnings should occur.
 	 *
-	 * @return array <int line number> => <int number of warnings>
+	 * @return array<int, int> Key is the line number, value is the number of expected warnings.
 	 */
 	public function getWarningList() {
 		return [

--- a/WordPressVIPMinimum/Tests/Performance/NoPagingUnitTest.php
+++ b/WordPressVIPMinimum/Tests/Performance/NoPagingUnitTest.php
@@ -23,7 +23,7 @@ class NoPagingUnitTest extends AbstractSniffUnitTest {
 	/**
 	 * Returns the lines where errors should occur.
 	 *
-	 * @return array <int line number> => <int number of errors>
+	 * @return array<int, int> Key is the line number, value is the number of expected errors.
 	 */
 	public function getErrorList() {
 		return [
@@ -35,7 +35,7 @@ class NoPagingUnitTest extends AbstractSniffUnitTest {
 	/**
 	 * Returns the lines where warnings should occur.
 	 *
-	 * @return array <int line number> => <int number of warnings>
+	 * @return array<int, int> Key is the line number, value is the number of expected warnings.
 	 */
 	public function getWarningList() {
 		return [];

--- a/WordPressVIPMinimum/Tests/Performance/OrderByRandUnitTest.php
+++ b/WordPressVIPMinimum/Tests/Performance/OrderByRandUnitTest.php
@@ -23,7 +23,7 @@ class OrderByRandUnitTest extends AbstractSniffUnitTest {
 	/**
 	 * Returns the lines where errors should occur.
 	 *
-	 * @return array <int line number> => <int number of errors>
+	 * @return array<int, int> Key is the line number, value is the number of expected errors.
 	 */
 	public function getErrorList() {
 		return [
@@ -39,7 +39,7 @@ class OrderByRandUnitTest extends AbstractSniffUnitTest {
 	/**
 	 * Returns the lines where warnings should occur.
 	 *
-	 * @return array <int line number> => <int number of warnings>
+	 * @return array<int, int> Key is the line number, value is the number of expected warnings.
 	 */
 	public function getWarningList() {
 		return [];

--- a/WordPressVIPMinimum/Tests/Performance/RegexpCompareUnitTest.php
+++ b/WordPressVIPMinimum/Tests/Performance/RegexpCompareUnitTest.php
@@ -21,7 +21,7 @@ class RegexpCompareUnitTest extends AbstractSniffUnitTest {
 	/**
 	 * Returns the lines where errors should occur.
 	 *
-	 * @return array <int line number> => <int number of errors>
+	 * @return array<int, int> Key is the line number, value is the number of expected errors.
 	 */
 	public function getErrorList() {
 		return [
@@ -35,7 +35,7 @@ class RegexpCompareUnitTest extends AbstractSniffUnitTest {
 	/**
 	 * Returns the lines where warnings should occur.
 	 *
-	 * @return array <int line number> => <int number of warnings>
+	 * @return array<int, int> Key is the line number, value is the number of expected warnings.
 	 */
 	public function getWarningList() {
 		return [];

--- a/WordPressVIPMinimum/Tests/Performance/RemoteRequestTimeoutUnitTest.php
+++ b/WordPressVIPMinimum/Tests/Performance/RemoteRequestTimeoutUnitTest.php
@@ -21,7 +21,7 @@ class RemoteRequestTimeoutUnitTest extends AbstractSniffUnitTest {
 	/**
 	 * Returns the lines where errors should occur.
 	 *
-	 * @return array <int line number> => <int number of errors>
+	 * @return array<int, int> Key is the line number, value is the number of expected errors.
 	 */
 	public function getErrorList() {
 		return [
@@ -32,7 +32,7 @@ class RemoteRequestTimeoutUnitTest extends AbstractSniffUnitTest {
 	/**
 	 * Returns the lines where warnings should occur.
 	 *
-	 * @return array <int line number> => <int number of warnings>
+	 * @return array<int, int> Key is the line number, value is the number of expected warnings.
 	 */
 	public function getWarningList() {
 		return [];

--- a/WordPressVIPMinimum/Tests/Performance/TaxonomyMetaInOptionsUnitTest.php
+++ b/WordPressVIPMinimum/Tests/Performance/TaxonomyMetaInOptionsUnitTest.php
@@ -21,7 +21,7 @@ class TaxonomyMetaInOptionsUnitTest extends AbstractSniffUnitTest {
 	/**
 	 * Returns the lines where errors should occur.
 	 *
-	 * @return array <int line number> => <int number of errors>
+	 * @return array<int, int> Key is the line number, value is the number of expected errors.
 	 */
 	public function getErrorList() {
 		return [];
@@ -30,7 +30,7 @@ class TaxonomyMetaInOptionsUnitTest extends AbstractSniffUnitTest {
 	/**
 	 * Returns the lines where warnings should occur.
 	 *
-	 * @return array <int line number> => <int number of warnings>
+	 * @return array<int, int> Key is the line number, value is the number of expected warnings.
 	 */
 	public function getWarningList() {
 		return [

--- a/WordPressVIPMinimum/Tests/Performance/WPQueryParamsUnitTest.php
+++ b/WordPressVIPMinimum/Tests/Performance/WPQueryParamsUnitTest.php
@@ -21,7 +21,7 @@ class WPQueryParamsUnitTest extends AbstractSniffUnitTest {
 	/**
 	 * Returns the lines where errors should occur.
 	 *
-	 * @return array <int line number> => <int number of errors>
+	 * @return array<int, int> Key is the line number, value is the number of expected errors.
 	 */
 	public function getErrorList() {
 		return [
@@ -33,7 +33,7 @@ class WPQueryParamsUnitTest extends AbstractSniffUnitTest {
 	/**
 	 * Returns the lines where warnings should occur.
 	 *
-	 * @return array <int line number> => <int number of warnings>
+	 * @return array<int, int> Key is the line number, value is the number of expected warnings.
 	 */
 	public function getWarningList() {
 		return [

--- a/WordPressVIPMinimum/Tests/Security/EscapingVoidReturnFunctionsUnitTest.php
+++ b/WordPressVIPMinimum/Tests/Security/EscapingVoidReturnFunctionsUnitTest.php
@@ -21,7 +21,7 @@ class EscapingVoidReturnFunctionsUnitTest extends AbstractSniffUnitTest {
 	/**
 	 * Returns the lines where errors should occur.
 	 *
-	 * @return array <int line number> => <int number of errors>
+	 * @return array<int, int> Key is the line number, value is the number of expected errors.
 	 */
 	public function getErrorList() {
 		return [
@@ -32,7 +32,7 @@ class EscapingVoidReturnFunctionsUnitTest extends AbstractSniffUnitTest {
 	/**
 	 * Returns the lines where warnings should occur.
 	 *
-	 * @return array <int line number> => <int number of warnings>
+	 * @return array<int, int> Key is the line number, value is the number of expected warnings.
 	 */
 	public function getWarningList() {
 		return [];

--- a/WordPressVIPMinimum/Tests/Security/ExitAfterRedirectUnitTest.php
+++ b/WordPressVIPMinimum/Tests/Security/ExitAfterRedirectUnitTest.php
@@ -21,7 +21,7 @@ class ExitAfterRedirectUnitTest extends AbstractSniffUnitTest {
 	/**
 	 * Returns the lines where errors should occur.
 	 *
-	 * @return array <int line number> => <int number of errors>
+	 * @return array<int, int> Key is the line number, value is the number of expected errors.
 	 */
 	public function getErrorList() {
 		return [
@@ -33,7 +33,7 @@ class ExitAfterRedirectUnitTest extends AbstractSniffUnitTest {
 	/**
 	 * Returns the lines where warnings should occur.
 	 *
-	 * @return array <int line number> => <int number of warnings>
+	 * @return array<int, int> Key is the line number, value is the number of expected warnings.
 	 */
 	public function getWarningList() {
 		return [];

--- a/WordPressVIPMinimum/Tests/Security/MustacheUnitTest.php
+++ b/WordPressVIPMinimum/Tests/Security/MustacheUnitTest.php
@@ -21,7 +21,7 @@ class MustacheUnitTest extends AbstractSniffUnitTest {
 	/**
 	 * Returns the lines where errors should occur.
 	 *
-	 * @return array <int line number> => <int number of errors>
+	 * @return array<int, int> Key is the line number, value is the number of expected errors.
 	 */
 	public function getErrorList() {
 		return [];
@@ -30,7 +30,7 @@ class MustacheUnitTest extends AbstractSniffUnitTest {
 	/**
 	 * Returns the lines where warnings should occur.
 	 *
-	 * @return array <int line number> => <int number of warnings>
+	 * @return array<int, int> Key is the line number, value is the number of expected warnings.
 	 */
 	public function getWarningList() {
 		return [

--- a/WordPressVIPMinimum/Tests/Security/PHPFilterFunctionsUnitTest.php
+++ b/WordPressVIPMinimum/Tests/Security/PHPFilterFunctionsUnitTest.php
@@ -21,7 +21,7 @@ class PHPFilterFunctionsUnitTest extends AbstractSniffUnitTest {
 	/**
 	 * Returns the lines where errors should occur.
 	 *
-	 * @return array <int line number> => <int number of errors>
+	 * @return array<int, int> Key is the line number, value is the number of expected errors.
 	 */
 	public function getErrorList() {
 		return [];
@@ -30,7 +30,7 @@ class PHPFilterFunctionsUnitTest extends AbstractSniffUnitTest {
 	/**
 	 * Returns the lines where warnings should occur.
 	 *
-	 * @return array <int line number> => <int number of warnings>
+	 * @return array<int, int> Key is the line number, value is the number of expected warnings.
 	 */
 	public function getWarningList() {
 		return [

--- a/WordPressVIPMinimum/Tests/Security/ProperEscapingFunctionUnitTest.php
+++ b/WordPressVIPMinimum/Tests/Security/ProperEscapingFunctionUnitTest.php
@@ -23,7 +23,7 @@ class ProperEscapingFunctionUnitTest extends AbstractSniffUnitTest {
 	 *
 	 * @param string $testFile The name of the file being tested.
 	 *
-	 * @return array <int line number> => <int number of errors>
+	 * @return array<int, int> Key is the line number, value is the number of expected errors.
 	 */
 	public function getErrorList( $testFile = '' ) {
 		switch ( $testFile ) {
@@ -71,7 +71,7 @@ class ProperEscapingFunctionUnitTest extends AbstractSniffUnitTest {
 	/**
 	 * Returns the lines where warnings should occur.
 	 *
-	 * @return array <int line number> => <int number of warnings>
+	 * @return array<int, int> Key is the line number, value is the number of expected warnings.
 	 */
 	public function getWarningList() {
 		return [];

--- a/WordPressVIPMinimum/Tests/Security/StaticStrreplaceUnitTest.php
+++ b/WordPressVIPMinimum/Tests/Security/StaticStrreplaceUnitTest.php
@@ -21,7 +21,7 @@ class StaticStrreplaceUnitTest extends AbstractSniffUnitTest {
 	/**
 	 * Returns the lines where errors should occur.
 	 *
-	 * @return array <int line number> => <int number of errors>
+	 * @return array<int, int> Key is the line number, value is the number of expected errors.
 	 */
 	public function getErrorList() {
 		return [
@@ -33,7 +33,7 @@ class StaticStrreplaceUnitTest extends AbstractSniffUnitTest {
 	/**
 	 * Returns the lines where warnings should occur.
 	 *
-	 * @return array <int line number> => <int number of warnings>
+	 * @return array<int, int> Key is the line number, value is the number of expected warnings.
 	 */
 	public function getWarningList() {
 		return [];

--- a/WordPressVIPMinimum/Tests/Security/TwigUnitTest.php
+++ b/WordPressVIPMinimum/Tests/Security/TwigUnitTest.php
@@ -21,7 +21,7 @@ class TwigUnitTest extends AbstractSniffUnitTest {
 	/**
 	 * Returns the lines where errors should occur.
 	 *
-	 * @return array <int line number> => <int number of errors>
+	 * @return array<int, int> Key is the line number, value is the number of expected errors.
 	 */
 	public function getErrorList() {
 		return [];
@@ -30,7 +30,7 @@ class TwigUnitTest extends AbstractSniffUnitTest {
 	/**
 	 * Returns the lines where warnings should occur.
 	 *
-	 * @return array <int line number> => <int number of warnings>
+	 * @return array<int, int> Key is the line number, value is the number of expected warnings.
 	 */
 	public function getWarningList() {
 		return [

--- a/WordPressVIPMinimum/Tests/Security/UnderscorejsUnitTest.php
+++ b/WordPressVIPMinimum/Tests/Security/UnderscorejsUnitTest.php
@@ -36,7 +36,7 @@ class UnderscorejsUnitTest extends AbstractSniffUnitTest {
 	/**
 	 * Returns the lines where errors should occur.
 	 *
-	 * @return array <int line number> => <int number of errors>
+	 * @return array<int, int> Key is the line number, value is the number of expected errors.
 	 */
 	public function getErrorList() {
 		return [];
@@ -47,7 +47,7 @@ class UnderscorejsUnitTest extends AbstractSniffUnitTest {
 	 *
 	 * @param string $testFile The name of the file being tested.
 	 *
-	 * @return array <int line number> => <int number of warnings>
+	 * @return array<int, int> Key is the line number, value is the number of expected warnings.
 	 */
 	public function getWarningList( $testFile = '' ) {
 		switch ( $testFile ) {

--- a/WordPressVIPMinimum/Tests/Security/VuejsUnitTest.php
+++ b/WordPressVIPMinimum/Tests/Security/VuejsUnitTest.php
@@ -21,7 +21,7 @@ class VuejsUnitTest extends AbstractSniffUnitTest {
 	/**
 	 * Returns the lines where errors should occur.
 	 *
-	 * @return array <int line number> => <int number of errors>
+	 * @return array<int, int> Key is the line number, value is the number of expected errors.
 	 */
 	public function getErrorList() {
 		return [];
@@ -30,7 +30,7 @@ class VuejsUnitTest extends AbstractSniffUnitTest {
 	/**
 	 * Returns the lines where warnings should occur.
 	 *
-	 * @return array <int line number> => <int number of warnings>
+	 * @return array<int, int> Key is the line number, value is the number of expected warnings.
 	 */
 	public function getWarningList() {
 		return [

--- a/WordPressVIPMinimum/Tests/UserExperience/AdminBarRemovalUnitTest.php
+++ b/WordPressVIPMinimum/Tests/UserExperience/AdminBarRemovalUnitTest.php
@@ -25,7 +25,7 @@ class AdminBarRemovalUnitTest extends AbstractSniffUnitTest {
 	 *
 	 * @param string $testFile The name of the file being tested.
 	 *
-	 * @return array <int line number> => <int number of errors>
+	 * @return array<int, int> Key is the line number, value is the number of expected errors.
 	 */
 	public function getErrorList( $testFile = '' ) {
 
@@ -85,7 +85,8 @@ class AdminBarRemovalUnitTest extends AbstractSniffUnitTest {
 	 * Returns the lines where warnings should occur.
 	 *
 	 * @param string $testFile The name of the file being tested.
-	 * @return array <int line number> => <int number of warnings>
+	 *
+	 * @return array<int, int> Key is the line number, value is the number of expected warnings.
 	 */
 	public function getWarningList( $testFile = '' ) {
 		switch ( $testFile ) {

--- a/WordPressVIPMinimum/Tests/Variables/RestrictedVariablesUnitTest.php
+++ b/WordPressVIPMinimum/Tests/Variables/RestrictedVariablesUnitTest.php
@@ -24,7 +24,7 @@ class RestrictedVariablesUnitTest extends AbstractSniffUnitTest {
 	/**
 	 * Returns the lines where errors should occur.
 	 *
-	 * @return array <int line number> => <int number of errors>
+	 * @return array<int, int> Key is the line number, value is the number of expected errors.
 	 */
 	public function getErrorList() {
 		return [
@@ -39,7 +39,7 @@ class RestrictedVariablesUnitTest extends AbstractSniffUnitTest {
 	/**
 	 * Returns the lines where warnings should occur.
 	 *
-	 * @return array <int line number> => <int number of warnings>
+	 * @return array<int, int> Key is the line number, value is the number of expected warnings.
 	 */
 	public function getWarningList() {
 		return [

--- a/WordPressVIPMinimum/Tests/Variables/ServerVariablesUnitTest.php
+++ b/WordPressVIPMinimum/Tests/Variables/ServerVariablesUnitTest.php
@@ -21,7 +21,7 @@ class ServerVariablesUnitTest extends AbstractSniffUnitTest {
 	/**
 	 * Returns the lines where errors should occur.
 	 *
-	 * @return array <int line number> => <int number of errors>
+	 * @return array<int, int> Key is the line number, value is the number of expected errors.
 	 */
 	public function getErrorList() {
 		return [
@@ -35,7 +35,7 @@ class ServerVariablesUnitTest extends AbstractSniffUnitTest {
 	/**
 	 * Returns the lines where warnings should occur.
 	 *
-	 * @return array <int line number> => <int number of warnings>
+	 * @return array<int, int> Key is the line number, value is the number of expected warnings.
 	 */
 	public function getWarningList() {
 		return [];

--- a/tests/RulesetTest.php
+++ b/tests/RulesetTest.php
@@ -124,6 +124,8 @@ class RulesetTest {
 
 	/**
 	 * Run all the tests.
+	 *
+	 * @return void
 	 */
 	private function run() {
 		// Check for missing expected values.
@@ -162,6 +164,8 @@ class RulesetTest {
 	 * Process the Decoded JSON output from PHP_CodeSniffer.
 	 *
 	 * @param \stdClass $output Decoded JSON output from PHP_CodeSniffer.
+	 *
+	 * @return void
 	 */
 	private function process_output( $output ) {
 		foreach ( $output->files as $file ) {
@@ -173,6 +177,8 @@ class RulesetTest {
 	 * Process single file of within PHP_CodeSniffer results.
 	 *
 	 * @param \stdClass $file File output.
+	 *
+	 * @return void
 	 */
 	private function process_file( $file ) {
 		foreach ( $file->messages as $violation ) {
@@ -184,6 +190,8 @@ class RulesetTest {
 	 * Process single violation within PHP_CodeSniffer results.
 	 *
 	 * @param \stdClass $violation Violation data.
+	 *
+	 * @return void
 	 */
 	private function process_violation( $violation ) {
 		if ( $this->violation_type_is_error( $violation ) ) {
@@ -210,6 +218,8 @@ class RulesetTest {
 	 * Add 1 to the number of errors for the given line.
 	 *
 	 * @param int $line Line number.
+	 *
+	 * @return void
 	 */
 	private function add_error_for_line( $line ) {
 		$this->errors[ $line ] = isset( $this->errors[ $line ] ) ? ++$this->errors[ $line ] : 1;
@@ -219,6 +229,8 @@ class RulesetTest {
 	 * Add 1 to the number of errors for the given line.
 	 *
 	 * @param int $line Line number.
+	 *
+	 * @return void
 	 */
 	private function add_warning_for_line( $line ) {
 		$this->warnings[ $line ] = isset( $this->warnings[ $line ] ) ? ++$this->warnings[ $line ] : 1;
@@ -229,6 +241,8 @@ class RulesetTest {
 	 *
 	 * @param int    $line    Line number.
 	 * @param string $message Message.
+	 *
+	 * @return void
 	 */
 	private function add_message_for_line( $line, $message ) {
 		$this->messages[ $line ] = ( ! isset( $this->messages[ $line ] ) || ! is_array( $this->messages[ $line ] ) ) ? [ $message ] : array_merge( $this->messages[ $line ], [ $message ] );
@@ -236,6 +250,8 @@ class RulesetTest {
 
 	/**
 	 * Check whether all expected numbers of errors and warnings are present in the output.
+	 *
+	 * @return void
 	 */
 	private function check_missing_expected_values() {
 		foreach ( $this->expected as $type => $lines ) {
@@ -261,6 +277,8 @@ class RulesetTest {
 
 	/**
 	 * Check whether there are no unexpected numbers of errors and warnings.
+	 *
+	 * @return void
 	 */
 	private function check_unexpected_values() {
 		foreach ( [ 'errors', 'warnings' ] as $type ) {
@@ -317,6 +335,8 @@ class RulesetTest {
 	 * @param string $type     The type of the issue.
 	 * @param int    $number   Real number of issues.
 	 * @param int    $line     Line number.
+	 *
+	 * @return void
 	 */
 	private function error_warning_message( $expected, $type, $number, $line ) {
 		// phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped

--- a/tests/RulesetTest.php
+++ b/tests/RulesetTest.php
@@ -199,6 +199,7 @@ class RulesetTest {
 	 * Check if violation is an error.
 	 *
 	 * @param \stdClass $violation Violation data.
+	 *
 	 * @return bool True if string matches error type.
 	 */
 	private function violation_type_is_error( $violation ) {


### PR DESCRIPTION
### Docs: improve test @return tags

... and use consistent spacing (blank line between param and return tags).

### Docs: various @var/@param/@return tag improvements

Definitely not claiming completeness. This is just another iteration step in improving the documented types.

### Docs: add missing @return tags

While WP tends to omit `@return void` statements, this is not WP and documenting the function return type is a good thing™.