### PR TITLE
Issue template: mention PHPCSExtra

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -47,6 +47,7 @@ Use `php -v` and `composer show` to get versions.
 | PHPCSUtils version       | x.y.z
 | VIPCS version            | x.y.z
 | WordPressCS version      | x.y.z
+| PHPCSExtra version       | x.y.z
 | VariableAnalysis version | x.y.z
 
 ## Additional Context (optional)


### PR DESCRIPTION
Noticed this while having a quick look through the release PR. As this is not a file which is included in the release (`export-ignore`d via `.gitattributes`), I'm pulling this to `develop`.