### PR TITLE
Security/Twig: sniff improvements

### DIFF
--- a/WordPressVIPMinimum/Sniffs/Security/TwigSniff.php
+++ b/WordPressVIPMinimum/Sniffs/Security/TwigSniff.php
@@ -8,6 +8,7 @@
 
 namespace WordPressVIPMinimum\Sniffs\Security;
 
+use PHP_CodeSniffer\Util\Tokens;
 use WordPressVIPMinimum\Sniffs\Sniff;
 
 /**
@@ -28,11 +29,7 @@ class TwigSniff extends Sniff {
 	 * @return array<int|string>
 	 */
 	public function register() {
-		return [
-			T_CONSTANT_ENCAPSED_STRING,
-			T_INLINE_HTML,
-			T_HEREDOC,
-		];
+		return Tokens::$textStringTokens;
 	}
 
 	/**

--- a/WordPressVIPMinimum/Sniffs/Security/TwigSniff.php
+++ b/WordPressVIPMinimum/Sniffs/Security/TwigSniff.php
@@ -9,6 +9,7 @@
 namespace WordPressVIPMinimum\Sniffs\Security;
 
 use PHP_CodeSniffer\Util\Tokens;
+use PHPCSUtils\Utils\TextStrings;
 use WordPressVIPMinimum\Sniffs\Sniff;
 
 /**
@@ -40,14 +41,21 @@ class TwigSniff extends Sniff {
 	 * @return void
 	 */
 	public function process_token( $stackPtr ) {
+		// Strip any potentially interpolated expressions.
+		$only_text = $this->tokens[ $stackPtr ]['content'];
+		if ( $this->tokens[ $stackPtr ]['code'] === T_DOUBLE_QUOTED_STRING
+			|| $this->tokens[ $stackPtr ]['code'] === T_HEREDOC
+		) {
+			$only_text = TextStrings::stripEmbeds( $only_text );
+		}
 
-		if ( preg_match( '/autoescape\s+false/', $this->tokens[ $stackPtr ]['content'] ) === 1 ) {
+		if ( preg_match( '/autoescape\s+false/', $only_text ) === 1 ) {
 			// Twig autoescape disabled.
 			$message = 'Found Twig autoescape disabling notation.';
 			$this->phpcsFile->addWarning( $message, $stackPtr, 'AutoescapeFalse' );
 		}
 
-		if ( preg_match( '/\|\s*raw/', $this->tokens[ $stackPtr ]['content'] ) === 1 ) {
+		if ( preg_match( '/\|\s*raw/', $only_text ) === 1 ) {
 			// Twig default unescape filter.
 			$message = 'Found Twig default unescape filter: "|raw".';
 			$this->phpcsFile->addWarning( $message, $stackPtr, 'RawFound' );

--- a/WordPressVIPMinimum/Tests/Security/TwigUnitTest.inc
+++ b/WordPressVIPMinimum/Tests/Security/TwigUnitTest.inc
@@ -25,7 +25,7 @@ echo '<script>
 
 echo "<script>
 {% autoescape false %}
-    Everything will be $outputted as is in this block
+    Everything will be $outputted as is in this {${$object->getBlock( SOME_FLAG | raw )}}
 {% endautoescape %}
 
 {% autoescape %}
@@ -49,7 +49,7 @@ EOD;
 echo <<<EOD
 <script>
 {% autoescape false %}
-    Everything will be $outputted as is in this block
+    Everything will be $outputted as is in this {$obj->blocks[SOME_FLAG | raw]->name}
 {% endautoescape %}
 EOD;
 echo <<<"EOD"

--- a/WordPressVIPMinimum/Tests/Security/TwigUnitTest.inc
+++ b/WordPressVIPMinimum/Tests/Security/TwigUnitTest.inc
@@ -10,3 +10,51 @@
     {{ safe_value|raw }}
 {% endautoescape %}
 </script>
+
+<?php
+
+echo '<script>
+{% autoescape false %}
+    Everything will be outputted as is in this block
+{% endautoescape %}
+
+{% autoescape %}
+    {{ safe_value|raw }}
+{% endautoescape %}
+</script>';
+
+echo "<script>
+{% autoescape false %}
+    Everything will be $outputted as is in this block
+{% endautoescape %}
+
+{% autoescape %}
+    {{ safe_value|raw }}
+{% endautoescape %}
+</script>
+";
+
+echo <<<'EOD'
+<script>
+{% autoescape false %}
+    Everything will be outputted as is in this block
+{% endautoescape %}
+
+{% autoescape %}
+    {{ safe_value|raw }}
+{% endautoescape %}
+</script>
+EOD;
+
+echo <<<EOD
+<script>
+{% autoescape false %}
+    Everything will be $outputted as is in this block
+{% endautoescape %}
+EOD;
+echo <<<"EOD"
+{% autoescape %}
+    {{ safe_value|raw }}
+{% endautoescape %}
+</script>
+EOD;

--- a/WordPressVIPMinimum/Tests/Security/TwigUnitTest.php
+++ b/WordPressVIPMinimum/Tests/Security/TwigUnitTest.php
@@ -34,6 +34,14 @@ class TwigUnitTest extends AbstractSniffUnitTest {
 		return [
 			5  => 1,
 			10 => 1,
+			17 => 1,
+			22 => 1,
+			27 => 1,
+			32 => 1,
+			39 => 1,
+			44 => 1,
+			51 => 1,
+			57 => 1,
 		];
 	}
 }


### PR DESCRIPTION
### Security/Twig: sniff for all text string tokens 

As things were, double quoted strings with interpolation and PHP 5.3+ nowdocs were not examined.

Includes ensuring that all tokens which should be examined have tests associated with them.

### Security/Twig: bug fix - prevent false positives on interpolated expressions

Double quoted strings and heredocs may contain interpolated expressions, which could lead to false positives.

Fixed now.

Includes unit tests proving the bug.

Closes #545