### PR TITLE
Switch to PHPCSStandards/PHP_CodeSniffer & raise minimum supported version

### DIFF
--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -19,9 +19,9 @@ To determine where best to report the bug, use the first part of the sniff name:
 
 Sniff name starts with | Report to
 --- | ---
-`Generic` | [PHP_CodeSniffer](https://github.com/squizlabs/PHP_CodeSniffer/issues/)
-`PSR2` | [PHP_CodeSniffer](https://github.com/squizlabs/PHP_CodeSniffer/issues/)
-`Squiz` | [PHP_CodeSniffer](https://github.com/squizlabs/PHP_CodeSniffer/issues/)
+`Generic` | [PHP_CodeSniffer](https://github.com/PHPCSStandards/PHP_CodeSniffer/issues/)
+`PSR2` | [PHP_CodeSniffer](https://github.com/PHPCSStandards/PHP_CodeSniffer/issues/)
+`Squiz` | [PHP_CodeSniffer](https://github.com/PHPCSStandards/PHP_CodeSniffer/issues/)
 `Universal` | [PHPCSExtra](https://github.com/PHPCSStandards/PHPCSExtra/issues/)
 `VariableAnalysis` | [VariableAnalysis](https://github.com/sirbrillig/phpcs-variable-analysis/issues/)
 `WordPress` | [WordPressCS](https://github.com/WordPress/WordPress-Coding-Standards/issues/)

--- a/.phpcs.xml.dist
+++ b/.phpcs.xml.dist
@@ -1,5 +1,5 @@
 <?xml version="1.0"?>
-<ruleset xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" name="VIP Coding Standards" xsi:noNamespaceSchemaLocation="https://raw.githubusercontent.com/squizlabs/PHP_CodeSniffer/master/phpcs.xsd">
+<ruleset xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" name="VIP Coding Standards" xsi:noNamespaceSchemaLocation="https://raw.githubusercontent.com/PHPCSStandards/PHP_CodeSniffer/master/phpcs.xsd">
 	<description>The custom ruleset for the VIP Coding Standards itself.</description>
 
 	<file>.</file>

--- a/LICENSE.md
+++ b/LICENSE.md
@@ -64,4 +64,4 @@ Included Files
 This project includes:
 
 - [WordPress-Coding-Standards](https://github.com/WordPress-Coding-Standards/WordPress-Coding-Standards), which is Copyright &copy; 2009 John Godley and contributors. Released under the MIT license https://github.com/WordPress-Coding-Standards/WordPress-Coding-Standards/blob/develop/LICENSE
-- [PHP_CodeSniffer](https://github.com/squizlabs/PHP_CodeSniffer), Copyright &copy; 2012, Squiz Pty Ltd (ABN 77 084 670 600). Released under the following license: https://github.com/squizlabs/PHP_CodeSniffer/blob/master/licence.txt
+- [PHP_CodeSniffer](https://github.com/PHPCSStandards/PHP_CodeSniffer), Copyright &copy; 2012, Squiz Pty Ltd (ABN 77 084 670 600). Released under the following license: https://github.com/PHPCSStandards/PHP_CodeSniffer/blob/master/licence.txt

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # VIP Coding Standards
 
-This project contains [PHP_CodeSniffer (PHPCS) sniffs and rulesets](https://github.com/squizlabs/PHP_CodeSniffer) to validate code developed for [WordPress VIP](https://wpvip.com/).
+This project contains [PHP_CodeSniffer (PHPCS) sniffs and rulesets](https://github.com/PHPCSStandards/PHP_CodeSniffer) to validate code developed for [WordPress VIP](https://wpvip.com/).
 
 This project contains two rulesets:
 
@@ -16,7 +16,7 @@ Go to https://docs.wpvip.com/technical-references/code-review/phpcs-report/ to l
 ## Minimal requirements
 
 * PHP 5.4+
-* [PHPCS 3.7.2+](https://github.com/squizlabs/PHP_CodeSniffer/releases)
+* [PHPCS 3.7.2+](https://github.com/PHPCSStandards/PHP_CodeSniffer/releases)
 * [PHPCSUtils 1.0.8+](https://github.com/PHPCSStandards/PHPCSUtils)
 * [WPCS 3.0.0+](https://github.com/WordPress-Coding-Standards/WordPress-Coding-Standards/releases)
 * [VariableAnalysis 2.11.17+](https://github.com/sirbrillig/phpcs-variable-analysis/releases)

--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ Go to https://docs.wpvip.com/technical-references/code-review/phpcs-report/ to l
 ## Minimal requirements
 
 * PHP 5.4+
-* [PHPCS 3.7.2+](https://github.com/PHPCSStandards/PHP_CodeSniffer/releases)
+* [PHPCS 3.8.0+](https://github.com/PHPCSStandards/PHP_CodeSniffer/releases)
 * [PHPCSUtils 1.0.8+](https://github.com/PHPCSStandards/PHPCSUtils)
 * [WPCS 3.0.0+](https://github.com/WordPress-Coding-Standards/WordPress-Coding-Standards/releases)
 * [VariableAnalysis 2.11.17+](https://github.com/sirbrillig/phpcs-variable-analysis/releases)

--- a/README.md
+++ b/README.md
@@ -17,7 +17,8 @@ Go to https://docs.wpvip.com/technical-references/code-review/phpcs-report/ to l
 
 * PHP 5.4+
 * [PHPCS 3.8.0+](https://github.com/PHPCSStandards/PHP_CodeSniffer/releases)
-* [PHPCSUtils 1.0.8+](https://github.com/PHPCSStandards/PHPCSUtils)
+* [PHPCSUtils 1.0.9+](https://github.com/PHPCSStandards/PHPCSUtils)
+* [PHPCSExtra 1.2.1+](https://github.com/PHPCSStandards/PHPCSExtra)
 * [WPCS 3.0.0+](https://github.com/WordPress-Coding-Standards/WordPress-Coding-Standards/releases)
 * [VariableAnalysis 2.11.17+](https://github.com/sirbrillig/phpcs-variable-analysis/releases)
 

--- a/WordPress-VIP-Go/ruleset.xml
+++ b/WordPress-VIP-Go/ruleset.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0"?>
-<ruleset xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" name="WordPress-VIP-Go" xsi:noNamespaceSchemaLocation="https://raw.githubusercontent.com/squizlabs/PHP_CodeSniffer/master/phpcs.xsd">
+<ruleset xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" name="WordPress-VIP-Go" xsi:noNamespaceSchemaLocation="https://raw.githubusercontent.com/PHPCSStandards/PHP_CodeSniffer/master/phpcs.xsd">
 	<description>WordPress VIP Go Coding Standards</description>
 
 	<!-- The rules below are the changes from between the original sniff or parent ruleset, and what should be applied for this Standard. -->

--- a/WordPressVIPMinimum/ruleset.xml
+++ b/WordPressVIPMinimum/ruleset.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0"?>
-<ruleset xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" name="WordPressVIPMinimum" xsi:noNamespaceSchemaLocation="https://raw.githubusercontent.com/squizlabs/PHP_CodeSniffer/master/phpcs.xsd">
+<ruleset xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" name="WordPressVIPMinimum" xsi:noNamespaceSchemaLocation="https://raw.githubusercontent.com/PHPCSStandards/PHP_CodeSniffer/master/phpcs.xsd">
 	<description>WordPress VIP Minimum Coding Standards</description>
 
 	<!--

--- a/composer.json
+++ b/composer.json
@@ -20,7 +20,7 @@
 		"phpcsstandards/phpcsextra": "^1.1.0",
 		"phpcsstandards/phpcsutils": "^1.0.8",
 		"sirbrillig/phpcs-variable-analysis": "^2.11.17",
-		"squizlabs/php_codesniffer": "^3.7.2",
+		"squizlabs/php_codesniffer": "^3.8.0",
 		"wp-coding-standards/wpcs": "^3.0"
 	},
 	"require-dev": {

--- a/composer.json
+++ b/composer.json
@@ -17,8 +17,8 @@
 	],
 	"require": {
 		"php": ">=5.4",
-		"phpcsstandards/phpcsextra": "^1.1.0",
-		"phpcsstandards/phpcsutils": "^1.0.8",
+		"phpcsstandards/phpcsextra": "^1.2.1",
+		"phpcsstandards/phpcsutils": "^1.0.9",
 		"sirbrillig/phpcs-variable-analysis": "^2.11.17",
 		"squizlabs/php_codesniffer": "^3.8.0",
 		"wp-coding-standards/wpcs": "^3.0"


### PR DESCRIPTION
⚠️  **_This is a DRAFT PR on purpose as it references releases which have not yet been tagged. Once the PHPCS 3.8.0 tag is available ~~(which contains the Composer `replace` directive)~~ and the other dependencies have released, this can/should be merged ~~and released ASAP~~._** ⚠️ 

---

### Switch to PHPCSStandards/PHP_CodeSniffer

The Squizlabs repo has been abandoned. The project continues in a fork in the PHPCSStandards organisation.

Ref:
* squizlabs/PHP_CodeSniffer#3932

### Composer: raise the minimum supported PHPCS version to 3.8.0

... for improved PHP 8.2 support.

~~... to prevent end-users from running into trouble with the name change.~~

~~The files in the Composer `vendor/bin` will only be replaced when the `replace...` directive is found and that is only available in the 3.8.0 tag.~~
~~When the files in the Composer `vendor/bin` are not replaced, they will continue to point to the `vendor/squizlabs/php_codesniffer` directory which will no longer exist, leading to fatal "File not found" errors for end-users trying to run PHPCS/PHPCBF.~~

Includes updating references to the PHPCS version whenever relevant throughout the codebase.

### Composer: update various version constraints

... after the tooling has also updated to the PHPCSStandards version of PHPCS.

Refs:
* https://github.com/PHPCSStandards/PHPCSUtils/releases
* https://github.com/PHPCSStandards/PHPCSExtra/releases

### ~~Changelog for the release of version 3.0.1~~

---

Closes #804