### PR TITLE
Performance/NoPaging: add extra tests

### DIFF
--- a/WordPressVIPMinimum/Tests/Performance/NoPagingUnitTest.inc
+++ b/WordPressVIPMinimum/Tests/Performance/NoPagingUnitTest.inc
@@ -7,3 +7,9 @@ $args = array(
 _query_posts( 'nopaging=true' ); // Bad.
 
 $query_args['my_posts_per_page'] = -1; // OK.
+
+// Verify handling with no trailing comma at end of array.
+$args = array(
+	'nopaging' => true // Bad.
+);
+$args = [ 'nopaging' => true ]; // Bad.

--- a/WordPressVIPMinimum/Tests/Performance/NoPagingUnitTest.php
+++ b/WordPressVIPMinimum/Tests/Performance/NoPagingUnitTest.php
@@ -27,8 +27,10 @@ class NoPagingUnitTest extends AbstractSniffUnitTest {
 	 */
 	public function getErrorList() {
 		return [
-			4 => 1,
-			7 => 1,
+			4  => 1,
+			7  => 1,
+			13 => 1,
+			15 => 1,
 		];
 	}
 


### PR DESCRIPTION
Safeguard the fix which was added to WPCS 3.0.0 in response to WPCS issue WordPress/WordPress-Coding-Standards #2211, which was created to handle VIPCS issue #713.