### PR TITLE
Performance/WPQueryParams: prevent false positives for 'exclude' with get_users()

### DIFF
--- a/WordPressVIPMinimum/Tests/Performance/WPQueryParamsUnitTest.inc
+++ b/WordPressVIPMinimum/Tests/Performance/WPQueryParamsUnitTest.inc
@@ -21,3 +21,11 @@ $q = new WP_query( $query_args );
 get_posts( [ 'exclude' => $post_ids ] ); // Warning.
 
 $exclude = [ 1, 2, 3 ];
+
+// Issue #672 / #729.
+get_users( [ 'exclude' => $post_ids ] ); // OK.
+get_users( My\get_args( [ 'exclude' => $post_ids ] ) ); // OK - arbitrary as the call to `My\get_args()` on its own would be flagged, but let's allow it.
+
+$context_unknown = [ 'exclude' => $post_ids ]; // Warning.
+other_fn_calls_still_throw_warning( [ 'exclude' => $post_ids ] ); // Warning.
+get_users( [ 'suppress_filters' => true ] ); // Error - not necessarily valid, but the exception being made is specifically about `exclude`.

--- a/WordPressVIPMinimum/Tests/Performance/WPQueryParamsUnitTest.php
+++ b/WordPressVIPMinimum/Tests/Performance/WPQueryParamsUnitTest.php
@@ -27,6 +27,7 @@ class WPQueryParamsUnitTest extends AbstractSniffUnitTest {
 		return [
 			5  => 1,
 			17 => 1,
+			31 => 1,
 		];
 	}
 
@@ -40,6 +41,8 @@ class WPQueryParamsUnitTest extends AbstractSniffUnitTest {
 			4  => 1,
 			11 => 1,
 			21 => 1,
+			29 => 1,
+			30 => 1,
 		];
 	}
 }


### PR DESCRIPTION
As reported in #672 and #729, the `get_users()` function also takes an array parameter which takes an `'exclude'` key. That key is not our target, so should not be flagged.

This commit adds a hard-coded exception specifically for that situation.

If at a later point in time, more situations which need exceptions would be discovered, this solution can be made more flexible, but for now, there is no need (or insight into where the flexibility should be).

As the `AbstractArrayAssignmentRestrictionsSniff::callback()` method does not have access to the `$stackPtr`, the logic which can be used in the `callback()` is limited. Also see the review notes from upstream WordPress/WordPress-Coding-Standards#2266, which basically already pointed out this exact problem.

To get round this, I'm overloading the `process_token()` method to set a temporary `$in_get_users` property, which can then be read out in the `callback()` method to be used in the actual determination of whether the exception should be made or not.

Includes tests.

Fixes #672