### PR TITLE
Fix RulesetTest

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,4 @@ phpunit.xml
 phpcs.cache
 phpstan.neon
 .phpunit.result.cache
+ruleset-tests-report.json

--- a/tests/RulesetTest.php
+++ b/tests/RulesetTest.php
@@ -147,15 +147,24 @@ class RulesetTest {
 			$php = \PHP_BINARY . ' ';
 		}
 
-		$shell = sprintf(
-			'%1$s%2$s --severity=1 --standard=%3$s --report=json ./%3$s/ruleset-test.inc',
+		$report_file = dirname( __DIR__ ) . '/ruleset-tests-report.json';
+		$shell       = sprintf(
+			'%1$s%2$s --severity=1 --standard=%3$s --report-json=%4$s ./%3$s/ruleset-test.inc',
 			$php, // Current PHP executable if available.
 			$this->phpcs_bin,
-			$this->ruleset
+			$this->ruleset,
+			$report_file
 		);
 
 		// phpcs:ignore WordPress.PHP.DiscouragedPHPFunctions.system_calls_shell_exec -- This is test code, not production.
-		$output = shell_exec( $shell );
+		shell_exec( $shell );
+
+		// phpcs:ignore WordPress.WP.AlternativeFunctions.file_get_contents_file_get_contents -- This code is not run in the context of WP.
+		$output = file_get_contents( $report_file );
+
+		// Delete the report as we no longer need it.
+		// phpcs:ignore WordPress.PHP.NoSilencedErrors.Discouraged,WordPress.WP.AlternativeFunctions.unlink_unlink
+		@unlink( $report_file );
 
 		return json_decode( $output );
 	}


### PR DESCRIPTION
As of PHPCS 3.13.0, PHPCS will show deprecation notices for various features which will be removed in PHPCS 4.0.0.

However, in PHPCS 3.x, PHPCS sends all output to `STDOUT` (this will change in PHPCS 4.x), so if the output of an `exec` command which expects a `json` report is captured, this will now also include the deprecation notices in the output, which means the `json_decode()` command will fail as the captured output is not valid JSON.

This, in turn, is currently causing the Ruleset test runs to fail in CI for the VIPCS repo. The issue is locally reproducable.

This commit fixes this by:
* Changing the `--report=json` in the command being run to `--report-json=[filename]` and storing the JSON output to a file. This way the report file will _only_ contain report output and will not include the deprecation notices (those will still go to `STDOUT`).
* Next, we read the report file to process the JSON report;
* And then delete the report file (and prevent it from being committed via the `.gitignore` file, just in case the file delete would fail at some point).

This solution is PHPCS cross-version compatible as the `--report-json=[filename]` CLI flag has been around for quite a while.

This solution should also improve the stability of the script for potential future changes in PHPCS.