### PR TITLE
Docs: improve consistency and specificity

### DIFF
--- a/WordPressVIPMinimum/Sniffs/AbstractVariableRestrictionsSniff.php
+++ b/WordPressVIPMinimum/Sniffs/AbstractVariableRestrictionsSniff.php
@@ -91,7 +91,7 @@ abstract class AbstractVariableRestrictionsSniff extends Sniff {
 	 *  )
 	 * )
 	 *
-	 * @return array
+	 * @return array<string, array<string, string|array<string>>>
 	 */
 	abstract public function getGroups();
 

--- a/WordPressVIPMinimum/Sniffs/AbstractVariableRestrictionsSniff.php
+++ b/WordPressVIPMinimum/Sniffs/AbstractVariableRestrictionsSniff.php
@@ -58,7 +58,7 @@ abstract class AbstractVariableRestrictionsSniff extends Sniff {
 	/**
 	 * Returns an array of tokens this test wants to listen for.
 	 *
-	 * @return array
+	 * @return array<int|string>
 	 */
 	public function register() {
 		// Retrieve the groups only once and don't set up a listener if there are no groups.

--- a/WordPressVIPMinimum/Sniffs/Classes/DeclarationCompatibilitySniff.php
+++ b/WordPressVIPMinimum/Sniffs/Classes/DeclarationCompatibilitySniff.php
@@ -315,7 +315,7 @@ class DeclarationCompatibilitySniff extends AbstractScopeSniff {
 	 *
 	 * @param array $methodSignature Signature of a method.
 	 *
-	 * @return array
+	 * @return array<string>
 	 */
 	private function generateParamList( $methodSignature ) {
 		$paramList = [];

--- a/WordPressVIPMinimum/Sniffs/Classes/DeclarationCompatibilitySniff.php
+++ b/WordPressVIPMinimum/Sniffs/Classes/DeclarationCompatibilitySniff.php
@@ -27,7 +27,7 @@ class DeclarationCompatibilitySniff extends AbstractScopeSniff {
 	/**
 	 * A list of classes and methods to check.
 	 *
-	 * @var array<string, array<string, array<string, mixed>>>
+	 * @var array<string, array<string, array<int|string, string|array<string, bool|string>>>>
 	 */
 	public $checkClasses = [
 		'WP_Widget' => [

--- a/WordPressVIPMinimum/Sniffs/Classes/RestrictedExtendClassesSniff.php
+++ b/WordPressVIPMinimum/Sniffs/Classes/RestrictedExtendClassesSniff.php
@@ -19,7 +19,7 @@ class RestrictedExtendClassesSniff extends AbstractClassRestrictionsSniff {
 	/**
 	 * Groups of classes to restrict.
 	 *
-	 * @return array
+	 * @return array<string, array<string, string|array<string>>>
 	 */
 	public function getGroups() {
 		return [

--- a/WordPressVIPMinimum/Sniffs/Constants/ConstantStringSniff.php
+++ b/WordPressVIPMinimum/Sniffs/Constants/ConstantStringSniff.php
@@ -20,7 +20,7 @@ class ConstantStringSniff extends Sniff {
 	/**
 	 * Returns an array of tokens this test wants to listen for.
 	 *
-	 * @return array
+	 * @return array<int|string>
 	 */
 	public function register() {
 		return [

--- a/WordPressVIPMinimum/Sniffs/Constants/RestrictedConstantsSniff.php
+++ b/WordPressVIPMinimum/Sniffs/Constants/RestrictedConstantsSniff.php
@@ -19,7 +19,7 @@ class RestrictedConstantsSniff extends Sniff {
 	/**
 	 * List of restricted constant names.
 	 *
-	 * @var array
+	 * @var array<string>
 	 */
 	public $restrictedConstantNames = [
 		'A8C_PROXIED_REQUEST',
@@ -28,7 +28,7 @@ class RestrictedConstantsSniff extends Sniff {
 	/**
 	 * List of restricted constant declarations.
 	 *
-	 * @var array
+	 * @var array<string>
 	 */
 	public $restrictedConstantDeclaration = [
 		'JETPACK_DEV_DEBUG',

--- a/WordPressVIPMinimum/Sniffs/Constants/RestrictedConstantsSniff.php
+++ b/WordPressVIPMinimum/Sniffs/Constants/RestrictedConstantsSniff.php
@@ -38,7 +38,7 @@ class RestrictedConstantsSniff extends Sniff {
 	/**
 	 * Returns an array of tokens this test wants to listen for.
 	 *
-	 * @return array
+	 * @return array<int|string>
 	 */
 	public function register() {
 		return [

--- a/WordPressVIPMinimum/Sniffs/Files/IncludingFileSniff.php
+++ b/WordPressVIPMinimum/Sniffs/Files/IncludingFileSniff.php
@@ -107,7 +107,7 @@ class IncludingFileSniff extends AbstractFunctionRestrictionsSniff {
 	/**
 	 * Returns an array of tokens this test wants to listen for.
 	 *
-	 * @return array
+	 * @return array<int|string>
 	 */
 	public function register() {
 		return Tokens::$includeTokens;

--- a/WordPressVIPMinimum/Sniffs/Files/IncludingFileSniff.php
+++ b/WordPressVIPMinimum/Sniffs/Files/IncludingFileSniff.php
@@ -20,7 +20,7 @@ class IncludingFileSniff extends AbstractFunctionRestrictionsSniff {
 	/**
 	 * List of function used for getting paths.
 	 *
-	 * @var array
+	 * @var array<string>
 	 */
 	public $getPathFunctions = [
 		'dirname',
@@ -55,7 +55,7 @@ class IncludingFileSniff extends AbstractFunctionRestrictionsSniff {
 	/**
 	 * List of restricted constants.
 	 *
-	 * @var array
+	 * @var array<string, string>
 	 */
 	public $restrictedConstants = [
 		'TEMPLATEPATH'   => 'get_template_directory',
@@ -65,7 +65,7 @@ class IncludingFileSniff extends AbstractFunctionRestrictionsSniff {
 	/**
 	 * List of allowed constants.
 	 *
-	 * @var array
+	 * @var array<string>
 	 */
 	public $allowedConstants = [
 		'ABSPATH',
@@ -77,7 +77,7 @@ class IncludingFileSniff extends AbstractFunctionRestrictionsSniff {
 	 * List of keywords allowed for use in custom constants.
 	 * Note: Customizing this property will overwrite current default values.
 	 *
-	 * @var array
+	 * @var array<string>
 	 */
 	public $allowedKeywords = [
 		'PATH',
@@ -87,7 +87,7 @@ class IncludingFileSniff extends AbstractFunctionRestrictionsSniff {
 	/**
 	 * Functions used for modify slashes.
 	 *
-	 * @var array
+	 * @var array<string>
 	 */
 	public $slashingFunctions = [
 		'trailingslashit',

--- a/WordPressVIPMinimum/Sniffs/Files/IncludingNonPHPFileSniff.php
+++ b/WordPressVIPMinimum/Sniffs/Files/IncludingNonPHPFileSniff.php
@@ -23,7 +23,7 @@ class IncludingNonPHPFileSniff extends Sniff {
 	 *
 	 * Files with these extensions are allowed to be `include`d.
 	 *
-	 * @var array Key is the extension, value is irrelevant.
+	 * @var array<string, bool> Key is the extension, value is irrelevant.
 	 */
 	private $php_extensions = [
 		'php'  => true,
@@ -34,7 +34,7 @@ class IncludingNonPHPFileSniff extends Sniff {
 	/**
 	 * File extensions used for SVG and CSS files.
 	 *
-	 * @var array Key is the extension, value is irrelevant.
+	 * @var array<string, bool> Key is the extension, value is irrelevant.
 	 */
 	private $svg_css_extensions = [
 		'css' => true,

--- a/WordPressVIPMinimum/Sniffs/Files/IncludingNonPHPFileSniff.php
+++ b/WordPressVIPMinimum/Sniffs/Files/IncludingNonPHPFileSniff.php
@@ -44,7 +44,7 @@ class IncludingNonPHPFileSniff extends Sniff {
 	/**
 	 * Returns an array of tokens this test wants to listen for.
 	 *
-	 * @return array
+	 * @return array<int|string>
 	 */
 	public function register() {
 		return Tokens::$includeTokens;

--- a/WordPressVIPMinimum/Sniffs/Functions/CheckReturnValueSniff.php
+++ b/WordPressVIPMinimum/Sniffs/Functions/CheckReturnValueSniff.php
@@ -24,7 +24,7 @@ class CheckReturnValueSniff extends Sniff {
 	/**
 	 * Pairs we are about to check.
 	 *
-	 * @var array
+	 * @var array<string, array<string>>
 	 */
 	public $catch = [
 		'esc_url'          => [
@@ -48,7 +48,7 @@ class CheckReturnValueSniff extends Sniff {
 	/**
 	 * Tokens we are about to examine, which are not functions.
 	 *
-	 * @var array
+	 * @var array<string, int|string>
 	 */
 	public $notFunctions = [
 		'foreach' => T_FOREACH,
@@ -293,7 +293,7 @@ class CheckReturnValueSniff extends Sniff {
 	 * Function used as as callback for the array_reduce call.
 	 *
 	 * @param string|null $carry The final string.
-	 * @param mixed       $item  Processed item.
+	 * @param array       $item  Processed item.
 	 *
 	 * @return string
 	 */

--- a/WordPressVIPMinimum/Sniffs/Functions/CheckReturnValueSniff.php
+++ b/WordPressVIPMinimum/Sniffs/Functions/CheckReturnValueSniff.php
@@ -57,7 +57,7 @@ class CheckReturnValueSniff extends Sniff {
 	/**
 	 * Returns the token types that this sniff is interested in.
 	 *
-	 * @return array(int)
+	 * @return array<int|string>
 	 */
 	public function register() {
 		return [ T_STRING ];

--- a/WordPressVIPMinimum/Sniffs/Functions/DynamicCallsSniff.php
+++ b/WordPressVIPMinimum/Sniffs/Functions/DynamicCallsSniff.php
@@ -29,7 +29,7 @@ class DynamicCallsSniff extends Sniff {
 	/**
 	 * Functions that should not be called dynamically.
 	 *
-	 * @var array
+	 * @var array<string, bool>
 	 */
 	private $disallowed_functions = [
 		'assert'           => true,
@@ -48,7 +48,7 @@ class DynamicCallsSniff extends Sniff {
 	 *
 	 * Populated at run-time.
 	 *
-	 * @var array The key is the name of the variable, the value, its assigned value.
+	 * @var array<string, string> The key is the name of the variable, the value, its assigned value.
 	 */
 	private $variables_arr = [];
 

--- a/WordPressVIPMinimum/Sniffs/Functions/DynamicCallsSniff.php
+++ b/WordPressVIPMinimum/Sniffs/Functions/DynamicCallsSniff.php
@@ -62,7 +62,7 @@ class DynamicCallsSniff extends Sniff {
 	/**
 	 * Returns the token types that this sniff is interested in.
 	 *
-	 * @return array(int)
+	 * @return array<int|string>
 	 */
 	public function register() {
 		return [ T_VARIABLE => T_VARIABLE ];

--- a/WordPressVIPMinimum/Sniffs/Functions/RestrictedFunctionsSniff.php
+++ b/WordPressVIPMinimum/Sniffs/Functions/RestrictedFunctionsSniff.php
@@ -18,7 +18,7 @@ class RestrictedFunctionsSniff extends AbstractFunctionRestrictionsSniff {
 	/**
 	 * Groups of functions to restrict.
 	 *
-	 * @return array
+	 * @return array<string, array<string, string|array<string>|array<string, bool>>>
 	 */
 	public function getGroups() {
 

--- a/WordPressVIPMinimum/Sniffs/Functions/StripTagsSniff.php
+++ b/WordPressVIPMinimum/Sniffs/Functions/StripTagsSniff.php
@@ -26,10 +26,7 @@ class StripTagsSniff extends AbstractFunctionParameterSniff {
 	/**
 	 * Functions this sniff is looking for.
 	 *
-	 * @var array The only requirement for this array is that the top level
-	 *            array keys are the names of the functions you're looking for.
-	 *            Other than that, the array can have arbitrary content
-	 *            depending on your needs.
+	 * @var array<string, bool> Key is the function name, value irrelevant.
 	 */
 	protected $target_functions = [
 		'strip_tags' => true,

--- a/WordPressVIPMinimum/Sniffs/Hooks/AlwaysReturnInFilterSniff.php
+++ b/WordPressVIPMinimum/Sniffs/Hooks/AlwaysReturnInFilterSniff.php
@@ -27,7 +27,7 @@ class AlwaysReturnInFilterSniff extends Sniff {
 	/**
 	 * Returns the token types that this sniff is interested in.
 	 *
-	 * @return array(int)
+	 * @return array<int|string>
 	 */
 	public function register() {
 		return [ T_STRING ];

--- a/WordPressVIPMinimum/Sniffs/Hooks/PreGetPostsSniff.php
+++ b/WordPressVIPMinimum/Sniffs/Hooks/PreGetPostsSniff.php
@@ -21,7 +21,7 @@ class PreGetPostsSniff extends Sniff {
 	/**
 	 * Returns the token types that this sniff is interested in.
 	 *
-	 * @return array(int)
+	 * @return array<int|string>
 	 */
 	public function register() {
 		return [ T_STRING ];

--- a/WordPressVIPMinimum/Sniffs/Hooks/RestrictedHooksSniff.php
+++ b/WordPressVIPMinimum/Sniffs/Hooks/RestrictedHooksSniff.php
@@ -26,10 +26,7 @@ class RestrictedHooksSniff extends AbstractFunctionParameterSniff {
 	/**
 	 * Functions this sniff is looking for.
 	 *
-	 * @var array The only requirement for this array is that the top level
-	 *            array keys are the names of the functions you're looking for.
-	 *            Other than that, the array can have arbitrary content
-	 *            depending on your needs.
+	 * @var array<string, bool> Key is the function name, value irrelevant.
 	 */
 	protected $target_functions = [
 		'add_filter' => true,

--- a/WordPressVIPMinimum/Sniffs/Hooks/RestrictedHooksSniff.php
+++ b/WordPressVIPMinimum/Sniffs/Hooks/RestrictedHooksSniff.php
@@ -36,7 +36,7 @@ class RestrictedHooksSniff extends AbstractFunctionParameterSniff {
 	/**
 	 * List of restricted filters by groups.
 	 *
-	 * @var array
+	 * @var array<string, array<string, string|array<string>>>
 	 */
 	private $restricted_hook_groups = [
 		'upload_mimes' => [

--- a/WordPressVIPMinimum/Sniffs/JS/DangerouslySetInnerHTMLSniff.php
+++ b/WordPressVIPMinimum/Sniffs/JS/DangerouslySetInnerHTMLSniff.php
@@ -27,7 +27,7 @@ class DangerouslySetInnerHTMLSniff extends Sniff {
 	/**
 	 * Returns an array of tokens this test wants to listen for.
 	 *
-	 * @return array
+	 * @return array<int|string>
 	 */
 	public function register() {
 		return [

--- a/WordPressVIPMinimum/Sniffs/JS/HTMLExecutingFunctionsSniff.php
+++ b/WordPressVIPMinimum/Sniffs/JS/HTMLExecutingFunctionsSniff.php
@@ -24,7 +24,7 @@ class HTMLExecutingFunctionsSniff extends Sniff {
 	 * Value indicates whether the function's arg is the content to be inserted, or the target where the inserted
 	 * content is to be inserted before/after/replaced. For the latter, the content is in the preceding method's arg.
 	 *
-	 * @var array
+	 * @var array<string, string>
 	 */
 	public $HTMLExecutingFunctions = [
 		'after'        => 'content', // jQuery.

--- a/WordPressVIPMinimum/Sniffs/JS/HTMLExecutingFunctionsSniff.php
+++ b/WordPressVIPMinimum/Sniffs/JS/HTMLExecutingFunctionsSniff.php
@@ -52,7 +52,7 @@ class HTMLExecutingFunctionsSniff extends Sniff {
 	/**
 	 * Returns an array of tokens this test wants to listen for.
 	 *
-	 * @return array
+	 * @return array<int|string>
 	 */
 	public function register() {
 		return [

--- a/WordPressVIPMinimum/Sniffs/JS/InnerHTMLSniff.php
+++ b/WordPressVIPMinimum/Sniffs/JS/InnerHTMLSniff.php
@@ -27,7 +27,7 @@ class InnerHTMLSniff extends Sniff {
 	/**
 	 * Returns an array of tokens this test wants to listen for.
 	 *
-	 * @return array
+	 * @return array<int|string>
 	 */
 	public function register() {
 		return [

--- a/WordPressVIPMinimum/Sniffs/JS/StringConcatSniff.php
+++ b/WordPressVIPMinimum/Sniffs/JS/StringConcatSniff.php
@@ -27,7 +27,7 @@ class StringConcatSniff extends Sniff {
 	/**
 	 * Returns an array of tokens this test wants to listen for.
 	 *
-	 * @return array
+	 * @return array<int|string>
 	 */
 	public function register() {
 		return [

--- a/WordPressVIPMinimum/Sniffs/JS/StringConcatSniff.php
+++ b/WordPressVIPMinimum/Sniffs/JS/StringConcatSniff.php
@@ -63,8 +63,8 @@ class StringConcatSniff extends Sniff {
 	/**
 	 * Consolidated violation.
 	 *
-	 * @param int   $stackPtr The position of the current token in the stack passed in $tokens.
-	 * @param array $data     Replacements for the error message.
+	 * @param int           $stackPtr The position of the current token in the stack passed in $tokens.
+	 * @param array<string> $data     Replacements for the error message.
 	 *
 	 * @return void
 	 */

--- a/WordPressVIPMinimum/Sniffs/JS/StrippingTagsSniff.php
+++ b/WordPressVIPMinimum/Sniffs/JS/StrippingTagsSniff.php
@@ -27,7 +27,7 @@ class StrippingTagsSniff extends Sniff {
 	/**
 	 * Returns an array of tokens this test wants to listen for.
 	 *
-	 * @return array
+	 * @return array<int|string>
 	 */
 	public function register() {
 		return [

--- a/WordPressVIPMinimum/Sniffs/JS/WindowSniff.php
+++ b/WordPressVIPMinimum/Sniffs/JS/WindowSniff.php
@@ -27,7 +27,7 @@ class WindowSniff extends Sniff {
 	/**
 	 * Returns an array of tokens this test wants to listen for.
 	 *
-	 * @return array
+	 * @return array<int|string>
 	 */
 	public function register() {
 		return [

--- a/WordPressVIPMinimum/Sniffs/JS/WindowSniff.php
+++ b/WordPressVIPMinimum/Sniffs/JS/WindowSniff.php
@@ -38,7 +38,7 @@ class WindowSniff extends Sniff {
 	/**
 	 * List of window properties that need to be flagged.
 	 *
-	 * @var array
+	 * @var array<string, bool|array<string, bool>>
 	 */
 	private $windowProperties = [
 		'location' => [

--- a/WordPressVIPMinimum/Sniffs/Performance/CacheValueOverrideSniff.php
+++ b/WordPressVIPMinimum/Sniffs/Performance/CacheValueOverrideSniff.php
@@ -18,7 +18,7 @@ class CacheValueOverrideSniff extends Sniff {
 	/**
 	 * Returns the token types that this sniff is interested in.
 	 *
-	 * @return array(int)
+	 * @return array<int|string>
 	 */
 	public function register() {
 		return [ T_STRING ];

--- a/WordPressVIPMinimum/Sniffs/Performance/FetchingRemoteDataSniff.php
+++ b/WordPressVIPMinimum/Sniffs/Performance/FetchingRemoteDataSniff.php
@@ -19,7 +19,7 @@ class FetchingRemoteDataSniff extends Sniff {
 	/**
 	 * Returns an array of tokens this test wants to listen for.
 	 *
-	 * @return array
+	 * @return array<int|string>
 	 */
 	public function register() {
 		return [ T_STRING ];

--- a/WordPressVIPMinimum/Sniffs/Performance/LowExpiryCacheTimeSniff.php
+++ b/WordPressVIPMinimum/Sniffs/Performance/LowExpiryCacheTimeSniff.php
@@ -41,7 +41,7 @@ class LowExpiryCacheTimeSniff extends AbstractFunctionParameterSniff {
 	/**
 	 * List of WP time constants, see https://codex.wordpress.org/Easier_Expression_of_Time_Constants.
 	 *
-	 * @var array
+	 * @var array<string, int>
 	 */
 	protected $wp_time_constants = [
 		'MINUTE_IN_SECONDS' => 60,

--- a/WordPressVIPMinimum/Sniffs/Performance/LowExpiryCacheTimeSniff.php
+++ b/WordPressVIPMinimum/Sniffs/Performance/LowExpiryCacheTimeSniff.php
@@ -30,10 +30,7 @@ class LowExpiryCacheTimeSniff extends AbstractFunctionParameterSniff {
 	/**
 	 * Functions this sniff is looking for.
 	 *
-	 * @var array The only requirement for this array is that the top level
-	 *            array keys are the names of the functions you're looking for.
-	 *            Other than that, the array can have arbitrary content
-	 *            depending on your needs.
+	 * @var array<string, bool> Key is the function name, value irrelevant.
 	 */
 	protected $target_functions = [
 		'wp_cache_set'     => true,

--- a/WordPressVIPMinimum/Sniffs/Performance/NoPagingSniff.php
+++ b/WordPressVIPMinimum/Sniffs/Performance/NoPagingSniff.php
@@ -23,7 +23,7 @@ class NoPagingSniff extends AbstractArrayAssignmentRestrictionsSniff {
 	/**
 	 * Groups of variables to restrict.
 	 *
-	 * @return array
+	 * @return array<string, array<string, string|array<string>>>
 	 */
 	public function getGroups() {
 		return [

--- a/WordPressVIPMinimum/Sniffs/Performance/OrderByRandSniff.php
+++ b/WordPressVIPMinimum/Sniffs/Performance/OrderByRandSniff.php
@@ -24,7 +24,7 @@ class OrderByRandSniff extends AbstractArrayAssignmentRestrictionsSniff {
 	/**
 	 * Groups of variables to restrict.
 	 *
-	 * @return array
+	 * @return array<string, array<string, string|array<string>>>
 	 */
 	public function getGroups() {
 		return [

--- a/WordPressVIPMinimum/Sniffs/Performance/RegexpCompareSniff.php
+++ b/WordPressVIPMinimum/Sniffs/Performance/RegexpCompareSniff.php
@@ -18,7 +18,7 @@ class RegexpCompareSniff extends AbstractArrayAssignmentRestrictionsSniff {
 	/**
 	 * Groups of variables to restrict.
 	 *
-	 * @return array
+	 * @return array<string, array<string, string|array<string>>>
 	 */
 	public function getGroups() {
 		return [

--- a/WordPressVIPMinimum/Sniffs/Performance/RemoteRequestTimeoutSniff.php
+++ b/WordPressVIPMinimum/Sniffs/Performance/RemoteRequestTimeoutSniff.php
@@ -17,7 +17,7 @@ class RemoteRequestTimeoutSniff extends AbstractArrayAssignmentRestrictionsSniff
 	/**
 	 * Groups of variables to restrict.
 	 *
-	 * @return array
+	 * @return array<string, array<string, string|array<string>>>
 	 */
 	public function getGroups() {
 		return [

--- a/WordPressVIPMinimum/Sniffs/Performance/TaxonomyMetaInOptionsSniff.php
+++ b/WordPressVIPMinimum/Sniffs/Performance/TaxonomyMetaInOptionsSniff.php
@@ -46,7 +46,7 @@ class TaxonomyMetaInOptionsSniff extends Sniff {
 	/**
 	 * Returns an array of tokens this test wants to listen for.
 	 *
-	 * @return array
+	 * @return array<int|string>
 	 */
 	public function register() {
 		return [ T_STRING ];

--- a/WordPressVIPMinimum/Sniffs/Performance/TaxonomyMetaInOptionsSniff.php
+++ b/WordPressVIPMinimum/Sniffs/Performance/TaxonomyMetaInOptionsSniff.php
@@ -19,7 +19,7 @@ class TaxonomyMetaInOptionsSniff extends Sniff {
 	/**
 	 * List of options_ functions
 	 *
-	 * @var array
+	 * @var array<string>
 	 */
 	public $option_functions = [
 		'get_option',
@@ -31,7 +31,7 @@ class TaxonomyMetaInOptionsSniff extends Sniff {
 	/**
 	 * List of possible variable names holding term ID.
 	 *
-	 * @var array
+	 * @var array<string>
 	 */
 	public $taxonomy_term_patterns = [
 		'category_id',

--- a/WordPressVIPMinimum/Sniffs/Performance/WPQueryParamsSniff.php
+++ b/WordPressVIPMinimum/Sniffs/Performance/WPQueryParamsSniff.php
@@ -28,7 +28,7 @@ class WPQueryParamsSniff extends AbstractArrayAssignmentRestrictionsSniff {
 	/**
 	 * Groups of variables to restrict.
 	 *
-	 * @return array
+	 * @return array<string, array<string, string|array<string>>>
 	 */
 	public function getGroups() {
 		return [

--- a/WordPressVIPMinimum/Sniffs/Security/EscapingVoidReturnFunctionsSniff.php
+++ b/WordPressVIPMinimum/Sniffs/Security/EscapingVoidReturnFunctionsSniff.php
@@ -26,7 +26,7 @@ class EscapingVoidReturnFunctionsSniff extends Sniff {
 	/**
 	 * Returns an array of tokens this test wants to listen for.
 	 *
-	 * @return array
+	 * @return array<int|string>
 	 */
 	public function register() {
 		return [

--- a/WordPressVIPMinimum/Sniffs/Security/ExitAfterRedirectSniff.php
+++ b/WordPressVIPMinimum/Sniffs/Security/ExitAfterRedirectSniff.php
@@ -19,7 +19,7 @@ class ExitAfterRedirectSniff extends Sniff {
 	/**
 	 * Returns an array of tokens this test wants to listen for.
 	 *
-	 * @return array
+	 * @return array<int|string>
 	 */
 	public function register() {
 		return [ T_STRING ];

--- a/WordPressVIPMinimum/Sniffs/Security/MustacheSniff.php
+++ b/WordPressVIPMinimum/Sniffs/Security/MustacheSniff.php
@@ -25,7 +25,7 @@ class MustacheSniff extends Sniff {
 	/**
 	 * Returns an array of tokens this test wants to listen for.
 	 *
-	 * @return array
+	 * @return array<int|string>
 	 */
 	public function register() {
 		return [

--- a/WordPressVIPMinimum/Sniffs/Security/PHPFilterFunctionsSniff.php
+++ b/WordPressVIPMinimum/Sniffs/Security/PHPFilterFunctionsSniff.php
@@ -26,10 +26,7 @@ class PHPFilterFunctionsSniff extends AbstractFunctionParameterSniff {
 	/**
 	 * Functions this sniff is looking for.
 	 *
-	 * @var array The only requirement for this array is that the top level
-	 *            array keys are the names of the functions you're looking for.
-	 *            Other than that, the array can have arbitrary content
-	 *            depending on your needs.
+	 * @var array<string, bool> Key is the function name, value irrelevant.
 	 */
 	protected $target_functions = [
 		'filter_var'         => true,

--- a/WordPressVIPMinimum/Sniffs/Security/PHPFilterFunctionsSniff.php
+++ b/WordPressVIPMinimum/Sniffs/Security/PHPFilterFunctionsSniff.php
@@ -38,7 +38,7 @@ class PHPFilterFunctionsSniff extends AbstractFunctionParameterSniff {
 	/**
 	 * List of restricted filter names.
 	 *
-	 * @var array
+	 * @var array<string, bool>
 	 */
 	private $restricted_filters = [
 		'FILTER_DEFAULT'    => true,

--- a/WordPressVIPMinimum/Sniffs/Security/ProperEscapingFunctionSniff.php
+++ b/WordPressVIPMinimum/Sniffs/Security/ProperEscapingFunctionSniff.php
@@ -107,7 +107,7 @@ class ProperEscapingFunctionSniff extends Sniff {
 	/**
 	 * Returns an array of tokens this test wants to listen for.
 	 *
-	 * @return array
+	 * @return array<int|string>
 	 */
 	public function register() {
 		$this->echo_or_concat_tokens += Tokens::$emptyTokens;

--- a/WordPressVIPMinimum/Sniffs/Security/ProperEscapingFunctionSniff.php
+++ b/WordPressVIPMinimum/Sniffs/Security/ProperEscapingFunctionSniff.php
@@ -28,7 +28,7 @@ class ProperEscapingFunctionSniff extends Sniff {
 	/**
 	 * List of escaping functions which are being tested.
 	 *
-	 * @var array
+	 * @var array<string, string>
 	 */
 	protected $escaping_functions = [
 		'esc_url'    => 'url',
@@ -45,7 +45,7 @@ class ProperEscapingFunctionSniff extends Sniff {
 	/**
 	 * List of tokens we can skip.
 	 *
-	 * @var array
+	 * @var array<int|string, int|string>
 	 */
 	private $echo_or_concat_tokens =
 	[
@@ -63,7 +63,7 @@ class ProperEscapingFunctionSniff extends Sniff {
 	 *                   for public methods which extending sniffs may be
 	 *                   relying on.
 	 *
-	 * @var array
+	 * @var array<string>
 	 */
 	private $url_attrs = [
 		'href',
@@ -79,7 +79,7 @@ class ProperEscapingFunctionSniff extends Sniff {
 	 *                   for public methods which extending sniffs may be
 	 *                   relying on.
 	 *
-	 * @var array
+	 * @var array<string>
 	 */
 	private $attr_endings = [
 		'=',

--- a/WordPressVIPMinimum/Sniffs/Security/StaticStrreplaceSniff.php
+++ b/WordPressVIPMinimum/Sniffs/Security/StaticStrreplaceSniff.php
@@ -19,7 +19,7 @@ class StaticStrreplaceSniff extends Sniff {
 	/**
 	 * Returns an array of tokens this test wants to listen for.
 	 *
-	 * @return array
+	 * @return array<int|string>
 	 */
 	public function register() {
 		return [ T_STRING ];

--- a/WordPressVIPMinimum/Sniffs/Security/TwigSniff.php
+++ b/WordPressVIPMinimum/Sniffs/Security/TwigSniff.php
@@ -25,7 +25,7 @@ class TwigSniff extends Sniff {
 	/**
 	 * Returns an array of tokens this test wants to listen for.
 	 *
-	 * @return array
+	 * @return array<int|string>
 	 */
 	public function register() {
 		return [

--- a/WordPressVIPMinimum/Sniffs/Security/UnderscorejsSniff.php
+++ b/WordPressVIPMinimum/Sniffs/Security/UnderscorejsSniff.php
@@ -50,7 +50,7 @@ class UnderscorejsSniff extends Sniff {
 	/**
 	 * Returns an array of tokens this test wants to listen for.
 	 *
-	 * @return array
+	 * @return array<int|string>
 	 */
 	public function register() {
 		$targets   = Tokens::$textStringTokens;

--- a/WordPressVIPMinimum/Sniffs/Security/VuejsSniff.php
+++ b/WordPressVIPMinimum/Sniffs/Security/VuejsSniff.php
@@ -25,7 +25,7 @@ class VuejsSniff extends Sniff {
 	/**
 	 * Returns an array of tokens this test wants to listen for.
 	 *
-	 * @return array
+	 * @return array<int|string>
 	 */
 	public function register() {
 		return [

--- a/WordPressVIPMinimum/Sniffs/UserExperience/AdminBarRemovalSniff.php
+++ b/WordPressVIPMinimum/Sniffs/UserExperience/AdminBarRemovalSniff.php
@@ -48,7 +48,7 @@ class AdminBarRemovalSniff extends AbstractFunctionParameterSniff {
 	/**
 	 * Functions this sniff is looking for.
 	 *
-	 * @var array
+	 * @var array<string, bool> Key is the function name, value irrelevant.
 	 */
 	protected $target_functions = [
 		'show_admin_bar' => true,

--- a/WordPressVIPMinimum/Sniffs/UserExperience/AdminBarRemovalSniff.php
+++ b/WordPressVIPMinimum/Sniffs/UserExperience/AdminBarRemovalSniff.php
@@ -118,7 +118,7 @@ class AdminBarRemovalSniff extends AbstractFunctionParameterSniff {
 	/**
 	 * Returns an array of tokens this test wants to listen for.
 	 *
-	 * @return array
+	 * @return array<int|string>
 	 */
 	public function register() {
 		// Set up all string targets.

--- a/WordPressVIPMinimum/Sniffs/UserExperience/AdminBarRemovalSniff.php
+++ b/WordPressVIPMinimum/Sniffs/UserExperience/AdminBarRemovalSniff.php
@@ -26,7 +26,7 @@ class AdminBarRemovalSniff extends AbstractFunctionParameterSniff {
 	/**
 	 * A list of tokenizers this sniff supports.
 	 *
-	 * @var array
+	 * @var array<string>
 	 */
 	public $supportedTokenizers = [
 		'PHP',
@@ -58,7 +58,7 @@ class AdminBarRemovalSniff extends AbstractFunctionParameterSniff {
 	/**
 	 * CSS properties this sniff is looking for.
 	 *
-	 * @var array
+	 * @var array<string, array<string, string|float>>
 	 */
 	protected $target_css_properties = [
 		'visibility' => [
@@ -78,7 +78,7 @@ class AdminBarRemovalSniff extends AbstractFunctionParameterSniff {
 	/**
 	 * CSS selectors this sniff is looking for.
 	 *
-	 * @var array
+	 * @var array<string>
 	 */
 	protected $target_css_selectors = [
 		'.show-admin-bar',
@@ -90,7 +90,7 @@ class AdminBarRemovalSniff extends AbstractFunctionParameterSniff {
 	 *
 	 * Set from the register() method.
 	 *
-	 * @var array
+	 * @var array<int|string>
 	 */
 	private $string_tokens = [];
 

--- a/WordPressVIPMinimum/Sniffs/Variables/RestrictedVariablesSniff.php
+++ b/WordPressVIPMinimum/Sniffs/Variables/RestrictedVariablesSniff.php
@@ -31,7 +31,7 @@ class RestrictedVariablesSniff extends AbstractVariableRestrictionsSniff {
 	 *  )
 	 * )
 	 *
-	 * @return array
+	 * @return array<string, array<string, string|array<string>>>
 	 */
 	public function getGroups() {
 		return [

--- a/WordPressVIPMinimum/Sniffs/Variables/ServerVariablesSniff.php
+++ b/WordPressVIPMinimum/Sniffs/Variables/ServerVariablesSniff.php
@@ -18,7 +18,7 @@ class ServerVariablesSniff extends Sniff {
 	/**
 	 * List of restricted constant names.
 	 *
-	 * @var array
+	 * @var array<string, array<string, bool>>
 	 */
 	public $restrictedVariables = [
 		'authVariables'           => [

--- a/WordPressVIPMinimum/Sniffs/Variables/ServerVariablesSniff.php
+++ b/WordPressVIPMinimum/Sniffs/Variables/ServerVariablesSniff.php
@@ -35,7 +35,7 @@ class ServerVariablesSniff extends Sniff {
 	/**
 	 * Returns an array of tokens this test wants to listen for.
 	 *
-	 * @return array
+	 * @return array<int|string>
 	 */
 	public function register() {
 		return [

--- a/tests/RulesetTest.php
+++ b/tests/RulesetTest.php
@@ -28,7 +28,7 @@ class RulesetTest {
 	 *
 	 * This is the giant array in the ruleset-test.php files.
 	 *
-	 * @var array
+	 * @var array<string, array<int, int|array<string>>>
 	 */
 	public $expected = [];
 
@@ -82,8 +82,8 @@ class RulesetTest {
 	/**
 	 * Init the object by processing the test file.
 	 *
-	 * @param string $ruleset  Name of the ruleset e.g. WordPressVIPMinimum or WordPress-VIP-Go.
-	 * @param array  $expected The array of expected errors, warnings and messages.
+	 * @param string                                       $ruleset  Name of the ruleset e.g. WordPressVIPMinimum or WordPress-VIP-Go.
+	 * @param array<string, array<int, int|array<string>>> $expected The array of expected errors, warnings and messages.
 	 */
 	public function __construct( $ruleset, $expected = [] ) {
 		$this->ruleset  = $ruleset;


### PR DESCRIPTION
## Context

This Monday, [PHPStan 2.0 will be released](https://phpc.social/@OndrejMirtes/113441109253809720).

I've done some preliminary scans with PHPStan 2.0-dev to check if this would have an impact on this codebase.

Based on that, the changes made in commits https://github.com/Automattic/VIP-Coding-Standards/commit/12154a65de39050aae86dcac126e8a6861742999 and https://github.com/Automattic/VIP-Coding-Standards/commit/b95dde72e15c5493a81c93a4ea4577f28ffdf3d7 are necessary to prevent the CI builds from failing once PHPStan 2.0 comes out.

As I was looking through the doc type declarations anyway, I've enhanced a significant number of other `array` types as well, though there is more to be done still.

## Commits


### Docs: improve consistency and specificity [1]

This fixes up the `@return` type declarations for all `register()` methods.

### Docs: improve consistency and specificity [2]

This fixes up the `@var` type declarations for all `AbstractFunctionParameterSniff::$target_functions` properties.

### Docs: improve consistency and specificity [3]

This fixes up the `@return` type declarations for all `AbstractVariableRestrictionsSniff::getGroups()` methods.

### Docs: improve consistency and specificity [4]

This fixes up the `@return` type declarations for all `AbstractArrayAssignmentRestrictionsSniff::getGroups()` methods.

### DeclarationCompatibility::$checkClasses: improve type specificity

### Docs: improve specificity

Miscellaneous other doc specificity fixes.

Note: this doesn't fix everything throughout the codebase, but is an iteration to improve things nonetheless.