### PR TITLE
Hooks/AlwaysReturnInFilter: remove redundant condition

### DIFF
--- a/WordPressVIPMinimum/Sniffs/Hooks/AlwaysReturnInFilterSniff.php
+++ b/WordPressVIPMinimum/Sniffs/Hooks/AlwaysReturnInFilterSniff.php
@@ -223,13 +223,10 @@ class AlwaysReturnInFilterSniff extends Sniff {
 			$functionBodyScopeEnd
 		);
 
-		$insideIfConditionalReturn = 0;
-		$outsideConditionalReturn  = 0;
+		$outsideConditionalReturn = 0;
 
 		while ( $returnTokenPtr ) {
-			if ( $this->isInsideIfConditonal( $returnTokenPtr ) ) {
-				++$insideIfConditionalReturn;
-			} else {
+			if ( $this->isInsideIfConditonal( $returnTokenPtr ) === false ) {
 				++$outsideConditionalReturn;
 			}
 			if ( $this->isReturningVoid( $returnTokenPtr ) ) {
@@ -244,11 +241,10 @@ class AlwaysReturnInFilterSniff extends Sniff {
 			);
 		}
 
-		if ( $insideIfConditionalReturn >= 0 && $outsideConditionalReturn === 0 ) {
+		if ( $outsideConditionalReturn === 0 ) {
 			$message = 'Please, make sure that a callback to `%s` filter is always returning some value.';
 			$data    = [ $filterName ];
 			$this->phpcsFile->addError( $message, $functionBodyScopeStart, 'MissingReturnStatement', $data );
-
 		}
 	}
 


### PR DESCRIPTION
Given that:
* `$insideIfConditionalReturn` has a default value of `0`;
* And that value is only ever increased;
* The `$insideIfConditionalReturn >= 0` condition will always be `true`.

So this condition can be safely removed, just like the - now unused - assignments to the variable.

The original condition was introduced with the introduction of the sniff in #177. The condition was adjusted in #291, which made the logic redundant.

Looking at the sniff, I believe the intention was to only flag the "return outside condition missing" when not all control structure paths had a `return` statement, but this was never really properly checked as the only control structures taken into account are `if` control structures.

I believe it would be good to improve the sniff to handle more control structures (`switch`, `while` etc) and to not throw the "return outside condition missing" error if all possible paths have a `return` statement, but that is outside the scope of the current PR.

I will add a note to this effect to the review ticket for this sniff - #520.