### PR TITLE
GH Actions: update for the release of PHP 8.3

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -28,10 +28,10 @@ jobs:
 
     strategy:
       matrix:
-        php: ['5.4', 'latest', '8.3']
+        php: ['5.4', 'latest', '8.4']
 
     name: "Lint: PHP ${{ matrix.php }}"
-    continue-on-error: ${{ matrix.php == '8.3' }}
+    continue-on-error: ${{ matrix.php == '8.4' }}
 
     steps:
       - name: Checkout code
@@ -67,8 +67,9 @@ jobs:
       #   - PHPCS will run without errors on PHP 5.4 - 7.4 on any supported version.
       #   - PHP 8.0 needs PHPCS 3.5.7+ to run without errors, and we require a higher minimum version.
       #   - PHP 8.1 needs PHPCS 3.6.1+ to run without errors, but works best with 3.7.1+, and we require at least this minimum version.
+      #   - PHP 8.2 and 8.3 need PHPCS 3.8.0+ to run without errors (though the errors don't affect the tests).
       matrix:
-        php: ['5.4', '5.5', '5.6', '7.0', '7.1', '7.2', '7.3', '7.4', '8.0', '8.1', '8.2']
+        php: ['5.4', '5.5', '5.6', '7.0', '7.1', '7.2', '7.3', '7.4', '8.0', '8.1', '8.2', '8.3']
         dependencies: ['lowest', 'stable']
 
         include:
@@ -79,16 +80,16 @@ jobs:
             dependencies: 'dev'
           - php: '7.4'
             dependencies: 'dev'
-          - php: '8.2'
+          - php: '8.3'
             dependencies: 'dev'
 
           # Test against upcoming PHP version.
-          - php: '8.3'
+          - php: '8.4'
             dependencies: 'dev'
 
     name: "Test: PHP ${{ matrix.php }} - PHPCS ${{ matrix.dependencies }}"
 
-    continue-on-error: ${{ matrix.php == '8.3' }}
+    continue-on-error: ${{ matrix.php == '8.4' }}
 
     steps:
       - name: Checkout code


### PR DESCRIPTION
... which is expected later today.

* Builds against PHP 8.3 are no longer allowed to fail.
* Add _allowed to fail_ build against PHP 8.4.