### PR TITLE
Fix dangerous use of value of token constants 

### DIFF
--- a/WordPressVIPMinimum/Sniffs/Hooks/AlwaysReturnInFilterSniff.php
+++ b/WordPressVIPMinimum/Sniffs/Hooks/AlwaysReturnInFilterSniff.php
@@ -76,7 +76,7 @@ class AlwaysReturnInFilterSniff extends Sniff {
 			return;
 		}
 
-		if ( $this->tokens[ $callbackPtr ]['code'] === 'PHPCS_T_CLOSURE' ) {
+		if ( $this->tokens[ $callbackPtr ]['code'] === T_CLOSURE ) {
 			$this->processFunctionBody( $callbackPtr );
 		} elseif ( $this->tokens[ $callbackPtr ]['code'] === T_ARRAY
 			|| $this->tokens[ $callbackPtr ]['code'] === T_OPEN_SHORT_ARRAY
@@ -262,7 +262,7 @@ class AlwaysReturnInFilterSniff extends Sniff {
 		}
 
 		// Similar case may be a conditional closure.
-		if ( end( $this->tokens[ $stackPtr ]['conditions'] ) === 'PHPCS_T_CLOSURE' ) {
+		if ( end( $this->tokens[ $stackPtr ]['conditions'] ) === T_CLOSURE ) {
 			return false;
 		}
 

--- a/WordPressVIPMinimum/Sniffs/Hooks/PreGetPostsSniff.php
+++ b/WordPressVIPMinimum/Sniffs/Hooks/PreGetPostsSniff.php
@@ -388,7 +388,7 @@ class PreGetPostsSniff extends Sniff {
 			true
 		);
 
-		if ( ! $next || $this->tokens[ $next ]['type'] !== 'T_OBJECT_OPERATOR' ) {
+		if ( ! $next || $this->tokens[ $next ]['code'] !== T_OBJECT_OPERATOR ) {
 			return false;
 		}
 

--- a/WordPressVIPMinimum/Sniffs/Hooks/PreGetPostsSniff.php
+++ b/WordPressVIPMinimum/Sniffs/Hooks/PreGetPostsSniff.php
@@ -76,7 +76,7 @@ class PreGetPostsSniff extends Sniff {
 			return;
 		}
 
-		if ( $this->tokens[ $callbackPtr ]['code'] === 'PHPCS_T_CLOSURE' ) {
+		if ( $this->tokens[ $callbackPtr ]['code'] === T_CLOSURE ) {
 			$this->processClosure( $callbackPtr );
 		} elseif ( $this->tokens[ $callbackPtr ]['code'] === T_ARRAY
 			|| $this->tokens[ $callbackPtr ]['code'] === T_OPEN_SHORT_ARRAY


### PR DESCRIPTION
### Fix dangerous use of value of token constants 

The value of tokens constants is not guaranteed, so should never be compared against directly.

Either use the token 'code' and compare against the constant (preferred).
Or use the token 'type' and compare against the constant name.
But **_never_** compare against the value of the constant.

Comparing against the 'type' should generally only be needed for tokens which may not exist in older PHPCS/PHP versions.

### Fix unnecessary comparison against token type