### PR TITLE
Hard-deprecate all JS specific sniffs

### DIFF
--- a/WordPress-VIP-Go/ruleset.xml
+++ b/WordPress-VIP-Go/ruleset.xml
@@ -4,7 +4,9 @@
 
 	<!-- The rules below are the changes from between the original sniff or parent ruleset, and what should be applied for this Standard. -->
 	<!-- Include the base VIP Minimum ruleset -->
-	<rule ref="WordPressVIPMinimum"/>
+	<rule ref="WordPressVIPMinimum">
+		<exclude name="WordPressVIPMinimum.JS"/>
+	</rule>
 
 	<!-- Things that may be incompatible with the VIP Go infrastructure and needs a dev to review -->
 	<rule ref="WordPressVIPMinimum.Functions.RestrictedFunctions.file_ops_file_put_contents">

--- a/WordPressVIPMinimum/Sniffs/JS/DangerouslySetInnerHTMLSniff.php
+++ b/WordPressVIPMinimum/Sniffs/JS/DangerouslySetInnerHTMLSniff.php
@@ -7,6 +7,7 @@
 
 namespace WordPressVIPMinimum\Sniffs\JS;
 
+use PHP_CodeSniffer\Sniffs\DeprecatedSniff;
 use PHP_CodeSniffer\Util\Tokens;
 use WordPressVIPMinimum\Sniffs\Sniff;
 
@@ -15,7 +16,7 @@ use WordPressVIPMinimum\Sniffs\Sniff;
  *
  * Looks for instances of React's dangerouslySetInnerHMTL.
  */
-class DangerouslySetInnerHTMLSniff extends Sniff {
+class DangerouslySetInnerHTMLSniff extends Sniff implements DeprecatedSniff {
 
 	/**
 	 * A list of tokenizers this sniff supports.
@@ -66,5 +67,32 @@ class DangerouslySetInnerHTMLSniff extends Sniff {
 		$message = "Any HTML passed to `%s` gets executed. Please make sure it's properly escaped.";
 		$data    = [ $this->tokens[ $stackPtr ]['content'] ];
 		$this->phpcsFile->addError( $message, $stackPtr, 'Found', $data );
+	}
+
+	/**
+	 * Provide the version number in which the sniff was deprecated.
+	 *
+	 * @return string
+	 */
+	public function getDeprecationVersion() {
+		return 'VIP-Coding-Standard v3.1.0';
+	}
+
+	/**
+	 * Provide the version number in which the sniff will be removed.
+	 *
+	 * @return string
+	 */
+	public function getRemovalVersion() {
+		return 'VIP-Coding-Standard v4.0.0';
+	}
+
+	/**
+	 * Provide a custom message to display with the deprecation.
+	 *
+	 * @return string
+	 */
+	public function getDeprecationMessage() {
+		return 'Support for scanning JavaScript files will be removed from PHP_CodeSniffer, so this sniff is no longer viable.';
 	}
 }

--- a/WordPressVIPMinimum/Sniffs/JS/HTMLExecutingFunctionsSniff.php
+++ b/WordPressVIPMinimum/Sniffs/JS/HTMLExecutingFunctionsSniff.php
@@ -7,6 +7,7 @@
 
 namespace WordPressVIPMinimum\Sniffs\JS;
 
+use PHP_CodeSniffer\Sniffs\DeprecatedSniff;
 use PHP_CodeSniffer\Util\Tokens;
 use WordPressVIPMinimum\Sniffs\Sniff;
 
@@ -15,7 +16,7 @@ use WordPressVIPMinimum\Sniffs\Sniff;
  *
  * Flags functions which are executing HTML passed to it.
  */
-class HTMLExecutingFunctionsSniff extends Sniff {
+class HTMLExecutingFunctionsSniff extends Sniff implements DeprecatedSniff {
 
 	/**
 	 * List of HTML executing functions.
@@ -127,5 +128,32 @@ class HTMLExecutingFunctionsSniff extends Sniff {
 				}
 			}
 		}
+	}
+
+	/**
+	 * Provide the version number in which the sniff was deprecated.
+	 *
+	 * @return string
+	 */
+	public function getDeprecationVersion() {
+		return 'VIP-Coding-Standard v3.1.0';
+	}
+
+	/**
+	 * Provide the version number in which the sniff will be removed.
+	 *
+	 * @return string
+	 */
+	public function getRemovalVersion() {
+		return 'VIP-Coding-Standard v4.0.0';
+	}
+
+	/**
+	 * Provide a custom message to display with the deprecation.
+	 *
+	 * @return string
+	 */
+	public function getDeprecationMessage() {
+		return 'Support for scanning JavaScript files will be removed from PHP_CodeSniffer, so this sniff is no longer viable.';
 	}
 }

--- a/WordPressVIPMinimum/Sniffs/JS/InnerHTMLSniff.php
+++ b/WordPressVIPMinimum/Sniffs/JS/InnerHTMLSniff.php
@@ -7,6 +7,7 @@
 
 namespace WordPressVIPMinimum\Sniffs\JS;
 
+use PHP_CodeSniffer\Sniffs\DeprecatedSniff;
 use PHP_CodeSniffer\Util\Tokens;
 use WordPressVIPMinimum\Sniffs\Sniff;
 
@@ -15,7 +16,7 @@ use WordPressVIPMinimum\Sniffs\Sniff;
  *
  * Looks for instances of .innerHMTL.
  */
-class InnerHTMLSniff extends Sniff {
+class InnerHTMLSniff extends Sniff implements DeprecatedSniff {
 
 	/**
 	 * A list of tokenizers this sniff supports.
@@ -80,5 +81,32 @@ class InnerHTMLSniff extends Sniff {
 			$data    = [ $this->tokens[ $stackPtr ]['content'] ];
 			$this->phpcsFile->addWarning( $message, $stackPtr, 'Found', $data );
 		}
+	}
+
+	/**
+	 * Provide the version number in which the sniff was deprecated.
+	 *
+	 * @return string
+	 */
+	public function getDeprecationVersion() {
+		return 'VIP-Coding-Standard v3.1.0';
+	}
+
+	/**
+	 * Provide the version number in which the sniff will be removed.
+	 *
+	 * @return string
+	 */
+	public function getRemovalVersion() {
+		return 'VIP-Coding-Standard v4.0.0';
+	}
+
+	/**
+	 * Provide a custom message to display with the deprecation.
+	 *
+	 * @return string
+	 */
+	public function getDeprecationMessage() {
+		return 'Support for scanning JavaScript files will be removed from PHP_CodeSniffer, so this sniff is no longer viable.';
 	}
 }

--- a/WordPressVIPMinimum/Sniffs/JS/StringConcatSniff.php
+++ b/WordPressVIPMinimum/Sniffs/JS/StringConcatSniff.php
@@ -7,6 +7,7 @@
 
 namespace WordPressVIPMinimum\Sniffs\JS;
 
+use PHP_CodeSniffer\Sniffs\DeprecatedSniff;
 use PHP_CodeSniffer\Util\Tokens;
 use WordPressVIPMinimum\Sniffs\Sniff;
 
@@ -15,7 +16,7 @@ use WordPressVIPMinimum\Sniffs\Sniff;
  *
  * Looks for HTML string concatenation.
  */
-class StringConcatSniff extends Sniff {
+class StringConcatSniff extends Sniff implements DeprecatedSniff {
 
 	/**
 	 * A list of tokenizers this sniff supports.
@@ -71,5 +72,32 @@ class StringConcatSniff extends Sniff {
 	private function addFoundError( $stackPtr, array $data ) {
 		$message = 'HTML string concatenation detected, this is a security risk, use DOM node construction or a templating language instead: %s.';
 		$this->phpcsFile->addError( $message, $stackPtr, 'Found', $data );
+	}
+
+	/**
+	 * Provide the version number in which the sniff was deprecated.
+	 *
+	 * @return string
+	 */
+	public function getDeprecationVersion() {
+		return 'VIP-Coding-Standard v3.1.0';
+	}
+
+	/**
+	 * Provide the version number in which the sniff will be removed.
+	 *
+	 * @return string
+	 */
+	public function getRemovalVersion() {
+		return 'VIP-Coding-Standard v4.0.0';
+	}
+
+	/**
+	 * Provide a custom message to display with the deprecation.
+	 *
+	 * @return string
+	 */
+	public function getDeprecationMessage() {
+		return 'Support for scanning JavaScript files will be removed from PHP_CodeSniffer, so this sniff is no longer viable.';
 	}
 }

--- a/WordPressVIPMinimum/Sniffs/JS/StrippingTagsSniff.php
+++ b/WordPressVIPMinimum/Sniffs/JS/StrippingTagsSniff.php
@@ -7,6 +7,7 @@
 
 namespace WordPressVIPMinimum\Sniffs\JS;
 
+use PHP_CodeSniffer\Sniffs\DeprecatedSniff;
 use PHP_CodeSniffer\Util\Tokens;
 use WordPressVIPMinimum\Sniffs\Sniff;
 
@@ -15,7 +16,7 @@ use WordPressVIPMinimum\Sniffs\Sniff;
  *
  * Looks for incorrect way of stripping tags.
  */
-class StrippingTagsSniff extends Sniff {
+class StrippingTagsSniff extends Sniff implements DeprecatedSniff {
 
 	/**
 	 * A list of tokenizers this sniff supports.
@@ -69,5 +70,32 @@ class StrippingTagsSniff extends Sniff {
 			$message = 'Vulnerable tag stripping approach detected.';
 			$this->phpcsFile->addError( $message, $stackPtr, 'VulnerableTagStripping' );
 		}
+	}
+
+	/**
+	 * Provide the version number in which the sniff was deprecated.
+	 *
+	 * @return string
+	 */
+	public function getDeprecationVersion() {
+		return 'VIP-Coding-Standard v3.1.0';
+	}
+
+	/**
+	 * Provide the version number in which the sniff will be removed.
+	 *
+	 * @return string
+	 */
+	public function getRemovalVersion() {
+		return 'VIP-Coding-Standard v4.0.0';
+	}
+
+	/**
+	 * Provide a custom message to display with the deprecation.
+	 *
+	 * @return string
+	 */
+	public function getDeprecationMessage() {
+		return 'Support for scanning JavaScript files will be removed from PHP_CodeSniffer, so this sniff is no longer viable.';
 	}
 }

--- a/WordPressVIPMinimum/Sniffs/JS/WindowSniff.php
+++ b/WordPressVIPMinimum/Sniffs/JS/WindowSniff.php
@@ -7,6 +7,7 @@
 
 namespace WordPressVIPMinimum\Sniffs\JS;
 
+use PHP_CodeSniffer\Sniffs\DeprecatedSniff;
 use PHP_CodeSniffer\Util\Tokens;
 use WordPressVIPMinimum\Sniffs\Sniff;
 
@@ -15,7 +16,7 @@ use WordPressVIPMinimum\Sniffs\Sniff;
  *
  * Looks for instances of window properties that should be flagged.
  */
-class WindowSniff extends Sniff {
+class WindowSniff extends Sniff implements DeprecatedSniff {
 
 	/**
 	 * A list of tokenizers this sniff supports.
@@ -124,5 +125,32 @@ class WindowSniff extends Sniff {
 
 		$message = 'Data from JS global "%s" may contain user-supplied values and should be sanitized before output to prevent XSS.';
 		$this->phpcsFile->addError( $message, $stackPtr, $nextNextToken, $data );
+	}
+
+	/**
+	 * Provide the version number in which the sniff was deprecated.
+	 *
+	 * @return string
+	 */
+	public function getDeprecationVersion() {
+		return 'VIP-Coding-Standard v3.1.0';
+	}
+
+	/**
+	 * Provide the version number in which the sniff will be removed.
+	 *
+	 * @return string
+	 */
+	public function getRemovalVersion() {
+		return 'VIP-Coding-Standard v4.0.0';
+	}
+
+	/**
+	 * Provide a custom message to display with the deprecation.
+	 *
+	 * @return string
+	 */
+	public function getDeprecationMessage() {
+		return 'Support for scanning JavaScript files will be removed from PHP_CodeSniffer, so this sniff is no longer viable.';
 	}
 }

--- a/WordPressVIPMinimum/ruleset.xml
+++ b/WordPressVIPMinimum/ruleset.xml
@@ -9,7 +9,16 @@
 		 descriptive error message during the loading of the ruleset instead of
 		 a fatal "class not found" error once the sniffs start running.
 	-->
-	<rule ref="PHPCSUtils"/>
+	<rule ref="PHPCSUtils">
+		<!--
+		Exclude all JS specific sniffs. These are deprecated and should no longer be used.
+
+		Note: While this exclusion has nothing to do with PHPCSUtils, exclusions must be placed within a "rule"
+		and as all sniffs from WordPressVIPMinimum are automatically included, we don't have a WordPressVIPMinimum
+		rule in which to place the exclusion, so this will have to do for now.
+		-->
+		<exclude name="WordPressVIPMinimum.JS"/>
+	</rule>
 
 	<rule ref="Generic.PHP.Syntax"/>
 	<rule ref="Generic.PHP.NoSilencedErrors">


### PR DESCRIPTION
Removing these sniffs needs to wait for a new major, as it would be a breaking change, however, in the mean time, we can:
* Exclude the sniffs from both rulesets. This will prevent PHP_CodeSniffer from throwing deprecation notices about these sniffs.
* Deprecate the sniffs themselves, in case users of the VIP-Coding-Standards would be explicitly including any of these sniff from within their own ruleset.

Fixes #836
Related to #442
Related to #552

Issue #442 should be kept open as a reminder to remove these sniffs in VIPCS 4.0.
Issues #267, #376, #393, #411, #524, #525, #526, #527, #528, #650, #686, which are all related to these sniffs, should probably be closed as superseded by the deprecation and the sniffs no longer being used by the VIPCS native rulesets.