### PR TITLE
Tests: allow for PHPUnit 8/9

### DIFF
--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -95,7 +95,7 @@ When you introduce new `public` sniff properties, or your sniff extends a class 
 * WordPress-Coding-Standards
 * PHPCSUtils 1.x
 * PHP_CodeSniffer 3.x
-* PHPUnit 4.x, 5.x, 6.x or 7.x
+* PHPUnit 4.x - 9.x
 
 The VIP Coding Standards use the PHP_CodeSniffer native unit test suite for unit testing the sniffs.
 
@@ -106,7 +106,7 @@ N.B.: If you installed VIPCS using Composer, make sure you used `--prefer-source
 If you already have PHPUnit installed on your system: Congrats, you're all set.
 
 If not, you can navigate to the directory where the `PHP_CodeSniffer` repo is checked out and do `composer install` to install the `dev` dependencies.
-Alternatively, you can [install PHPUnit](https://phpunit.readthedocs.io/en/7.5/installation.html) as a PHAR file.
+Alternatively, you can [install PHPUnit](https://phpunit.readthedocs.io/en/9.6/installation.html) as a PHAR file.
 
 ### Before running the unit tests
 
@@ -146,7 +146,7 @@ The easiest way to do this is to add a `phpunit.xml` file to the root of your VI
 
 Expected output:
 ```
-PHPUnit 7.5.20 by Sebastian Bergmann and contributors.
+PHPUnit 9.6.15 by Sebastian Bergmann and contributors.
 
 ........................................                          40 / 40 (100%)
 

--- a/.github/workflows/basics.yml
+++ b/.github/workflows/basics.yml
@@ -90,7 +90,7 @@ jobs:
       - name: Install PHP
         uses: shivammathur/setup-php@v2
         with:
-          php-version: '7.4'
+          php-version: 'latest'
           coverage: none
           tools: phpstan
 

--- a/.github/workflows/quicktest.yml
+++ b/.github/workflows/quicktest.yml
@@ -53,36 +53,16 @@ jobs:
 
       # Install dependencies and handle caching in one go.
       # @link https://github.com/marketplace/actions/install-php-dependencies-with-composer
-      - name: Install Composer dependencies - normal
-        if: ${{ startsWith( matrix.php, '8' ) == false && matrix.php != 'latest' }}
+      - name: Install Composer dependencies
         uses: "ramsey/composer-install@v2"
         with:
           # Bust the cache at least once a month - output format: YYYY-MM.
           custom-cache-suffix: $(date -u "+%Y-%m")
 
-      # PHPUnit 7.x does not allow for installation on PHP 8, so ignore platform
-      # requirements to get PHPUnit 7.x to install on nightly.
-      - name: Install Composer dependencies - with ignore platform
-        if: ${{ startsWith( matrix.php, '8' ) || matrix.php == 'latest' }}
-        uses: "ramsey/composer-install@v2"
-        with:
-          composer-options: --ignore-platform-req=php+
-          custom-cache-suffix: $(date -u "+%Y-%m")
-
       - name: "Composer: downgrade PHPCS dependencies for tests (lowest)"
-        if: ${{ matrix.php == '5.4' && matrix.dependencies == 'lowest' }}
+        if: ${{ matrix.dependencies == 'lowest' }}
         run: >
           composer update --prefer-lowest --no-scripts --no-interaction
-          squizlabs/php_codesniffer
-          phpcsstandards/phpcsutils
-          phpcsstandards/phpcsextra
-          sirbrillig/phpcs-variable-analysis
-          wp-coding-standards/wpcs
-
-      - name: "Composer: downgrade PHPCS dependencies for tests (lowest) - with ignore platform"
-        if: ${{ matrix.php == 'latest' && matrix.dependencies == 'lowest' }}
-        run: >
-          composer update --prefer-lowest --no-scripts --no-interaction --ignore-platform-req=php+
           squizlabs/php_codesniffer
           phpcsstandards/phpcsutils
           phpcsstandards/phpcsextra

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -125,36 +125,16 @@ jobs:
 
       # Install dependencies and handle caching in one go.
       # @link https://github.com/marketplace/actions/install-php-dependencies-with-composer
-      - name: Install Composer dependencies - normal
-        if: ${{ startsWith( matrix.php, '8' ) == false }}
+      - name: Install Composer dependencies
         uses: "ramsey/composer-install@v2"
         with:
           # Bust the cache at least once a month - output format: YYYY-MM.
           custom-cache-suffix: $(date -u "+%Y-%m")
 
-      # PHPUnit 7.x does not allow for installation on PHP 8, so ignore platform
-      # requirements to get PHPUnit 7.x to install on nightly.
-      - name: Install Composer dependencies - with ignore platform
-        if: ${{ startsWith( matrix.php, '8' ) }}
-        uses: "ramsey/composer-install@v2"
-        with:
-          composer-options: --ignore-platform-req=php+
-          custom-cache-suffix: $(date -u "+%Y-%m")
-
       - name: "Composer: downgrade PHPCS dependencies for tests (lowest)"
-        if: ${{ ! startsWith( matrix.php, '8' ) && matrix.dependencies == 'lowest' }}
+        if: ${{ matrix.dependencies == 'lowest' }}
         run: >
           composer update --prefer-lowest --no-scripts --no-interaction
-          squizlabs/php_codesniffer
-          phpcsstandards/phpcsutils
-          phpcsstandards/phpcsextra
-          sirbrillig/phpcs-variable-analysis
-          wp-coding-standards/wpcs
-
-      - name: "Composer: downgrade PHPCS dependencies for tests (lowest) - with ignore platform"
-        if: ${{ startsWith( matrix.php, '8' ) && matrix.dependencies == 'lowest' }}
-        run: >
-          composer update --prefer-lowest --no-scripts --no-interaction --ignore-platform-req=php+
           squizlabs/php_codesniffer
           phpcsstandards/phpcsutils
           phpcsstandards/phpcsextra

--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,4 @@ phpcs.xml
 phpunit.xml
 phpcs.cache
 phpstan.neon
+.phpunit.result.cache

--- a/bin/unit-tests
+++ b/bin/unit-tests
@@ -16,8 +16,4 @@
 #   ./bin/unit-tests --filter SniffName
 #
 
-if [[ $(php -r 'echo PHP_VERSION_ID;') -ge 80100 ]]; then
-	"$(pwd)/vendor/bin/phpunit" --filter=WordPressVIPMinimum "$(pwd)/vendor/squizlabs/php_codesniffer/tests/AllTests.php" --no-coverage --no-configuration --bootstrap=./tests/bootstrap.php --dont-report-useless-tests $@
-else
-	"$(pwd)/vendor/bin/phpunit" --filter=WordPressVIPMinimum "$(pwd)/vendor/squizlabs/php_codesniffer/tests/AllTests.php" --no-coverage $@
-fi
+"$(pwd)/vendor/bin/phpunit" --filter WordPressVIPMinimum "$(pwd)/vendor/squizlabs/php_codesniffer/tests/AllTests.php" --no-coverage $@

--- a/composer.json
+++ b/composer.json
@@ -28,7 +28,7 @@
 		"php-parallel-lint/php-console-highlighter": "^1.0.0",
 		"phpcompatibility/php-compatibility": "^9",
 		"phpcsstandards/phpcsdevtools": "^1.0",
-		"phpunit/phpunit": "^4 || ^5 || ^6 || ^7"
+		"phpunit/phpunit": "^4 || ^5 || ^6 || ^7 || ^8 || ^9"
 	},
 	"config": {
 		"allow-plugins": {

--- a/phpstan.neon.dist
+++ b/phpstan.neon.dist
@@ -1,5 +1,5 @@
 parameters:
-    #phpVersion: 50400 # Needs to be 70100 or higher... sigh...
+    phpVersion: 70100 # Needs to be 70100 or higher... sigh...
     level: 5
     paths:
         - WordPressVIPMinimum

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -5,6 +5,10 @@
 	backupGlobals="true"
 	bootstrap="./tests/bootstrap.php"
 	beStrictAboutTestsThatDoNotTestAnything="false"
+	convertErrorsToExceptions="true"
+	convertWarningsToExceptions="true"
+	convertNoticesToExceptions="true"
+	convertDeprecationsToExceptions="true"
 	forceCoversAnnotation="true"
 	colors="true"
 	>


### PR DESCRIPTION
Follow up on #805

PHP_CodeSniffer 3.8.0 now allows for running the tests, which are based on the PHPCS native test suite, with PHPUnit 8 and 9.

This commit updates the package to take advantage of that.

Includes:
* Widening the PHPUnit version requirements.
* Adding the PHPUnit 8+ cache file to `.gitignore`.
* Updating the PHPUnit configuration to make sure that PHP deprecations will always show, even when on a high PHPUnit 9.6 version.
* Updating the info in `CONTRIBUTING`.
* Simplifications to the `quicktest` and `test` workflows. Also, the code coverage "high" run can now be run against PHP 8.3.
* Running PHPStan against PHP `latest` (couldn't previously be done due to the old PHPUnit version).
* Updating the `unit-tests` script to remove the PHP version based toggle, which is no longer needed.

Ref:
* PHPCSStandards/PHP_CodeSniffer#59