### PR TITLE
Security/Mustache: sniff improvements

### DIFF
--- a/WordPressVIPMinimum/Sniffs/Security/MustacheSniff.php
+++ b/WordPressVIPMinimum/Sniffs/Security/MustacheSniff.php
@@ -56,12 +56,19 @@ class MustacheSniff extends Sniff {
 			$this->phpcsFile->addWarning( $message, $stackPtr, 'VariableNotation' );
 		}
 
-		if ( strpos( $this->tokens[ $stackPtr ]['content'], '{{=' ) !== false ) {
+		$start_delimiter_change = strpos( $this->tokens[ $stackPtr ]['content'], '{{=' );
+		if ( $start_delimiter_change !== false ) {
 			// Mustache delimiter change.
-			$new_delimiter = trim( str_replace( [ '{{=', '=}}' ], '', substr( $this->tokens[ $stackPtr ]['content'], 0, strpos( $this->tokens[ $stackPtr ]['content'], '=}}' ) + 3 ) ) );
-			$message       = 'Found Mustache delimiter change notation. New delimiter is: %s.';
-			$data          = [ $new_delimiter ];
-			$this->phpcsFile->addWarning( $message, $stackPtr, 'DelimiterChange', $data );
+			$end_delimiter_change = strpos( $this->tokens[ $stackPtr ]['content'], '=}}' );
+			if ( $end_delimiter_change !== false && $start_delimiter_change < $end_delimiter_change ) {
+				$start_new_delimiter  = $start_delimiter_change + 3;
+				$new_delimiter_length = $end_delimiter_change - ( $start_delimiter_change + 3 );
+				$new_delimiter        = substr( $this->tokens[ $stackPtr ]['content'], $start_new_delimiter, $new_delimiter_length );
+
+				$message = 'Found Mustache delimiter change notation. New delimiter is: %s.';
+				$data    = [ $new_delimiter ];
+				$this->phpcsFile->addWarning( $message, $stackPtr, 'DelimiterChange', $data );
+			}
 		}
 
 		if ( strpos( $this->tokens[ $stackPtr ]['content'], 'SafeString' ) !== false ) {

--- a/WordPressVIPMinimum/Sniffs/Security/MustacheSniff.php
+++ b/WordPressVIPMinimum/Sniffs/Security/MustacheSniff.php
@@ -71,7 +71,7 @@ class MustacheSniff extends Sniff {
 			}
 		}
 
-		if ( strpos( $this->tokens[ $stackPtr ]['content'], 'SafeString' ) !== false ) {
+		if ( strpos( $this->tokens[ $stackPtr ]['content'], '.SafeString' ) !== false ) {
 			// Handlebars.js Handlebars.SafeString does not get escaped.
 			$message = 'Found Handlebars.SafeString call which does not get escaped.';
 			$this->phpcsFile->addWarning( $message, $stackPtr, 'SafeString' );

--- a/WordPressVIPMinimum/Sniffs/Security/MustacheSniff.php
+++ b/WordPressVIPMinimum/Sniffs/Security/MustacheSniff.php
@@ -8,6 +8,7 @@
 
 namespace WordPressVIPMinimum\Sniffs\Security;
 
+use PHP_CodeSniffer\Util\Tokens;
 use WordPressVIPMinimum\Sniffs\Sniff;
 
 /**
@@ -28,12 +29,10 @@ class MustacheSniff extends Sniff {
 	 * @return array<int|string>
 	 */
 	public function register() {
-		return [
-			T_CONSTANT_ENCAPSED_STRING,
-			T_STRING,
-			T_INLINE_HTML,
-			T_HEREDOC,
-		];
+		$targets             = Tokens::$textStringTokens;
+		$targets[ T_STRING ] = T_STRING;
+
+		return $targets;
 	}
 
 	/**

--- a/WordPressVIPMinimum/Tests/Security/MustacheUnitTest.inc
+++ b/WordPressVIPMinimum/Tests/Security/MustacheUnitTest.inc
@@ -49,3 +49,6 @@ $m = '%>=}} {{=<%'; // Incorrect order, not a delimiter change.
 
 // Correctly recognize mid-line delimiter change.
 $m = '{{default_tags}} {{=<% %>=}} <% erb_style_tags %> <%={{ }}=%> {{ default_tags_again }}'; // NOK: delimiter change.
+
+// Prevent false positives on SafeString being a partial name.
+echo 'MySafeString';

--- a/WordPressVIPMinimum/Tests/Security/MustacheUnitTest.inc
+++ b/WordPressVIPMinimum/Tests/Security/MustacheUnitTest.inc
@@ -42,3 +42,10 @@ echo <<<'NOW'
 {{=<% %>=}} <!-- NOK: delimiter change -->
 </script>
 NOW;
+
+// Don't throw false positives on incorrect/incomplete mustache delimiter change.
+$m = '{{=<%'; // Missing end of delimiter change.
+$m = '%>=}} {{=<%'; // Incorrect order, not a delimiter change.
+
+// Correctly recognize mid-line delimiter change.
+$m = '{{default_tags}} {{=<% %>=}} <% erb_style_tags %> <%={{ }}=%> {{ default_tags_again }}'; // NOK: delimiter change.

--- a/WordPressVIPMinimum/Tests/Security/MustacheUnitTest.inc
+++ b/WordPressVIPMinimum/Tests/Security/MustacheUnitTest.inc
@@ -23,11 +23,11 @@ echo '<a href="{{href}}">{{&data}}</div></a>'; // NOK: data.
 <div class="wp-block-group"><!-- wp:heading {"textAlign":"center","style":{"spacing":{"margin":{"top":"0","right":"0","bottom":"var:preset|spacing|medium","left":"0"}}}} --><!-- OK. -->
 
 <?php
-echo "<a href='$href'>{{{data}}}</div></a>"; // NOK: data.
+echo "<a href='${foo->{$baz}}'>{{{data}}}</div></a>"; // NOK: data.
 
 echo <<<HERE
 <script type="text/html" id="tmpl-example">
-<a href="$href">{{{data}}}</div></a><!-- NOK: data. -->
+<a href="${(href)}">{{{data}}}</div></a><!-- NOK: data. -->
 <a href="{{href}}">{{&data}}</div></a><!-- NOK: data. -->
 HERE;
 echo <<<"HERE"

--- a/WordPressVIPMinimum/Tests/Security/MustacheUnitTest.inc
+++ b/WordPressVIPMinimum/Tests/Security/MustacheUnitTest.inc
@@ -21,3 +21,24 @@ echo '<a href="{{href}}">{{&data}}</div></a>'; // NOK: data.
 
 // Issue 541#issuecomment-1692323177: don't flag GB syntax.
 <div class="wp-block-group"><!-- wp:heading {"textAlign":"center","style":{"spacing":{"margin":{"top":"0","right":"0","bottom":"var:preset|spacing|medium","left":"0"}}}} --><!-- OK. -->
+
+<?php
+echo "<a href='$href'>{{{data}}}</div></a>"; // NOK: data.
+
+echo <<<HERE
+<script type="text/html" id="tmpl-example">
+<a href="$href">{{{data}}}</div></a><!-- NOK: data. -->
+<a href="{{href}}">{{&data}}</div></a><!-- NOK: data. -->
+HERE;
+echo <<<"HERE"
+{{=<% %>=}} <!-- NOK: delimiter change -->
+</script>
+HERE;
+
+echo <<<'NOW'
+<script type="text/html" id="tmpl-example">
+<a href="{{href}}">{{{data}}}</div></a><!-- NOK: data. -->
+<a href="{{href}}">{{&data}}</div></a><!-- NOK: data. -->
+{{=<% %>=}} <!-- NOK: delimiter change -->
+</script>
+NOW;

--- a/WordPressVIPMinimum/Tests/Security/MustacheUnitTest.php
+++ b/WordPressVIPMinimum/Tests/Security/MustacheUnitTest.php
@@ -45,6 +45,7 @@ class MustacheUnitTest extends AbstractSniffUnitTest {
 			40 => 1,
 			41 => 1,
 			42 => 1,
+			51 => 1,
 		];
 	}
 }

--- a/WordPressVIPMinimum/Tests/Security/MustacheUnitTest.php
+++ b/WordPressVIPMinimum/Tests/Security/MustacheUnitTest.php
@@ -38,6 +38,13 @@ class MustacheUnitTest extends AbstractSniffUnitTest {
 			7  => 1,
 			8  => 1,
 			18 => 1,
+			26 => 1,
+			30 => 1,
+			31 => 1,
+			34 => 1,
+			40 => 1,
+			41 => 1,
+			42 => 1,
 		];
 	}
 }


### PR DESCRIPTION
### Security/Mustache: sniff for all text string tokens 

As things were, double quoted strings with interpolation and PHP 5.3+ nowdocs were not examined.

Includes ensuring that all tokens which should be examined have tests associated with them.

Note: the `T_STRING` token in the `registed()` method looks out of place, but is probably included to support JS scanning, though there are no tests for JS files.
As support for scanning JS is being removed in PHPCS 4.0, verifying (and probably fixing) JS support by adding tests is not worth spending time on.

### Security/Mustache: improve tests 

Make sure some tests contain more complex PHP interpolated expressions to ensure this doesn't lead to false positives.

Note: as I haven't been able to come up with valid code samples which would confuse the Mustache syntax with PHP interpolated expressions, I have not implemented the use of the `TextStrings::stripEmbeds()` method, though that could be considered for the future (would need double-checking that the method does not get confused over the Mustache syntaxes).

### Security/Mustache: bug fix - potential false positives for delimiter change

The sniff didn't have enough guard code to safeguard that the test cases I've added in this commit would be handled correctly.

Fixed now.

### Security/Mustache: prevent false positive on partial text 

Includes test.

Closes #541 