### PR TITLE
Disable WordPress.Security.EscapeOutput.ExceptionNotEscaped

### DIFF
--- a/WordPress-VIP-Go/ruleset.xml
+++ b/WordPress-VIP-Go/ruleset.xml
@@ -251,5 +251,7 @@
 	<rule ref="WordPress.WP.AlternativeFunctions.file_system_operations_fclose">
 		<severity>0</severity>
 	</rule>
-
+	<rule ref="WordPress.Security.EscapeOutput.ExceptionNotEscaped">
+		<severity>0</severity>
+	</rule>
 </ruleset>


### PR DESCRIPTION
This ruleset is disabled by several teams already, so we should just disable it due to its controversy as we've discussed internally.

For example, this triggers it:
```
throw new InvalidArgumentException( __( 'Bad request.', 'two-factor-provider-webauthn' ) );
```