### PR TITLE
Classes/DeclarationCompatibility: sync with WP Core

### DIFF
--- a/WordPressVIPMinimum/Sniffs/Classes/DeclarationCompatibilitySniff.php
+++ b/WordPressVIPMinimum/Sniffs/Classes/DeclarationCompatibilitySniff.php
@@ -40,7 +40,7 @@ class DeclarationCompatibilitySniff extends AbstractScopeSniff {
 				'widget_options'  => [
 					'default' => 'array()',
 				],
-				'constol_options' => [
+				'control_options' => [
 					'default' => 'array()',
 				],
 			],
@@ -103,7 +103,7 @@ class DeclarationCompatibilitySniff extends AbstractScopeSniff {
 				'output'            => [
 					'pass_by_reference' => true,
 				],
-				'object',
+				'data_object',
 				'depth'             => [
 					'default' => '0',
 				],
@@ -118,7 +118,7 @@ class DeclarationCompatibilitySniff extends AbstractScopeSniff {
 				'output' => [
 					'pass_by_reference' => true,
 				],
-				'object',
+				'data_object',
 				'depth'  => [
 					'default' => '0',
 				],
@@ -158,7 +158,7 @@ class DeclarationCompatibilitySniff extends AbstractScopeSniff {
 				'elements',
 			],
 			'unset_children'              => [
-				'el',
+				'element',
 				'children_elements' => [
 					'pass_by_reference' => true,
 				],
@@ -215,7 +215,7 @@ class DeclarationCompatibilitySniff extends AbstractScopeSniff {
 			return;
 		}
 
-		// Meed to define the originalParentClassName since we might override the parentClassName due to signature notations grouping.
+		// Need to define the originalParentClassName since we might override the parentClassName due to signature notations grouping.
 		$originalParentClassName = $parentClassName;
 
 		if ( array_key_exists( $parentClassName, $this->checkClasses ) === false ) {

--- a/WordPressVIPMinimum/Tests/Classes/DeclarationCompatibilityUnitTest.inc
+++ b/WordPressVIPMinimum/Tests/Classes/DeclarationCompatibilityUnitTest.inc
@@ -125,15 +125,21 @@ class MyWalker extends Walker {
 	function display_element( $element, &$children_elements, $max_depth, $depth, $args, &$output ) {
 	} // Ok.
 
-	function unset_children( $el, $children_elements ) {
+	function unset_children( $element, $children_elements ) {
 	} // Bad. $children_elements should be passed by reference
-	
+
 	function walk( $elements, $max_depth, ...$args ) {
 	} // Ok.
-	
+
 	function paged_walk( $elements, $max_depth, $page_num, $per_page ) {
 	} // Bad. Missing $args.
 
 	function paged_walk( $elements, $max_depth, $page_num, $per_page, $args ) {
 	} // Bad. $args is not variadic.
+
+	function start_el( $output, $data_object, $depth, $args = array(), $current_object_id = 0 ) {
+	} // Bad. $output should be passed by reference, $depth should have a default value.
+
+	function end_el( &$output, $data_object, $depth = 0, $args = array() ) {
+	} // Ok.
 }

--- a/WordPressVIPMinimum/Tests/Classes/DeclarationCompatibilityUnitTest.php
+++ b/WordPressVIPMinimum/Tests/Classes/DeclarationCompatibilityUnitTest.php
@@ -47,6 +47,7 @@ class DeclarationCompatibilityUnitTest extends AbstractSniffUnitTest {
 			128 => 1,
 			134 => 1,
 			137 => 1,
+			140 => 1,
 		];
 	}
 


### PR DESCRIPTION
While looking at this sniff for something unrelated, I started wondering if the signature definitions were still in line with WP Core.

Turned out they were not, though with the current checks being done in the sniff, this wasn't necessarily problematic (though it should have been, but that's for another PR).

Also see the [additional notes I've added to the review ticket](https://github.com/Automattic/VIP-Coding-Standards/issues/507#issuecomment-1724805522).

Refs:
* https://developer.wordpress.org/reference/classes/wp_widget/wp_widget/
* https://developer.wordpress.org/reference/classes/walker/start_el/
* https://developer.wordpress.org/reference/classes/walker/end_el/
* https://developer.wordpress.org/reference/classes/walker/unset_children/