### PR TITLE
PHPCS: silence deprecation notice for CS run

### DIFF
--- a/.phpcs.xml.dist
+++ b/.phpcs.xml.dist
@@ -21,6 +21,7 @@
 		<exclude name="WordPress.NamingConventions.ValidVariableName"/>
 		<exclude name="Universal.Arrays.DisallowShortArraySyntax"/>
 		<exclude name="WordPress.PHP.YodaConditions"/>
+		<exclude name="Generic.Functions.CallTimePassByReference"/>
 	</rule>
 
 	<rule ref="WordPress-Docs"/>


### PR DESCRIPTION
For the code in this repo, various rulesets from the WordPressCS project are used.

One of those ruleset includes a sniff - `Generic.Functions.CallTimePassByReference` - which is (hard) deprecated since PHPCS 3.13.0 and which is kind of redundant anyhow as:
1. The sniff is looking for a syntax which was removed from PHP in PHP 5.4.
2. The PHPCompatibility standard safeguards against re-introduction of the removed PHP syntax anyhow.

This will at some point need addressing in WordPressCS upstream, but for now, we can silence the deprecation notice by excluding the redundant sniff.