### PR TITLE
Composer: bump PHP Parallel Lint

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -24,7 +24,7 @@
 		"wp-coding-standards/wpcs": "^3.1.0"
 	},
 	"require-dev": {
-		"php-parallel-lint/php-parallel-lint": "^1.3.2",
+		"php-parallel-lint/php-parallel-lint": "^1.4.0",
 		"php-parallel-lint/php-console-highlighter": "^1.0.0",
 		"phpcompatibility/php-compatibility": "^9",
 		"phpcsstandards/phpcsdevtools": "^1.0",


### PR DESCRIPTION
Mostly to ensure the version installed will be compatible with all PHP version supported by this tool. (v1.4.0 added support for PHP 8.4)

Ref: https://github.com/php-parallel-lint/PHP-Parallel-Lint/releases/tag/v1.4.0