### PR TITLE
Docs: remove redundant `@package` tags

### DIFF
--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -140,8 +140,6 @@ use PHP_CodeSniffer\Tests\Standards\AbstractSniffUnitTest;
 
 /**
  * Unit test class for the WP_Query params sniff.
- *
- * @package VIPCS\WordPressVIPMinimum
  */
 class WPQueryParamsUnitTest extends AbstractSniffUnitTest {
 

--- a/WordPressVIPMinimum/Sniffs/AbstractVariableRestrictionsSniff.php
+++ b/WordPressVIPMinimum/Sniffs/AbstractVariableRestrictionsSniff.php
@@ -18,8 +18,6 @@ use WordPressCS\WordPress\Helpers\RulesetPropertyHelper;
  * Restricts usage of some variables.
  *
  * Originally part of WordPress Coding Standards repo.
- *
- * @package VIPCS\WordPressVIPMinimum
  */
 abstract class AbstractVariableRestrictionsSniff extends Sniff {
 

--- a/WordPressVIPMinimum/Sniffs/Classes/DeclarationCompatibilitySniff.php
+++ b/WordPressVIPMinimum/Sniffs/Classes/DeclarationCompatibilitySniff.php
@@ -14,8 +14,6 @@ use PHPCSUtils\Utils\ObjectDeclarations;
 
 /**
  * Class WordPressVIPMinimum_Sniffs_Classes_DeclarationCompatibilitySniff
- *
- * @package VIPCS\WordPressVIPMinimum
  */
 class DeclarationCompatibilitySniff extends AbstractScopeSniff {
 

--- a/WordPressVIPMinimum/Sniffs/Classes/RestrictedExtendClassesSniff.php
+++ b/WordPressVIPMinimum/Sniffs/Classes/RestrictedExtendClassesSniff.php
@@ -12,8 +12,6 @@ use WordPressCS\WordPress\AbstractClassRestrictionsSniff;
 /**
  * WordPressVIPMinimum_Sniffs_Classes_RestrictedExtendClassesSniff.
  *
- * @package VIPCS\WordPressVIPMinimum
- *
  * @since 0.4.0
  */
 class RestrictedExtendClassesSniff extends AbstractClassRestrictionsSniff {

--- a/WordPressVIPMinimum/Sniffs/Constants/ConstantStringSniff.php
+++ b/WordPressVIPMinimum/Sniffs/Constants/ConstantStringSniff.php
@@ -14,8 +14,6 @@ use WordPressVIPMinimum\Sniffs\Sniff;
 
 /**
  * Sniff for properly using constant name when checking whether a constant is defined.
- *
- * @package VIPCS\WordPressVIPMinimum
  */
 class ConstantStringSniff extends Sniff {
 

--- a/WordPressVIPMinimum/Sniffs/Constants/RestrictedConstantsSniff.php
+++ b/WordPressVIPMinimum/Sniffs/Constants/RestrictedConstantsSniff.php
@@ -13,8 +13,6 @@ use WordPressVIPMinimum\Sniffs\Sniff;
 
 /**
  * Restricts usage of some constants.
- *
- * @package VIPCS\WordPressVIPMinimum
  */
 class RestrictedConstantsSniff extends Sniff {
 

--- a/WordPressVIPMinimum/Sniffs/Files/IncludingFileSniff.php
+++ b/WordPressVIPMinimum/Sniffs/Files/IncludingFileSniff.php
@@ -14,8 +14,6 @@ use WordPressCS\WordPress\AbstractFunctionRestrictionsSniff;
  * WordPressVIPMinimum_Sniffs_Files_IncludingFileSniff.
  *
  * Checks for custom variables, functions and constants, and external URLs used in file inclusion.
- *
- * @package VIPCS\WordPressVIPMinimum
  */
 class IncludingFileSniff extends AbstractFunctionRestrictionsSniff {
 

--- a/WordPressVIPMinimum/Sniffs/Files/IncludingNonPHPFileSniff.php
+++ b/WordPressVIPMinimum/Sniffs/Files/IncludingNonPHPFileSniff.php
@@ -15,8 +15,6 @@ use WordPressVIPMinimum\Sniffs\Sniff;
  * Ensure that non-PHP files are included via `file_get_contents()` instead of using `include/require[_once]`.
  *
  * This prevents potential PHP code embedded in those files from being automatically executed.
- *
- * @package VIPCS\WordPressVIPMinimum
  */
 class IncludingNonPHPFileSniff extends Sniff {
 

--- a/WordPressVIPMinimum/Sniffs/Functions/RestrictedFunctionsSniff.php
+++ b/WordPressVIPMinimum/Sniffs/Functions/RestrictedFunctionsSniff.php
@@ -12,8 +12,6 @@ use WordPressCS\WordPress\AbstractFunctionRestrictionsSniff;
 
 /**
  * Restricts usage of some functions in VIP context.
- *
- * @package VIPCS\WordPressVIPMinimum
  */
 class RestrictedFunctionsSniff extends AbstractFunctionRestrictionsSniff {
 

--- a/WordPressVIPMinimum/Sniffs/Functions/StripTagsSniff.php
+++ b/WordPressVIPMinimum/Sniffs/Functions/StripTagsSniff.php
@@ -12,8 +12,6 @@ use WordPressCS\WordPress\AbstractFunctionParameterSniff;
 /**
  * This sniff ensures proper tag stripping.
  *
- * @package VIPCS\WordPressVIPMinimum
- *
  * @since 0.4.0
  */
 class StripTagsSniff extends AbstractFunctionParameterSniff {

--- a/WordPressVIPMinimum/Sniffs/Hooks/AlwaysReturnInFilterSniff.php
+++ b/WordPressVIPMinimum/Sniffs/Hooks/AlwaysReturnInFilterSniff.php
@@ -14,8 +14,6 @@ use WordPressVIPMinimum\Sniffs\Sniff;
 
 /**
  * This sniff validates that filters always return a value
- *
- * @package VIPCS\WordPressVIPMinimum
  */
 class AlwaysReturnInFilterSniff extends Sniff {
 

--- a/WordPressVIPMinimum/Sniffs/Hooks/PreGetPostsSniff.php
+++ b/WordPressVIPMinimum/Sniffs/Hooks/PreGetPostsSniff.php
@@ -15,8 +15,6 @@ use WordPressVIPMinimum\Sniffs\Sniff;
  * This sniff validates a proper usage of pre_get_posts action callback.
  *
  * It looks for cases when the WP_Query object is being modified without checking for WP_Query::is_main_query().
- *
- * @package VIPCS\WordPressVIPMinimum
  */
 class PreGetPostsSniff extends Sniff {
 

--- a/WordPressVIPMinimum/Sniffs/Hooks/RestrictedHooksSniff.php
+++ b/WordPressVIPMinimum/Sniffs/Hooks/RestrictedHooksSniff.php
@@ -12,8 +12,6 @@ use WordPressCS\WordPress\AbstractFunctionParameterSniff;
 /**
  * This sniff restricts usage of some action and filter hooks.
  *
- * @package VIPCS\WordPressVIPMinimum
- *
  * @since 0.4.0
  */
 class RestrictedHooksSniff extends AbstractFunctionParameterSniff {

--- a/WordPressVIPMinimum/Sniffs/JS/DangerouslySetInnerHTMLSniff.php
+++ b/WordPressVIPMinimum/Sniffs/JS/DangerouslySetInnerHTMLSniff.php
@@ -14,8 +14,6 @@ use WordPressVIPMinimum\Sniffs\Sniff;
  * WordPressVIPMinimum_Sniffs_JS_DangerouslySetInnerHTMLSniff.
  *
  * Looks for instances of React's dangerouslySetInnerHMTL.
- *
- * @package VIPCS\WordPressVIPMinimum
  */
 class DangerouslySetInnerHTMLSniff extends Sniff {
 

--- a/WordPressVIPMinimum/Sniffs/JS/HTMLExecutingFunctionsSniff.php
+++ b/WordPressVIPMinimum/Sniffs/JS/HTMLExecutingFunctionsSniff.php
@@ -14,8 +14,6 @@ use WordPressVIPMinimum\Sniffs\Sniff;
  * WordPressVIPMinimum_Sniffs_JS_HTMLExecutingFunctions.
  *
  * Flags functions which are executing HTML passed to it.
- *
- * @package VIPCS\WordPressVIPMinimum
  */
 class HTMLExecutingFunctionsSniff extends Sniff {
 

--- a/WordPressVIPMinimum/Sniffs/JS/InnerHTMLSniff.php
+++ b/WordPressVIPMinimum/Sniffs/JS/InnerHTMLSniff.php
@@ -14,8 +14,6 @@ use WordPressVIPMinimum\Sniffs\Sniff;
  * WordPressVIPMinimum_Sniffs_JS_InnerHTMLSniff.
  *
  * Looks for instances of .innerHMTL.
- *
- * @package VIPCS\WordPressVIPMinimum
  */
 class InnerHTMLSniff extends Sniff {
 

--- a/WordPressVIPMinimum/Sniffs/JS/StringConcatSniff.php
+++ b/WordPressVIPMinimum/Sniffs/JS/StringConcatSniff.php
@@ -14,8 +14,6 @@ use WordPressVIPMinimum\Sniffs\Sniff;
  * WordPressVIPMinimum_Sniffs_JS_StringConcatSniff.
  *
  * Looks for HTML string concatenation.
- *
- * @package VIPCS\WordPressVIPMinimum
  */
 class StringConcatSniff extends Sniff {
 

--- a/WordPressVIPMinimum/Sniffs/JS/StrippingTagsSniff.php
+++ b/WordPressVIPMinimum/Sniffs/JS/StrippingTagsSniff.php
@@ -14,8 +14,6 @@ use WordPressVIPMinimum\Sniffs\Sniff;
  * WordPressVIPMinimum_Sniffs_JS_StrippingTagsSniff.
  *
  * Looks for incorrect way of stripping tags.
- *
- * @package VIPCS\WordPressVIPMinimum
  */
 class StrippingTagsSniff extends Sniff {
 

--- a/WordPressVIPMinimum/Sniffs/JS/WindowSniff.php
+++ b/WordPressVIPMinimum/Sniffs/JS/WindowSniff.php
@@ -14,8 +14,6 @@ use WordPressVIPMinimum\Sniffs\Sniff;
  * WordPressVIPMinimum_Sniffs_JS_WindowSniff.
  *
  * Looks for instances of window properties that should be flagged.
- *
- * @package VIPCS\WordPressVIPMinimum
  */
 class WindowSniff extends Sniff {
 

--- a/WordPressVIPMinimum/Sniffs/Performance/CacheValueOverrideSniff.php
+++ b/WordPressVIPMinimum/Sniffs/Performance/CacheValueOverrideSniff.php
@@ -12,8 +12,6 @@ use WordPressVIPMinimum\Sniffs\Sniff;
 
 /**
  * This sniff check whether a cached value is being overridden.
- *
- * @package VIPCS\WordPressVIPMinimum
  */
 class CacheValueOverrideSniff extends Sniff {
 

--- a/WordPressVIPMinimum/Sniffs/Performance/FetchingRemoteDataSniff.php
+++ b/WordPressVIPMinimum/Sniffs/Performance/FetchingRemoteDataSniff.php
@@ -13,8 +13,6 @@ use WordPressVIPMinimum\Sniffs\Sniff;
 
 /**
  * Restricts usage of file_get_contents().
- *
- *  @package VIPCS\WordPressVIPMinimum
  */
 class FetchingRemoteDataSniff extends Sniff {
 

--- a/WordPressVIPMinimum/Sniffs/Performance/LowExpiryCacheTimeSniff.php
+++ b/WordPressVIPMinimum/Sniffs/Performance/LowExpiryCacheTimeSniff.php
@@ -16,8 +16,6 @@ use WordPressCS\WordPress\AbstractFunctionParameterSniff;
  *
  * {@internal VIP uses the Memcached object cache implementation. {@link https://github.com/Automattic/wp-memcached}}
  *
- * @package VIPCS\WordPressVIPMinimum
- *
  * @since 0.4.0
  */
 class LowExpiryCacheTimeSniff extends AbstractFunctionParameterSniff {

--- a/WordPressVIPMinimum/Sniffs/Performance/NoPagingSniff.php
+++ b/WordPressVIPMinimum/Sniffs/Performance/NoPagingSniff.php
@@ -16,9 +16,7 @@ use WordPressCS\WordPress\AbstractArrayAssignmentRestrictionsSniff;
  *
  * @link https://docs.wpvip.com/technical-references/code-review/#no-limit-queries
  *
- * @package VIPCS\WordPressVIPMinimum
- *
- * @since   0.5.0
+ * @since 0.5.0
  */
 class NoPagingSniff extends AbstractArrayAssignmentRestrictionsSniff {
 

--- a/WordPressVIPMinimum/Sniffs/Performance/OrderByRandSniff.php
+++ b/WordPressVIPMinimum/Sniffs/Performance/OrderByRandSniff.php
@@ -17,9 +17,7 @@ use WordPressCS\WordPress\AbstractArrayAssignmentRestrictionsSniff;
  *
  * @link https://docs.wpvip.com/technical-references/code-review/vip-errors/#h-order-by-rand
  *
- * @package VIPCS\WordPressVIPMinimum
- *
- * @since   0.5.0
+ * @since 0.5.0
  */
 class OrderByRandSniff extends AbstractArrayAssignmentRestrictionsSniff {
 

--- a/WordPressVIPMinimum/Sniffs/Performance/RegexpCompareSniff.php
+++ b/WordPressVIPMinimum/Sniffs/Performance/RegexpCompareSniff.php
@@ -12,8 +12,6 @@ use WordPressCS\WordPress\AbstractArrayAssignmentRestrictionsSniff;
 
 /**
  * Flag REGEXP and NOT REGEXP in meta compare
- *
- *  @package VIPCS\WordPressVIPMinimum
  */
 class RegexpCompareSniff extends AbstractArrayAssignmentRestrictionsSniff {
 

--- a/WordPressVIPMinimum/Sniffs/Performance/RemoteRequestTimeoutSniff.php
+++ b/WordPressVIPMinimum/Sniffs/Performance/RemoteRequestTimeoutSniff.php
@@ -11,8 +11,6 @@ use WordPressCS\WordPress\AbstractArrayAssignmentRestrictionsSniff;
 
 /**
  * Flag use of a timeout of more than 3 seconds for remote requests.
- *
- * @package VIPCS\WordPressVIPMinimum
  */
 class RemoteRequestTimeoutSniff extends AbstractArrayAssignmentRestrictionsSniff {
 

--- a/WordPressVIPMinimum/Sniffs/Performance/TaxonomyMetaInOptionsSniff.php
+++ b/WordPressVIPMinimum/Sniffs/Performance/TaxonomyMetaInOptionsSniff.php
@@ -13,8 +13,6 @@ use WordPressVIPMinimum\Sniffs\Sniff;
 
 /**
  * Restricts the implementation of taxonomy term meta via options.
- *
- *  @package VIPCS\WordPressVIPMinimum
  */
 class TaxonomyMetaInOptionsSniff extends Sniff {
 

--- a/WordPressVIPMinimum/Sniffs/Performance/WPQueryParamsSniff.php
+++ b/WordPressVIPMinimum/Sniffs/Performance/WPQueryParamsSniff.php
@@ -14,8 +14,6 @@ use WordPressCS\WordPress\AbstractArrayAssignmentRestrictionsSniff;
  * Flag suspicious WP_Query and get_posts params.
  *
  * @link https://docs.wpvip.com/technical-references/caching/uncached-functions/
- *
- * @package VIPCS\WordPressVIPMinimum
  */
 class WPQueryParamsSniff extends AbstractArrayAssignmentRestrictionsSniff {
 

--- a/WordPressVIPMinimum/Sniffs/Security/EscapingVoidReturnFunctionsSniff.php
+++ b/WordPressVIPMinimum/Sniffs/Security/EscapingVoidReturnFunctionsSniff.php
@@ -17,8 +17,6 @@ use WordPressVIPMinimum\Sniffs\Sniff;
  *
  * E.g. esc_html( _e( 'foo' ) );
  *
- * @package VIPCS\WordPressVIPMinimum
- *
  * @uses \WordPressCS\WordPress\Helpers\PrintingFunctionsTrait::$customPrintingFunctions
  */
 class EscapingVoidReturnFunctionsSniff extends Sniff {

--- a/WordPressVIPMinimum/Sniffs/Security/ExitAfterRedirectSniff.php
+++ b/WordPressVIPMinimum/Sniffs/Security/ExitAfterRedirectSniff.php
@@ -13,8 +13,6 @@ use WordPressVIPMinimum\Sniffs\Sniff;
 
 /**
  * Require `exit;` being called after wp_redirect and wp_safe_redirect.
- *
- *  @package VIPCS\WordPressVIPMinimum
  */
 class ExitAfterRedirectSniff extends Sniff {
 

--- a/WordPressVIPMinimum/Sniffs/Security/MustacheSniff.php
+++ b/WordPressVIPMinimum/Sniffs/Security/MustacheSniff.php
@@ -12,8 +12,6 @@ use WordPressVIPMinimum\Sniffs\Sniff;
 
 /**
  * Looks for instances of unescaped output for Mustache templating engine and Handlebars.js.
- *
- * @package VIPCS\WordPressVIPMinimum
  */
 class MustacheSniff extends Sniff {
 

--- a/WordPressVIPMinimum/Sniffs/Security/PHPFilterFunctionsSniff.php
+++ b/WordPressVIPMinimum/Sniffs/Security/PHPFilterFunctionsSniff.php
@@ -12,8 +12,6 @@ use WordPressCS\WordPress\AbstractFunctionParameterSniff;
 /**
  * This sniff ensures that proper sanitization is occurring when PHP's filter_* functions are used.
  *
- * @package VIPCS\WordPressVIPMinimum
- *
  * @since 0.4.0
  */
 class PHPFilterFunctionsSniff extends AbstractFunctionParameterSniff {

--- a/WordPressVIPMinimum/Sniffs/Security/ProperEscapingFunctionSniff.php
+++ b/WordPressVIPMinimum/Sniffs/Security/ProperEscapingFunctionSniff.php
@@ -15,8 +15,6 @@ use WordPressVIPMinimum\Sniffs\Sniff;
 
 /**
  * Checks whether proper escaping function is used.
- *
- *  @package VIPCS\WordPressVIPMinimum
  */
 class ProperEscapingFunctionSniff extends Sniff {
 

--- a/WordPressVIPMinimum/Sniffs/Security/StaticStrreplaceSniff.php
+++ b/WordPressVIPMinimum/Sniffs/Security/StaticStrreplaceSniff.php
@@ -13,8 +13,6 @@ use WordPressVIPMinimum\Sniffs\Sniff;
 
 /**
  * Restricts usage of str_replace with all 3 params being static.
- *
- *  @package VIPCS\WordPressVIPMinimum
  */
 class StaticStrreplaceSniff extends Sniff {
 

--- a/WordPressVIPMinimum/Sniffs/Security/TwigSniff.php
+++ b/WordPressVIPMinimum/Sniffs/Security/TwigSniff.php
@@ -12,8 +12,6 @@ use WordPressVIPMinimum\Sniffs\Sniff;
 
 /**
  * Looks for instances of unescaped output for Twig templating engine.
- *
- * @package VIPCS\WordPressVIPMinimum
  */
 class TwigSniff extends Sniff {
 

--- a/WordPressVIPMinimum/Sniffs/Security/UnderscorejsSniff.php
+++ b/WordPressVIPMinimum/Sniffs/Security/UnderscorejsSniff.php
@@ -14,8 +14,6 @@ use WordPressVIPMinimum\Sniffs\Sniff;
 
 /**
  * Looks for instances of unescaped output for Underscore.js templating engine.
- *
- * @package VIPCS\WordPressVIPMinimum
  */
 class UnderscorejsSniff extends Sniff {
 

--- a/WordPressVIPMinimum/Sniffs/Security/VuejsSniff.php
+++ b/WordPressVIPMinimum/Sniffs/Security/VuejsSniff.php
@@ -12,8 +12,6 @@ use WordPressVIPMinimum\Sniffs\Sniff;
 
 /**
  * Looks for instances of unescaped output for Twig templating engine.
- *
- * @package VIPCS\WordPressVIPMinimum
  */
 class VuejsSniff extends Sniff {
 

--- a/WordPressVIPMinimum/Sniffs/Sniff.php
+++ b/WordPressVIPMinimum/Sniffs/Sniff.php
@@ -15,8 +15,6 @@ use WordPressCS\WordPress\Sniff as WPCS_Sniff;
  * Represents a WordPress\Sniff for sniffing VIP coding standards.
  *
  * Provides a bootstrap for the sniffs, to reduce code duplication.
- *
- * @package VIPCS\WordPressVIPMinimum
  */
 abstract class Sniff extends WPCS_Sniff {
 }

--- a/WordPressVIPMinimum/Sniffs/UserExperience/AdminBarRemovalSniff.php
+++ b/WordPressVIPMinimum/Sniffs/UserExperience/AdminBarRemovalSniff.php
@@ -19,9 +19,7 @@ use WordPressCS\WordPress\AbstractFunctionParameterSniff;
  *
  * @link https://docs.wpvip.com/technical-references/code-review/vip-warnings/#h-removing-the-admin-bar
  *
- * @package VIPCS\WordPressVIPMinimum
- *
- * @since   0.5.0
+ * @since 0.5.0
  */
 class AdminBarRemovalSniff extends AbstractFunctionParameterSniff {
 

--- a/WordPressVIPMinimum/Sniffs/Variables/RestrictedVariablesSniff.php
+++ b/WordPressVIPMinimum/Sniffs/Variables/RestrictedVariablesSniff.php
@@ -14,9 +14,7 @@ use WordPressVIPMinimum\Sniffs\AbstractVariableRestrictionsSniff;
 /**
  * Restricts usage of some variables in VIP context.
  *
- * @package VIPCS\WordPressVIPMinimum
- *
- * @since   0.5.0
+ * @since 0.5.0
  */
 class RestrictedVariablesSniff extends AbstractVariableRestrictionsSniff {
 

--- a/WordPressVIPMinimum/Sniffs/Variables/ServerVariablesSniff.php
+++ b/WordPressVIPMinimum/Sniffs/Variables/ServerVariablesSniff.php
@@ -12,8 +12,6 @@ use WordPressVIPMinimum\Sniffs\Sniff;
 
 /**
  * Restricts usage of some server variables.
- *
- * @package VIPCS\WordPressVIPMinimum
  */
 class ServerVariablesSniff extends Sniff {
 

--- a/WordPressVIPMinimum/Tests/Classes/DeclarationCompatibilityUnitTest.php
+++ b/WordPressVIPMinimum/Tests/Classes/DeclarationCompatibilityUnitTest.php
@@ -12,8 +12,6 @@ use PHP_CodeSniffer\Tests\Standards\AbstractSniffUnitTest;
 /**
  * Unit test class for the DeclarationCompatibility sniff.
  *
- * @package VIPCS\WordPressVIPMinimum
- *
  * @covers \WordPressVIPMinimum\Sniffs\Classes\DeclarationCompatibilitySniff
  */
 class DeclarationCompatibilityUnitTest extends AbstractSniffUnitTest {

--- a/WordPressVIPMinimum/Tests/Classes/RestrictedExtendClassesUnitTest.php
+++ b/WordPressVIPMinimum/Tests/Classes/RestrictedExtendClassesUnitTest.php
@@ -12,8 +12,6 @@ use PHP_CodeSniffer\Tests\Standards\AbstractSniffUnitTest;
 /**
  * Unit test class for the RestrictedExtendClasses sniff.
  *
- * @package VIPCS\WordPressVIPMinimum
- *
  * @covers \WordPressVIPMinimum\Sniffs\Classes\RestrictedExtendClassesSniff
  */
 class RestrictedExtendClassesUnitTest extends AbstractSniffUnitTest {

--- a/WordPressVIPMinimum/Tests/Constants/ConstantStringUnitTest.php
+++ b/WordPressVIPMinimum/Tests/Constants/ConstantStringUnitTest.php
@@ -12,8 +12,6 @@ use PHP_CodeSniffer\Tests\Standards\AbstractSniffUnitTest;
 /**
  * Unit test class for the ConstantString sniff.
  *
- * @package VIPCS\WordPressVIPMinimum
- *
  * @covers \WordPressVIPMinimum\Sniffs\Constants\ConstantStringSniff
  */
 class ConstantStringUnitTest extends AbstractSniffUnitTest {

--- a/WordPressVIPMinimum/Tests/Constants/RestrictedConstantsUnitTest.php
+++ b/WordPressVIPMinimum/Tests/Constants/RestrictedConstantsUnitTest.php
@@ -12,8 +12,6 @@ use PHP_CodeSniffer\Tests\Standards\AbstractSniffUnitTest;
 /**
  * Unit test class for the ConstantRestrictions sniff.
  *
- * @package VIPCS\WordPressVIPMinimum
- *
  * @covers \WordPressVIPMinimum\Sniffs\Constants\RestrictedConstantsSniff
  */
 class RestrictedConstantsUnitTest extends AbstractSniffUnitTest {

--- a/WordPressVIPMinimum/Tests/Files/IncludingFileUnitTest.php
+++ b/WordPressVIPMinimum/Tests/Files/IncludingFileUnitTest.php
@@ -11,8 +11,6 @@ use PHP_CodeSniffer\Tests\Standards\AbstractSniffUnitTest;
 /**
  * Unit test class for the IncludingFile sniff.
  *
- * @package VIPCS\WordPressVIPMinimum
- *
  * @covers \WordPressVIPMinimum\Sniffs\Files\IncludingFileSniff
  */
 class IncludingFileUnitTest extends AbstractSniffUnitTest {

--- a/WordPressVIPMinimum/Tests/Files/IncludingNonPHPFileUnitTest.php
+++ b/WordPressVIPMinimum/Tests/Files/IncludingNonPHPFileUnitTest.php
@@ -12,8 +12,6 @@ use PHP_CodeSniffer\Tests\Standards\AbstractSniffUnitTest;
 /**
  * Unit test class for the IncludingNonPHPFile sniff.
  *
- * @package VIPCS\WordPressVIPMinimum
- *
  * @covers \WordPressVIPMinimum\Sniffs\Files\IncludingNonPHPFileSniff
  */
 class IncludingNonPHPFileUnitTest extends AbstractSniffUnitTest {

--- a/WordPressVIPMinimum/Tests/Functions/CheckReturnValueUnitTest.php
+++ b/WordPressVIPMinimum/Tests/Functions/CheckReturnValueUnitTest.php
@@ -12,8 +12,6 @@ use PHP_CodeSniffer\Tests\Standards\AbstractSniffUnitTest;
 /**
  * Unit test class for the CheckReturnValue sniff.
  *
- * @package VIPCS\WordPressVIPMinimum
- *
  * @covers \WordPressVIPMinimum\Sniffs\Functions\CheckReturnValueSniff
  */
 class CheckReturnValueUnitTest extends AbstractSniffUnitTest {

--- a/WordPressVIPMinimum/Tests/Functions/DynamicCallsUnitTest.php
+++ b/WordPressVIPMinimum/Tests/Functions/DynamicCallsUnitTest.php
@@ -12,8 +12,6 @@ use PHP_CodeSniffer\Tests\Standards\AbstractSniffUnitTest;
 /**
  * Unit test class for the DynamicCalls sniff.
  *
- * @package VIPCS\WordPressVIPMinimum
- *
  * @covers \WordPressVIPMinimum\Sniffs\Functions\DynamicCallsSniff
  */
 class DynamicCallsUnitTest extends AbstractSniffUnitTest {

--- a/WordPressVIPMinimum/Tests/Functions/RestrictedFunctionsUnitTest.php
+++ b/WordPressVIPMinimum/Tests/Functions/RestrictedFunctionsUnitTest.php
@@ -12,8 +12,6 @@ use PHP_CodeSniffer\Tests\Standards\AbstractSniffUnitTest;
 /**
  * Unit test class for the RestrictedFunctions sniff.
  *
- * @package VIPCS\WordPressVIPMinimum
- *
  * @covers \WordPressVIPMinimum\Sniffs\Functions\RestrictedFunctionsSniff
  */
 class RestrictedFunctionsUnitTest extends AbstractSniffUnitTest {

--- a/WordPressVIPMinimum/Tests/Functions/StripTagsUnitTest.php
+++ b/WordPressVIPMinimum/Tests/Functions/StripTagsUnitTest.php
@@ -12,8 +12,6 @@ use PHP_CodeSniffer\Tests\Standards\AbstractSniffUnitTest;
 /**
  * Unit test class for the StripTags sniff.
  *
- * @package VIPCS\WordPressVIPMinimum
- *
  * @covers \WordPressVIPMinimum\Sniffs\Functions\StripTagsSniff
  */
 class StripTagsUnitTest extends AbstractSniffUnitTest {

--- a/WordPressVIPMinimum/Tests/Hooks/AlwaysReturnInFilterUnitTest.php
+++ b/WordPressVIPMinimum/Tests/Hooks/AlwaysReturnInFilterUnitTest.php
@@ -13,8 +13,6 @@ use PHP_CodeSniffer\Tests\Standards\AbstractSniffUnitTest;
 /**
  * Unit test class for the Hooks/AlwaysReturn sniff.
  *
- * @package VIPCS\WordPressVIPMinimum
- *
  * @covers \WordPressVIPMinimum\Sniffs\Hooks\AlwaysReturnInFilterSniff
  */
 class AlwaysReturnInFilterUnitTest extends AbstractSniffUnitTest {

--- a/WordPressVIPMinimum/Tests/Hooks/PreGetPostsUnitTest.php
+++ b/WordPressVIPMinimum/Tests/Hooks/PreGetPostsUnitTest.php
@@ -12,8 +12,6 @@ use PHP_CodeSniffer\Tests\Standards\AbstractSniffUnitTest;
 /**
  * Unit test class for the PreGetPosts sniff.
  *
- * @package VIPCS\WordPressVIPMinimum
- *
  * @covers \WordPressVIPMinimum\Sniffs\Hooks\PreGetPostsSniff
  */
 class PreGetPostsUnitTest extends AbstractSniffUnitTest {

--- a/WordPressVIPMinimum/Tests/Hooks/RestrictedHooksUnitTest.php
+++ b/WordPressVIPMinimum/Tests/Hooks/RestrictedHooksUnitTest.php
@@ -11,8 +11,6 @@ use PHP_CodeSniffer\Tests\Standards\AbstractSniffUnitTest;
 /**
  * Unit test class for the Filters/RestrictedHooks sniff.
  *
- * @package VIPCS\WordPressVIPMinimum
- *
  * @since 0.4.0
  *
  * @covers \WordPressVIPMinimum\Sniffs\Hooks\RestrictedHooksSniff

--- a/WordPressVIPMinimum/Tests/JS/DangerouslySetInnerHTMLUnitTest.php
+++ b/WordPressVIPMinimum/Tests/JS/DangerouslySetInnerHTMLUnitTest.php
@@ -12,8 +12,6 @@ use PHP_CodeSniffer\Tests\Standards\AbstractSniffUnitTest;
 /**
  * Unit test class for the HTML String concatenation in JS sniff.
  *
- * @package VIPCS\WordPressVIPMinimum
- *
  * @covers \WordPressVIPMinimum\Sniffs\JS\DangerouslySetInnerHTMLSniff
  */
 class DangerouslySetInnerHTMLUnitTest extends AbstractSniffUnitTest {

--- a/WordPressVIPMinimum/Tests/JS/HTMLExecutingFunctionsUnitTest.php
+++ b/WordPressVIPMinimum/Tests/JS/HTMLExecutingFunctionsUnitTest.php
@@ -12,8 +12,6 @@ use PHP_CodeSniffer\Tests\Standards\AbstractSniffUnitTest;
 /**
  * Unit test class for the HTML executing JS functions sniff.
  *
- * @package VIPCS\WordPressVIPMinimum
- *
  * @covers \WordPressVIPMinimum\Sniffs\JS\HTMLExecutingFunctionsSniff
  */
 class HTMLExecutingFunctionsUnitTest extends AbstractSniffUnitTest {

--- a/WordPressVIPMinimum/Tests/JS/InnerHTMLUnitTest.php
+++ b/WordPressVIPMinimum/Tests/JS/InnerHTMLUnitTest.php
@@ -12,8 +12,6 @@ use PHP_CodeSniffer\Tests\Standards\AbstractSniffUnitTest;
 /**
  * Unit test class for the HTML String concatenation in JS sniff.
  *
- * @package VIPCS\WordPressVIPMinimum
- *
  * @covers \WordPressVIPMinimum\Sniffs\JS\InnerHTMLSniff
  */
 class InnerHTMLUnitTest extends AbstractSniffUnitTest {

--- a/WordPressVIPMinimum/Tests/JS/StringConcatUnitTest.php
+++ b/WordPressVIPMinimum/Tests/JS/StringConcatUnitTest.php
@@ -12,8 +12,6 @@ use PHP_CodeSniffer\Tests\Standards\AbstractSniffUnitTest;
 /**
  * Unit test class for the HTML String concatenation in JS sniff.
  *
- * @package VIPCS\WordPressVIPMinimum
- *
  * @covers \WordPressVIPMinimum\Sniffs\JS\StringConcatSniff
  */
 class StringConcatUnitTest extends AbstractSniffUnitTest {

--- a/WordPressVIPMinimum/Tests/JS/StrippingTagsUnitTest.php
+++ b/WordPressVIPMinimum/Tests/JS/StrippingTagsUnitTest.php
@@ -12,8 +12,6 @@ use PHP_CodeSniffer\Tests\Standards\AbstractSniffUnitTest;
 /**
  * Unit test class for incorrect HTML tags stripping approach in JS sniff.
  *
- * @package VIPCS\WordPressVIPMinimum
- *
  * @covers \WordPressVIPMinimum\Sniffs\JS\StrippingTagsSniff
  */
 class StrippingTagsUnitTest extends AbstractSniffUnitTest {

--- a/WordPressVIPMinimum/Tests/JS/WindowUnitTest.php
+++ b/WordPressVIPMinimum/Tests/JS/WindowUnitTest.php
@@ -12,8 +12,6 @@ use PHP_CodeSniffer\Tests\Standards\AbstractSniffUnitTest;
 /**
  * Unit test class for the HTML String concatenation in JS sniff.
  *
- * @package VIPCS\WordPressVIPMinimum
- *
  * @covers \WordPressVIPMinimum\Sniffs\JS\WindowSniff
  */
 class WindowUnitTest extends AbstractSniffUnitTest {

--- a/WordPressVIPMinimum/Tests/Performance/CacheValueOverrideUnitTest.php
+++ b/WordPressVIPMinimum/Tests/Performance/CacheValueOverrideUnitTest.php
@@ -12,8 +12,6 @@ use PHP_CodeSniffer\Tests\Standards\AbstractSniffUnitTest;
 /**
  * Unit test class for the CacheValueOverride sniff.
  *
- * @package VIPCS\WordPressVIPMinimum
- *
  * @covers \WordPressVIPMinimum\Sniffs\Performance\CacheValueOverrideSniff
  */
 class CacheValueOverrideUnitTest extends AbstractSniffUnitTest {

--- a/WordPressVIPMinimum/Tests/Performance/FetchingRemoteDataUnitTest.php
+++ b/WordPressVIPMinimum/Tests/Performance/FetchingRemoteDataUnitTest.php
@@ -12,8 +12,6 @@ use PHP_CodeSniffer\Tests\Standards\AbstractSniffUnitTest;
 /**
  * Unit test class for the ExitAfterRedirect sniff.
  *
- * @package VIPCS\WordPressVIPMinimum
- *
  * @covers \WordPressVIPMinimum\Sniffs\Performance\FetchingRemoteDataSniff
  */
 class FetchingRemoteDataUnitTest extends AbstractSniffUnitTest {

--- a/WordPressVIPMinimum/Tests/Performance/LowExpiryCacheTimeUnitTest.php
+++ b/WordPressVIPMinimum/Tests/Performance/LowExpiryCacheTimeUnitTest.php
@@ -12,8 +12,6 @@ use PHP_CodeSniffer\Tests\Standards\AbstractSniffUnitTest;
 /**
  * Unit test class for the LowExpiryCacheTime sniff.
  *
- * @package VIPCS\WordPressVIPMinimum
- *
  * @covers \WordPressVIPMinimum\Sniffs\Performance\LowExpiryCacheTimeSniff
  */
 class LowExpiryCacheTimeUnitTest extends AbstractSniffUnitTest {

--- a/WordPressVIPMinimum/Tests/Performance/NoPagingUnitTest.php
+++ b/WordPressVIPMinimum/Tests/Performance/NoPagingUnitTest.php
@@ -12,9 +12,7 @@ use PHP_CodeSniffer\Tests\Standards\AbstractSniffUnitTest;
 /**
  * Unit test class for the NoPaging sniff.
  *
- * @package VIPCS\WordPressVIPMinimum
- *
- * @since   0.5.0
+ * @since 0.5.0
  *
  * @covers \WordPressVIPMinimum\Sniffs\Performance\NoPagingSniff
  */

--- a/WordPressVIPMinimum/Tests/Performance/OrderByRandUnitTest.php
+++ b/WordPressVIPMinimum/Tests/Performance/OrderByRandUnitTest.php
@@ -12,9 +12,7 @@ use PHP_CodeSniffer\Tests\Standards\AbstractSniffUnitTest;
 /**
  * Unit test class for the OrderByRand sniff.
  *
- * @package VIPCS\WordPressVIPMinimum
- *
- * @since   0.5.0
+ * @since 0.5.0
  *
  * @covers \WordPressVIPMinimum\Sniffs\Performance\OrderByRandSniff
  */

--- a/WordPressVIPMinimum/Tests/Performance/RegexpCompareUnitTest.php
+++ b/WordPressVIPMinimum/Tests/Performance/RegexpCompareUnitTest.php
@@ -12,8 +12,6 @@ use PHP_CodeSniffer\Tests\Standards\AbstractSniffUnitTest;
 /**
  * Unit test class for the RegexpCompare sniff.
  *
- * @package VIPCS\WordPressVIPMinimum
- *
  * @covers \WordPressVIPMinimum\Sniffs\Performance\RegexpCompareSniff
  */
 class RegexpCompareUnitTest extends AbstractSniffUnitTest {

--- a/WordPressVIPMinimum/Tests/Performance/RemoteRequestTimeoutUnitTest.php
+++ b/WordPressVIPMinimum/Tests/Performance/RemoteRequestTimeoutUnitTest.php
@@ -12,8 +12,6 @@ use PHP_CodeSniffer\Tests\Standards\AbstractSniffUnitTest;
 /**
  * Unit test class for the RemoteRequestTimeout sniff.
  *
- * @package VIPCS\WordPressVIPMinimum
- *
  * @covers \WordPressVIPMinimum\Sniffs\Performance\RemoteRequestTimeoutSniff
  */
 class RemoteRequestTimeoutUnitTest extends AbstractSniffUnitTest {

--- a/WordPressVIPMinimum/Tests/Performance/TaxonomyMetaInOptionsUnitTest.php
+++ b/WordPressVIPMinimum/Tests/Performance/TaxonomyMetaInOptionsUnitTest.php
@@ -12,8 +12,6 @@ use PHP_CodeSniffer\Tests\Standards\AbstractSniffUnitTest;
 /**
  * Unit test class for the TaxonomyMetaInOptions sniff.
  *
- * @package VIPCS\WordPressVIPMinimum
- *
  * @covers \WordPressVIPMinimum\Sniffs\Performance\TaxonomyMetaInOptionsSniff
  */
 class TaxonomyMetaInOptionsUnitTest extends AbstractSniffUnitTest {

--- a/WordPressVIPMinimum/Tests/Performance/WPQueryParamsUnitTest.php
+++ b/WordPressVIPMinimum/Tests/Performance/WPQueryParamsUnitTest.php
@@ -12,8 +12,6 @@ use PHP_CodeSniffer\Tests\Standards\AbstractSniffUnitTest;
 /**
  * Unit test class for the WP_Query params sniff.
  *
- * @package VIPCS\WordPressVIPMinimum
- *
  * @covers \WordPressVIPMinimum\Sniffs\Performance\WPQueryParamsSniff
  */
 class WPQueryParamsUnitTest extends AbstractSniffUnitTest {

--- a/WordPressVIPMinimum/Tests/Security/EscapingVoidReturnFunctionsUnitTest.php
+++ b/WordPressVIPMinimum/Tests/Security/EscapingVoidReturnFunctionsUnitTest.php
@@ -12,8 +12,6 @@ use PHP_CodeSniffer\Tests\Standards\AbstractSniffUnitTest;
 /**
  * Unit test class for the EscapingVoidReturnFunctions sniff.
  *
- * @package VIPCS\WordPressVIPMinimum
- *
  * @covers \WordPressVIPMinimum\Sniffs\Security\EscapingVoidReturnFunctionsSniff
  */
 class EscapingVoidReturnFunctionsUnitTest extends AbstractSniffUnitTest {

--- a/WordPressVIPMinimum/Tests/Security/ExitAfterRedirectUnitTest.php
+++ b/WordPressVIPMinimum/Tests/Security/ExitAfterRedirectUnitTest.php
@@ -12,8 +12,6 @@ use PHP_CodeSniffer\Tests\Standards\AbstractSniffUnitTest;
 /**
  * Unit test class for the ExitAfterRedirect sniff.
  *
- * @package VIPCS\WordPressVIPMinimum
- *
  * @covers \WordPressVIPMinimum\Sniffs\Security\ExitAfterRedirectSniff
  */
 class ExitAfterRedirectUnitTest extends AbstractSniffUnitTest {

--- a/WordPressVIPMinimum/Tests/Security/MustacheUnitTest.php
+++ b/WordPressVIPMinimum/Tests/Security/MustacheUnitTest.php
@@ -12,8 +12,6 @@ use PHP_CodeSniffer\Tests\Standards\AbstractSniffUnitTest;
 /**
  * Unit test class for the unescaped output in Mustache templating engine.
  *
- * @package VIPCS\WordPressVIPMinimum
- *
  * @covers \WordPressVIPMinimum\Sniffs\Security\MustacheSniff
  */
 class MustacheUnitTest extends AbstractSniffUnitTest {

--- a/WordPressVIPMinimum/Tests/Security/PHPFilterFunctionsUnitTest.php
+++ b/WordPressVIPMinimum/Tests/Security/PHPFilterFunctionsUnitTest.php
@@ -12,8 +12,6 @@ use PHP_CodeSniffer\Tests\Standards\AbstractSniffUnitTest;
 /**
  * Unit test class for the WP_Query params sniff.
  *
- * @package VIPCS\WordPressVIPMinimum
- *
  * @covers \WordPressVIPMinimum\Sniffs\Security\PHPFilterFunctionsSniff
  */
 class PHPFilterFunctionsUnitTest extends AbstractSniffUnitTest {

--- a/WordPressVIPMinimum/Tests/Security/ProperEscapingFunctionUnitTest.php
+++ b/WordPressVIPMinimum/Tests/Security/ProperEscapingFunctionUnitTest.php
@@ -12,8 +12,6 @@ use PHP_CodeSniffer\Tests\Standards\AbstractSniffUnitTest;
 /**
  * Unit test class for the ProperEscapingFunction sniff.
  *
- * @package VIPCS\WordPressVIPMinimum
- *
  * @covers \WordPressVIPMinimum\Sniffs\Security\ProperEscapingFunctionSniff
  */
 class ProperEscapingFunctionUnitTest extends AbstractSniffUnitTest {

--- a/WordPressVIPMinimum/Tests/Security/StaticStrreplaceUnitTest.php
+++ b/WordPressVIPMinimum/Tests/Security/StaticStrreplaceUnitTest.php
@@ -12,8 +12,6 @@ use PHP_CodeSniffer\Tests\Standards\AbstractSniffUnitTest;
 /**
  * Unit test class for the StaticStrreplace sniff.
  *
- * @package VIPCS\WordPressVIPMinimum
- *
  * @covers \WordPressVIPMinimum\Sniffs\Security\StaticStrreplaceSniff
  */
 class StaticStrreplaceUnitTest extends AbstractSniffUnitTest {

--- a/WordPressVIPMinimum/Tests/Security/TwigUnitTest.php
+++ b/WordPressVIPMinimum/Tests/Security/TwigUnitTest.php
@@ -12,8 +12,6 @@ use PHP_CodeSniffer\Tests\Standards\AbstractSniffUnitTest;
 /**
  * Unit test class for the unescaped output in Twig templating engine.
  *
- * @package VIPCS\WordPressVIPMinimum
- *
  * @covers \WordPressVIPMinimum\Sniffs\Security\TwigSniff
  */
 class TwigUnitTest extends AbstractSniffUnitTest {

--- a/WordPressVIPMinimum/Tests/Security/UnderscorejsUnitTest.php
+++ b/WordPressVIPMinimum/Tests/Security/UnderscorejsUnitTest.php
@@ -12,8 +12,6 @@ use PHP_CodeSniffer\Tests\Standards\AbstractSniffUnitTest;
 /**
  * Unit test class for the unescaped output in Underscore.js templating engine.
  *
- * @package VIPCS\WordPressVIPMinimum
- *
  * @covers \WordPressVIPMinimum\Sniffs\Security\UnderscorejsSniff
  */
 class UnderscorejsUnitTest extends AbstractSniffUnitTest {

--- a/WordPressVIPMinimum/Tests/Security/VuejsUnitTest.php
+++ b/WordPressVIPMinimum/Tests/Security/VuejsUnitTest.php
@@ -12,8 +12,6 @@ use PHP_CodeSniffer\Tests\Standards\AbstractSniffUnitTest;
 /**
  * Unit test class for the unescaped output in Vue.js templating engine.
  *
- * @package VIPCS\WordPressVIPMinimum
- *
  * @covers \WordPressVIPMinimum\Sniffs\Security\VuejsSniff
  */
 class VuejsUnitTest extends AbstractSniffUnitTest {

--- a/WordPressVIPMinimum/Tests/UserExperience/AdminBarRemovalUnitTest.php
+++ b/WordPressVIPMinimum/Tests/UserExperience/AdminBarRemovalUnitTest.php
@@ -12,9 +12,7 @@ use PHP_CodeSniffer\Tests\Standards\AbstractSniffUnitTest;
 /**
  * Unit test class for the AdminBarRemoval sniff.
  *
- * @package VIPCS\WordPressVIPMinimum
- *
- * @since   0.5.0
+ * @since 0.5.0
  *
  * @covers \WordPressVIPMinimum\Sniffs\UserExperience\AdminBarRemovalSniff
  */

--- a/WordPressVIPMinimum/Tests/Variables/RestrictedVariablesUnitTest.php
+++ b/WordPressVIPMinimum/Tests/Variables/RestrictedVariablesUnitTest.php
@@ -12,10 +12,8 @@ use PHP_CodeSniffer\Tests\Standards\AbstractSniffUnitTest;
 /**
  * Unit test class for the VIP_RestrictedVariables sniff.
  *
- * @package WPCS\WordPressCodingStandards
- *
- * @since   0.3.0
- * @since   0.13.0 Class name changed: this class is now namespaced.
+ * @since 0.3.0
+ * @since 0.13.0 Class name changed: this class is now namespaced.
  *
  * @covers \WordPressVIPMinimum\Sniffs\Variables\RestrictedVariablesSniff
  */

--- a/WordPressVIPMinimum/Tests/Variables/ServerVariablesUnitTest.php
+++ b/WordPressVIPMinimum/Tests/Variables/ServerVariablesUnitTest.php
@@ -12,8 +12,6 @@ use PHP_CodeSniffer\Tests\Standards\AbstractSniffUnitTest;
 /**
  * Unit test class for the Variable Analysis sniff.
  *
- * @package VIPCS\WordPressVIPMinimum
- *
  * @covers \WordPressVIPMinimum\Sniffs\Variables\ServerVariablesSniff
  */
 class ServerVariablesUnitTest extends AbstractSniffUnitTest {


### PR DESCRIPTION
`@package` tags are an arcane manner to group related files as belonging to one project.

For projects using namespaces, the current recommendation is to only have `@package` tags when they have supplemental information to the namespace.

That is only in a very limited way the case in VIPCS, so I'm proposing to remove the `@package` tags from the VIPCS class docblocks, though leaving them for now in the file docblocks.

At the very least, this removed duplicate information for which there is no reason for the duplication.

Includes cleaning up (normalizing) the tag description alignments in the class docblocks.

:point_right: reviewing with whitespace changes ignored should make it easier to see that the only real change is the removal of the package tags.

Refs:
* https://docs.phpdoc.org/3.0/guide/references/phpdoc/tags/package.html#package
* https://github.com/php-fig/fig-standards/blob/master/proposed/phpdoc-tags.md#59-package