### PR TITLE
Security/Mustache: prevent false positives on block editor templates

### DIFF
--- a/WordPressVIPMinimum/Sniffs/Security/MustacheSniff.php
+++ b/WordPressVIPMinimum/Sniffs/Security/MustacheSniff.php
@@ -45,7 +45,7 @@ class MustacheSniff extends Sniff {
 	 */
 	public function process_token( $stackPtr ) {
 
-		if ( strpos( $this->tokens[ $stackPtr ]['content'], '{{{' ) !== false || strpos( $this->tokens[ $stackPtr ]['content'], '}}}' ) !== false ) {
+		if ( strpos( $this->tokens[ $stackPtr ]['content'], '{{{' ) !== false && strpos( $this->tokens[ $stackPtr ]['content'], '}}}' ) !== false ) {
 			// Mustache unescaped output notation.
 			$message = 'Found Mustache unescaped output notation: "{{{}}}".';
 			$this->phpcsFile->addWarning( $message, $stackPtr, 'OutputNotation' );

--- a/WordPressVIPMinimum/Tests/Security/MustacheUnitTest.inc
+++ b/WordPressVIPMinimum/Tests/Security/MustacheUnitTest.inc
@@ -18,3 +18,6 @@ echo '<a href="{{href}}">{{&data}}</div></a>'; // NOK: data.
 		return new Handlebars.SafeString(result); // NOK: SafeString.
 	});
 </script>
+
+// Issue 541#issuecomment-1692323177: don't flag GB syntax.
+<div class="wp-block-group"><!-- wp:heading {"textAlign":"center","style":{"spacing":{"margin":{"top":"0","right":"0","bottom":"var:preset|spacing|medium","left":"0"}}}} --><!-- OK. -->


### PR DESCRIPTION
As reported in [541#issuecomment-1692323177](https://github.com/Automattic/VIP-Coding-Standards/issues/541#issuecomment-1692323177).

This commit fixes the issue + adds a test to safeguard the fix.