### PR TITLE
Disable VariableAnalysis for phpcbf to speed up by 20%

### DIFF
--- a/WordPress-VIP-Go/ruleset.xml
+++ b/WordPress-VIP-Go/ruleset.xml
@@ -218,7 +218,7 @@
 		<type>warning</type>
 		<severity>3</severity>
 	</rule>
-	<rule ref="VariableAnalysis.CodeAnalysis.VariableAnalysis.UndefinedVariable">
+	<rule phpcs-only="true" ref="VariableAnalysis.CodeAnalysis.VariableAnalysis.UndefinedVariable">
 		<severity>3</severity>
 	</rule>
 	<rule ref="WordPressVIPMinimum.UserExperience.AdminBarRemoval">
@@ -238,7 +238,7 @@
 	</rule>
 
 	<!-- Silence is golden, these don't affect us on VIP Go -->
-	<rule ref="VariableAnalysis.CodeAnalysis.VariableAnalysis.UnusedVariable">
+	<rule phpcs-only="true" ref="VariableAnalysis.CodeAnalysis.VariableAnalysis.UnusedVariable">
 		<severity>0</severity>
 	</rule>
 

--- a/WordPressVIPMinimum/ruleset.xml
+++ b/WordPressVIPMinimum/ruleset.xml
@@ -178,9 +178,8 @@
 		<message>`%1$s()` performs a no-LIMIT query by default, make sure to set a reasonable `posts_per_page`. `%1$s()` will do a -1 query by default, a maximum of 100 should be used.</message>
 	</rule>
 
-	<!-- Include VariableAnalysis checks -->
-	<rule ref="VariableAnalysis"/>
-	<rule ref="VariableAnalysis.CodeAnalysis.VariableAnalysis">
+	<!-- Include VariableAnalysis checks - not loading this for phpcbf significantly (20%) speeds up phpcbf and there are no auto-fixers for this rule -->
+	<rule phpcs-only="true" ref="VariableAnalysis.CodeAnalysis.VariableAnalysis">
 		<properties>
 			<!-- Do not report on unused variables before require nor usused or undefined variables in file scope. -->
 			<property name="allowUnusedVariablesBeforeRequire" value="true"/>


### PR DESCRIPTION
- Disable VariableAnalysis for phpcbf to speed up by 20%
- Also removes default "ruleset", as there's only one rule which is specifically declared, therefore making the ruleset redundant and causing problems with custom rulesets, that only declare the rule (with phpcs-only="true"), but not the ruleset itself, causing this ruleset to load variable analysis unnecessarily