### PR TITLE
Docs/install update

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,23 +23,29 @@ Go to https://docs.wpvip.com/technical-references/code-review/phpcs-report/ to l
 
 ## Installation
 
-To install the VIP Coding Standards, run:
-```bash
-composer config allow-plugins.dealerdirect/phpcodesniffer-composer-installer true
-composer require automattic/vipwpcs
-```
-
-or if installing globally:
-```bash
-composer g config allow-plugins.dealerdirect/phpcodesniffer-composer-installer true
-composer g require automattic/vipwpcs
-```
-
-This will install the latest compatible versions of PHPCS, PHPCSUtils, PHPCSExtra, WPCS and VariableAnalysis and register the external standards with PHP_CodeSniffer.
+[Composer](https://getcomposer.org/) will install the latest compatible versions of PHPCS, PHPCSUtils, PHPCSExtra, WPCS and VariableAnalysis and register the external standards with PHP_CodeSniffer.
 
 Please refer to the [installation instructions for installing PHP_CodeSniffer for WordPress.com VIP](https://docs.wpvip.com/how-tos/code-review/php_codesniffer/) for more details.
 
 As of VIPCS version 2.3.0, there is no need to `require` the [PHP_CodeSniffer Standards Composer Installer Plugin](https://github.com/PHPCSStandards/composer-installer) anymore as it is now a requirement of VIPCS itself. Permission to run the plugin will still need to be granted though when using Composer 2.2 or higher.
+
+### Composer Project-based Installation
+
+To install the VIP Coding Standards, run the following from the root of your project:
+
+```bash
+composer config allow-plugins.dealerdirect/phpcodesniffer-composer-installer true
+composer require --dev automattic/vipwpcs
+```
+
+## Composer Global Installation
+
+Alternatively, it can be installed standard globally for use across multiple projects:
+
+```bash
+composer global config allow-plugins.dealerdirect/phpcodesniffer-composer-installer true
+composer global require --dev automattic/vipwpcs
+```
 
 ## Contribution
 

--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ Go to https://docs.wpvip.com/technical-references/code-review/phpcs-report/ to l
 
 [Composer](https://getcomposer.org/) will install the latest compatible versions of PHPCS, PHPCSUtils, PHPCSExtra, WPCS and VariableAnalysis and register the external standards with PHP_CodeSniffer.
 
-Please refer to the [installation instructions for installing PHP_CodeSniffer for WordPress.com VIP](https://docs.wpvip.com/how-tos/code-review/php_codesniffer/) for more details.
+Please refer to the [installation instructions for installing PHP_CodeSniffer for WordPress VIP](https://docs.wpvip.com/how-tos/code-review/php_codesniffer/) for more details.
 
 As of VIPCS version 2.3.0, there is no need to `require` the [PHP_CodeSniffer Standards Composer Installer Plugin](https://github.com/PHPCSStandards/composer-installer) anymore as it is now a requirement of VIPCS itself. Permission to run the plugin will still need to be granted though when using Composer 2.2 or higher.
 

--- a/README.md
+++ b/README.md
@@ -38,7 +38,7 @@ composer config allow-plugins.dealerdirect/phpcodesniffer-composer-installer tru
 composer require --dev automattic/vipwpcs
 ```
 
-## Composer Global Installation
+### Composer Global Installation
 
 Alternatively, it can be installed standard globally for use across multiple projects:
 


### PR DESCRIPTION
*  Include `--dev` in require commands
* Use the full term `global` instead of the shorthand `g`
* Mirror the "Installation" section structure to the structure on WordPress/WordPress-Coding-Standards