### PR TITLE
AlwaysReturnInFilterUnitTest: remove PHPCS version toggle

### DIFF
--- a/WordPressVIPMinimum/Tests/Hooks/AlwaysReturnInFilterUnitTest.inc
+++ b/WordPressVIPMinimum/Tests/Hooks/AlwaysReturnInFilterUnitTest.inc
@@ -185,7 +185,7 @@ class tokenizer_bug_test {
 		add_filter( 'tokenizer_bug', [ $this, 'tokenizer_bug' ] );
 	}
 
-	public function tokenizer_bug( $param ): namespace\Foo {} // Ok (tokenizer bug PHPCS < 3.5.7) / Error in PHPCS >= 3.5.7.
+	public function tokenizer_bug( $param ): namespace\Foo {} // Error.
 }
 
 // Intentional parse error. This has to be the last test in the file!

--- a/WordPressVIPMinimum/Tests/Hooks/AlwaysReturnInFilterUnitTest.php
+++ b/WordPressVIPMinimum/Tests/Hooks/AlwaysReturnInFilterUnitTest.php
@@ -7,7 +7,6 @@
 
 namespace WordPressVIPMinimum\Tests\Hooks;
 
-use PHP_CodeSniffer\Config;
 use PHP_CodeSniffer\Tests\Standards\AbstractSniffUnitTest;
 
 /**
@@ -31,7 +30,7 @@ class AlwaysReturnInFilterUnitTest extends AbstractSniffUnitTest {
 			105 => 1,
 			129 => 1,
 			163 => 1,
-			188 => version_compare( Config::VERSION, '3.5.7', '>=' ) ? 1 : 0,
+			188 => 1,
 		];
 	}
 


### PR DESCRIPTION
... which has no longer been needed since support for PHPCS < 3.5.7 was dropped.