### PR TITLE
GH Actions: tweak the way the PHPCS/WPCS versions are set

### DIFF
--- a/.github/workflows/quicktest.yml
+++ b/.github/workflows/quicktest.yml
@@ -27,48 +27,29 @@ jobs:
       matrix:
         include:
           - php: '5.4'
-            phpcs_version: 'dev-master'
-            wpcs_version: '3.0.*'
+            dependencies: 'stable'
           - php: '5.4'
-            phpcs_version: '3.7.2'
-            wpcs_version: '3.0.*'
+            dependencies: 'lowest'
 
           - php: 'latest'
-            phpcs_version: 'dev-master'
-            wpcs_version: '3.0.*'
+            dependencies: 'stable'
           - php: 'latest'
-            phpcs_version: '3.7.2'
-            wpcs_version: '3.0.*'
+            dependencies: 'lowest'
 
-    name: "QTest${{ matrix.phpcs_version == 'dev-master' && ' + Lint' || '' }}: PHP ${{ matrix.php }} - PHPCS ${{ matrix.phpcs_version }}"
+    name: "QTest${{ matrix.dependencies == 'stable' && ' + Lint' || '' }}: PHP ${{ matrix.php }} - PHPCS ${{ matrix.dependencies }}"
 
     steps:
       - name: Checkout code
         uses: actions/checkout@v3
 
-      # On stable PHPCS versions, allow for PHP deprecation notices.
-      # Unit tests don't need to fail on those for stable releases where those issues won't get fixed anymore.
-      - name: Setup ini config
-        id: set_ini
-        run: |
-          if [[ "${{ matrix.phpcs_version }}" != "dev-master" ]]; then
-            echo 'PHP_INI=error_reporting=E_ALL & ~E_DEPRECATED, display_errors=On' >> $GITHUB_OUTPUT
-          else
-            echo 'PHP_INI=error_reporting=-1, display_errors=On' >> $GITHUB_OUTPUT
-          fi
-
       - name: Set up PHP
         uses: shivammathur/setup-php@v2
         with:
           php-version: ${{ matrix.php }}
-          ini-values: ${{ steps.set_ini.outputs.PHP_INI }}
+          # With stable PHPCS dependencies, allow for PHP deprecation notices.
+          # Unit tests shouldn't fail on those for stable releases where those issues won't get fixed anymore.
+          ini-values: error_reporting=E_ALL & ~E_DEPRECATED, display_errors=On
           coverage: none
-
-      - name: 'Composer: set PHPCS version for tests'
-        run: composer require squizlabs/php_codesniffer:"${{ matrix.phpcs_version }}" --no-update --no-scripts --no-interaction
-
-      - name: 'Composer: set WPCS version for tests'
-        run: composer require wp-coding-standards/wpcs:"${{ matrix.wpcs_version }}" --no-update --no-scripts --no-interaction
 
       # Install dependencies and handle caching in one go.
       # @link https://github.com/marketplace/actions/install-composer-dependencies
@@ -88,11 +69,31 @@ jobs:
           composer-options: --ignore-platform-req=php+
           custom-cache-suffix: $(date -u "+%Y-%m")
 
+      - name: "Composer: downgrade PHPCS dependencies for tests (lowest)"
+        if: ${{ matrix.php == '5.4' && matrix.dependencies == 'lowest' }}
+        run: >
+          composer update --prefer-lowest --no-scripts --no-interaction
+          squizlabs/php_codesniffer
+          phpcsstandards/phpcsutils
+          phpcsstandards/phpcsextra
+          sirbrillig/phpcs-variable-analysis
+          wp-coding-standards/wpcs
+
+      - name: "Composer: downgrade PHPCS dependencies for tests (lowest) - with ignore platform"
+        if: ${{ matrix.php == 'latest' && matrix.dependencies == 'lowest' }}
+        run: >
+          composer update --prefer-lowest --no-scripts --no-interaction --ignore-platform-req=php+
+          squizlabs/php_codesniffer
+          phpcsstandards/phpcsutils
+          phpcsstandards/phpcsextra
+          sirbrillig/phpcs-variable-analysis
+          wp-coding-standards/wpcs
+
       - name: Display PHPCS installed standards
         run: ./vendor/bin/phpcs -i
 
       - name: Lint against parse errors
-        if: matrix.phpcs_version == 'dev-master'
+        if: matrix.dependencies == 'stable'
         run: ./bin/php-lint
 
       - name: Run the unit tests

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -62,25 +62,31 @@ jobs:
     strategy:
       # Keys:
       # - php: The PHP versions to test against.
-      # - phpcs_version: The PHPCS versions to test against.
+      # - dependencies: The PHPCS dependencies versions to test against.
       #   IMPORTANT: test runs shouldn't fail because of PHPCS being incompatible with a PHP version.
       #   - PHPCS will run without errors on PHP 5.4 - 7.4 on any supported version.
       #   - PHP 8.0 needs PHPCS 3.5.7+ to run without errors, and we require a higher minimum version.
       #   - PHP 8.1 needs PHPCS 3.6.1+ to run without errors, but works best with 3.7.1+, and we require at least this minimum version.
-      # - The `wpcs_version` key is added to allow additional test builds when multiple WPCS versions
-      #   would be supported. As, at this time, only the latest stable release of WPCS is supported,
-      #   no additional versions are included in the array.
       matrix:
         php: ['5.4', '5.5', '5.6', '7.0', '7.1', '7.2', '7.3', '7.4', '8.0', '8.1', '8.2']
-        phpcs_version: ['3.7.2', 'dev-master']
-        wpcs_version: ['3.0.*']
+        dependencies: ['lowest', 'stable']
 
         include:
-          - php: '8.3'
-            phpcs_version: 'dev-master'
-            wpcs_version: '3.0.*'
+          # Test against dev versions of all dependencies with select PHP versions for early detection of issues.
+          - php: '5.4'
+            dependencies: 'dev'
+          - php: '7.0'
+            dependencies: 'dev'
+          - php: '7.4'
+            dependencies: 'dev'
+          - php: '8.2'
+            dependencies: 'dev'
 
-    name: "Test: PHP ${{ matrix.php }} - PHPCS ${{ matrix.phpcs_version }} - WPCS ${{ matrix.wpcs_version }}"
+          # Test against upcoming PHP version.
+          - php: '8.3'
+            dependencies: 'dev'
+
+    name: "Test: PHP ${{ matrix.php }} - PHPCS ${{ matrix.dependencies }}"
 
     continue-on-error: ${{ matrix.php == '8.3' }}
 
@@ -88,15 +94,15 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@v3
 
-      # On stable PHPCS versions, allow for PHP deprecation notices.
+      # With stable PHPCS dependencies, allow for PHP deprecation notices.
       # Unit tests don't need to fail on those for stable releases where those issues won't get fixed anymore.
       - name: Setup ini config
         id: set_ini
         run: |
-          if [[ "${{ matrix.phpcs_version }}" != "dev-master" ]]; then
-            echo 'PHP_INI=error_reporting=E_ALL & ~E_DEPRECATED' >> $GITHUB_OUTPUT
+          if [[ "${{ matrix.dependencies }}" != "dev" ]]; then
+            echo 'PHP_INI=error_reporting=E_ALL & ~E_DEPRECATED, display_errors=On' >> $GITHUB_OUTPUT
           else
-            echo 'PHP_INI=error_reporting=-1' >> $GITHUB_OUTPUT
+            echo 'PHP_INI=error_reporting=-1, display_errors=On' >> $GITHUB_OUTPUT
           fi
 
       - name: Install PHP
@@ -106,11 +112,15 @@ jobs:
           ini-values: ${{ steps.set_ini.outputs.PHP_INI }}
           coverage: none
 
-      - name: 'Composer: set PHPCS version for tests'
-        run: composer require squizlabs/php_codesniffer:"${{ matrix.phpcs_version }}" --no-update --no-scripts --no-interaction
-
-      - name: 'Composer: set WPCS version for tests'
-        run: composer require wp-coding-standards/wpcs:"${{ matrix.wpcs_version }}" --no-update --no-scripts --no-interaction
+      - name: "Composer: set PHPCS dependencies for tests (dev)"
+        if: ${{ matrix.dependencies == 'dev' }}
+        run: >
+          composer require --no-update --no-scripts --no-interaction
+          squizlabs/php_codesniffer:"dev-master"
+          phpcsstandards/phpcsutils:"dev-develop"
+          phpcsstandards/phpcsextra:"dev-develop"
+          sirbrillig/phpcs-variable-analysis:"2.x"
+          wp-coding-standards/wpcs:"dev-develop"
 
       # Install dependencies and handle caching in one go.
       # @link https://github.com/marketplace/actions/install-composer-dependencies
@@ -129,6 +139,26 @@ jobs:
         with:
           composer-options: --ignore-platform-req=php+
           custom-cache-suffix: $(date -u "+%Y-%m")
+
+      - name: "Composer: downgrade PHPCS dependencies for tests (lowest)"
+        if: ${{ ! startsWith( matrix.php, '8' ) && matrix.dependencies == 'lowest' }}
+        run: >
+          composer update --prefer-lowest --no-scripts --no-interaction
+          squizlabs/php_codesniffer
+          phpcsstandards/phpcsutils
+          phpcsstandards/phpcsextra
+          sirbrillig/phpcs-variable-analysis
+          wp-coding-standards/wpcs
+
+      - name: "Composer: downgrade PHPCS dependencies for tests (lowest) - with ignore platform"
+        if: ${{ startsWith( matrix.php, '8' ) && matrix.dependencies == 'lowest' }}
+        run: >
+          composer update --prefer-lowest --no-scripts --no-interaction --ignore-platform-req=php+
+          squizlabs/php_codesniffer
+          phpcsstandards/phpcsutils
+          phpcsstandards/phpcsextra
+          sirbrillig/phpcs-variable-analysis
+          wp-coding-standards/wpcs
 
       - name: Run the unit tests
         run: ./bin/unit-tests


### PR DESCRIPTION
VIPCS now doesn't just have PHPCS and WPCS as dependencies for the sniffs and ruleset tests, but also PHPCSUtils, PHPCSExtra and VariableAnalysis and for those last three, the different versions which may be supported are not (yet) taken into account.

Now, it could be argued that every single combination of the different versions of each of these dependencies should be tested, but that would make the matrix _huge_ to little added benefit.

So, instead I'm proposing a slightly different strategy, which should still allow us to verify that things work correctly with enough confidence, while making the workflow maintenance less involved.

The change I'm proposed in this commit takes advantage of the Composer `--prefer-lowest` option to achieve this.

It basically sets the matrix up to test against a combination of all CS dependencies on their lowest supported version + on their stable/highest supported version.

While at this time, the lowest and the stable versions are the same, this will not always be the case, so having the matrix set up this way allows for new releases of these CS dependencies automatically.

In the original setup, the highest/stable version combi wasn't tested. Instead a combi using the `dev` version of the dependencies was used. To me, it makes sense to test against the `dev` versions as well, but I don't believe this needs to be done for the whole range of supported PHP versions. To that end, I've set up four extra jobs against select high/low PHP versions in the `test` workflow to test against a combination of all CS dependencies on their latest `dev` version.

Note: I have not added the setup for testing against `dev` versions to the `quicktest` workflow.

Also note that the workflows currently contain a toggle for installing the `lowest` versions with/without ignoring platform requirement. This toggle is needed for PHP 8.x due to the max supported PHPUnit version being PHPUnit 7.x. This toggle can be removed once upstream PR squizlabs/PHP_CodeSniffer#3803 has been merged.