### PR TITLE
PHPStan: fix the build

### DIFF
--- a/tests/RulesetTest.php
+++ b/tests/RulesetTest.php
@@ -143,7 +143,7 @@ class RulesetTest {
 	 */
 	private function collect_phpcs_result() {
 		$php = '';
-		if ( \PHP_BINARY && in_array( \PHP_SAPI, [ 'cgi-fcgi', 'cli', 'cli-server', 'phpdbg' ], true ) ) {
+		if ( defined( 'PHP_BINARY' ) && in_array( \PHP_SAPI, [ 'cgi-fcgi', 'cli', 'cli-server', 'phpdbg' ], true ) ) {
 			$php = \PHP_BINARY . ' ';
 		}
 


### PR DESCRIPTION
The last few builds (well, the last three months of builds) were failing due to the below PHPStan error:
```
 ------ ---------------------------------
  Line   tests/RulesetTest.php
 ------ ---------------------------------
  146    Left side of && is always true.
 ------ ---------------------------------
```

Fixed now.

Note: the condition could possibly be removed, but I have a feeling I added it for a reason, so I left it in under the guise of "better safe than sorry".