### PR TITLE
Add PHPStan to QA checks

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -8,6 +8,7 @@
 /.gitattributes            export-ignore
 /.gitignore                export-ignore
 /.phpcs.xml.dist           export-ignore
+/phpstan.neon.dist         export-ignore
 /phpunit.xml.dist          export-ignore
 /.github                   export-ignore
 /bin                       export-ignore

--- a/.github/workflows/basics.yml
+++ b/.github/workflows/basics.yml
@@ -76,3 +76,31 @@ jobs:
       # At a later stage the documentation check can be activated.
       - name: Check sniff feature completeness
         run: composer feature-completeness
+
+  phpstan:
+    name: "PHPStan"
+
+    runs-on: "ubuntu-latest"
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v3
+
+      - name: Install PHP
+        uses: shivammathur/setup-php@v2
+        with:
+          php-version: '7.4'
+          coverage: none
+          tools: phpstan
+
+      # Install dependencies and handle caching in one go.
+      # Dependencies need to be installed to make sure the PHPCS and PHPUnit classes are recognized.
+      # @link https://github.com/marketplace/actions/install-composer-dependencies
+      - name: Install Composer dependencies
+        uses: "ramsey/composer-install@v2"
+        with:
+          # Bust the cache at least once a month - output format: YYYY-MM.
+          custom-cache-suffix: $(date -u "+%Y-%m")
+
+      - name: Run PHPStan
+        run: phpstan analyse

--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,4 @@ phpcs.xml
 .phpcs.xml
 phpunit.xml
 phpcs.cache
+phpstan.neon

--- a/phpstan.neon.dist
+++ b/phpstan.neon.dist
@@ -1,0 +1,13 @@
+parameters:
+    #phpVersion: 50400 # Needs to be 70100 or higher... sigh...
+    level: 5
+    paths:
+        - WordPressVIPMinimum
+        - tests
+    bootstrapFiles:
+        - tests/bootstrap.php
+    scanDirectories:
+        - vendor/wp-coding-standards/wpcs/WordPress
+    treatPhpDocTypesAsCertain: false
+
+    ignoreErrors:


### PR DESCRIPTION
PHPStan is a good addition to our QA toolkit and with improvements PHPStan has made over the years is now a viable tool for us to use (previously it would give way too many false positives).

This commit:
* Adds a separate job to the `basics` workflow in GH Actions.
    Notes:
    - I've chosen **not** to add PHPStan to the Composer dependencies for two reasons:
        1. It doesn't allow for installation on PHP < 7.2, which would break/block the `composer install` for our test runs.
        2. It would add dependencies which could conflict/cause problems for our test runs due to those defining token constants too.
    - We could potentially use [Phive](https://phar.io/) to still have a setup which can be used locally, but just running locally from a PHPStan PHAR file should work just fine.
    - For CI, PHPStan will be installed as a PHAR file by `setup-php` now.
        This does carry a risk _if_ PHPStan would make breaking changes or if a new release adds rules for the levels being scanned as, in that case, builds could unexpectedly start failing.
        We could fix the version `setup-php` action installs to the current release `1.10.32`, but that adds an additional maintenance burden of having to keep updating the version as PHPStan releases pretty often.
        So, for now, I've elected to run the risk of random failures. If and when those start happening, we can re-evaluate.
    - The PHP version for the CI run is set to PHP 7.4 to prevent PHPStan throwing some errors/notices related to the outdated PHPUnit version being used.
* Adds a configuration file for PHPStan.
    Notes:
    - PHPStan needs to know about our dependencies (PHPCS et al), so I'm (re-)using the bootstrap file we have for our tests to load the PHPCS autoloader and register the standard with the PHPCS autoloader as we can't add an `autoload` directive to our `composer.json` file as it would cause problems with the PHPCS autoloader.
    - PHPStan flags type checks on properties with a documented type, while - especially for the `public` properties - we cannot always be sure the properties set will be of the correct type. For that reason, I've set `treatPhpDocTypesAsCertain` to `false` (which silences those notices).
* Adds the configuration file to `.gitattributes` and the typical overload file for the configuration file to `.gitignore`.

Refs:
* https://phpstan.org/
* https://phpstan.org/config-reference