### PR TITLE
Fix license info and standardize file docblocks

### DIFF
--- a/LICENSE.md
+++ b/LICENSE.md
@@ -63,5 +63,8 @@ Included Files
 
 This project includes:
 
-- [WordPress-Coding-Standards](https://github.com/WordPress-Coding-Standards/WordPress-Coding-Standards), which is Copyright &copy; 2009 John Godley and contributors. Released under the MIT license https://github.com/WordPress-Coding-Standards/WordPress-Coding-Standards/blob/develop/LICENSE
-- [PHP_CodeSniffer](https://github.com/PHPCSStandards/PHP_CodeSniffer), Copyright &copy; 2012, Squiz Pty Ltd (ABN 77 084 670 600). Released under the following license: https://github.com/PHPCSStandards/PHP_CodeSniffer/blob/master/licence.txt
+- [PHP_CodeSniffer](https://github.com/PHPCSStandards/PHP_CodeSniffer), Copyright &copy; 2012, Squiz Pty Ltd (ABN 77 084 670 600); Copyright (c) 2023, PHPCSStandards and contributors. Released under the [BSD 3-Clause "New" or "Revised" License](https://github.com/PHPCSStandards/PHP_CodeSniffer/blob/HEAD/licence.txt)
+- [PHPCSUtils](https://github.com/PHPCSStandards/PHPCSUtils), Copyright &copy; 2019, PHPCSUtils Contributors. Released under the [LGPL v3.0 License](https://github.com/PHPCSStandards/PHPCSUtils/blob/develop/LICENSE)
+- [PHPCSExtra](https://github.com/PHPCSStandards/PHPCSExtra), Copyright &copy; 2019, PHPCSExtra Contributors. Released under the [LGPL v3.0 License](https://github.com/PHPCSStandards/PHPCSExtra/blob/develop/LICENSE)
+- [WordPress-Coding-Standards](https://github.com/WordPress-Coding-Standards/WordPress-Coding-Standards), which is Copyright &copy; 2009 John Godley and contributors. Released under the [MIT license](https://github.com/WordPress-Coding-Standards/WordPress-Coding-Standards/blob/develop/LICENSE).
+- [VariableAnalysis](https://github.com/sirbrillig/phpcs-variable-analysis). Released under the [BSD license](https://github.com/sirbrillig/phpcs-variable-analysis/blob/2.x/LICENSE).

--- a/WordPressVIPMinimum/Sniffs/AbstractVariableRestrictionsSniff.php
+++ b/WordPressVIPMinimum/Sniffs/AbstractVariableRestrictionsSniff.php
@@ -4,6 +4,7 @@
  *
  * @package VIPCS\WordPressVIPMinimum
  * @link https://github.com/Automattic/VIP-Coding-Standards
+ * @license https://opensource.org/license/gpl-2-0 GPL-2.0
  * @license https://opensource.org/licenses/MIT MIT
  */
 

--- a/WordPressVIPMinimum/Sniffs/Classes/DeclarationCompatibilitySniff.php
+++ b/WordPressVIPMinimum/Sniffs/Classes/DeclarationCompatibilitySniff.php
@@ -3,6 +3,8 @@
  * WordPressVIPMinimum Coding Standard.
  *
  * @package VIPCS\WordPressVIPMinimum
+ * @link https://github.com/Automattic/VIP-Coding-Standards
+ * @license https://opensource.org/license/gpl-2-0 GPL-2.0
  */
 
 namespace WordPressVIPMinimum\Sniffs\Classes;

--- a/WordPressVIPMinimum/Sniffs/Classes/RestrictedExtendClassesSniff.php
+++ b/WordPressVIPMinimum/Sniffs/Classes/RestrictedExtendClassesSniff.php
@@ -3,6 +3,8 @@
  * WordPressVIPMinimum Coding Standard.
  *
  * @package VIPCS\WordPressVIPMinimum
+ * @link https://github.com/Automattic/VIP-Coding-Standards
+ * @license https://opensource.org/license/gpl-2-0 GPL-2.0
  */
 
 namespace WordPressVIPMinimum\Sniffs\Classes;

--- a/WordPressVIPMinimum/Sniffs/Constants/ConstantStringSniff.php
+++ b/WordPressVIPMinimum/Sniffs/Constants/ConstantStringSniff.php
@@ -1,9 +1,10 @@
 <?php
 /**
- * WordPress-VIP-Minimum Coding Standard.
+ * WordPressVIPMinimum Coding Standard.
  *
  * @package VIPCS\WordPressVIPMinimum
  * @link https://github.com/Automattic/VIP-Coding-Standards
+ * @license https://opensource.org/license/gpl-2-0 GPL-2.0
  */
 
 namespace WordPressVIPMinimum\Sniffs\Constants;

--- a/WordPressVIPMinimum/Sniffs/Constants/RestrictedConstantsSniff.php
+++ b/WordPressVIPMinimum/Sniffs/Constants/RestrictedConstantsSniff.php
@@ -1,9 +1,10 @@
 <?php
 /**
- * WordPress-VIP-Minimum Coding Standard.
+ * WordPressVIPMinimum Coding Standard.
  *
  * @package VIPCS\WordPressVIPMinimum
  * @link https://github.com/Automattic/VIP-Coding-Standards
+ * @license https://opensource.org/license/gpl-2-0 GPL-2.0
  */
 
 namespace WordPressVIPMinimum\Sniffs\Constants;

--- a/WordPressVIPMinimum/Sniffs/Files/IncludingFileSniff.php
+++ b/WordPressVIPMinimum/Sniffs/Files/IncludingFileSniff.php
@@ -1,8 +1,10 @@
 <?php
 /**
- * WordPressVIPMinimum_Sniffs_Files_IncludingFileSniff.
+ * WordPressVIPMinimum Coding Standard.
  *
  * @package VIPCS\WordPressVIPMinimum
+ * @link https://github.com/Automattic/VIP-Coding-Standards
+ * @license https://opensource.org/license/gpl-2-0 GPL-2.0
  */
 
 namespace WordPressVIPMinimum\Sniffs\Files;

--- a/WordPressVIPMinimum/Sniffs/Files/IncludingNonPHPFileSniff.php
+++ b/WordPressVIPMinimum/Sniffs/Files/IncludingNonPHPFileSniff.php
@@ -1,8 +1,10 @@
 <?php
 /**
- * WordPressVIPMinimum_Sniffs_Files_IncludingNonPHPFileSniff.
+ * WordPressVIPMinimum Coding Standard.
  *
  * @package VIPCS\WordPressVIPMinimum
+ * @link https://github.com/Automattic/VIP-Coding-Standards
+ * @license https://opensource.org/license/gpl-2-0 GPL-2.0
  */
 
 namespace WordPressVIPMinimum\Sniffs\Files;

--- a/WordPressVIPMinimum/Sniffs/Functions/CheckReturnValueSniff.php
+++ b/WordPressVIPMinimum/Sniffs/Functions/CheckReturnValueSniff.php
@@ -3,6 +3,8 @@
  * WordPressVIPMinimum Coding Standard.
  *
  * @package VIPCS\WordPressVIPMinimum
+ * @link https://github.com/Automattic/VIP-Coding-Standards
+ * @license https://opensource.org/license/gpl-2-0 GPL-2.0
  */
 
 namespace WordPressVIPMinimum\Sniffs\Functions;

--- a/WordPressVIPMinimum/Sniffs/Functions/DynamicCallsSniff.php
+++ b/WordPressVIPMinimum/Sniffs/Functions/DynamicCallsSniff.php
@@ -3,6 +3,8 @@
  * WordPressVIPMinimum Coding Standard.
  *
  * @package VIPCS\WordPressVIPMinimum
+ * @link https://github.com/Automattic/VIP-Coding-Standards
+ * @license https://opensource.org/license/gpl-2-0 GPL-2.0
  */
 
 namespace WordPressVIPMinimum\Sniffs\Functions;

--- a/WordPressVIPMinimum/Sniffs/Functions/RestrictedFunctionsSniff.php
+++ b/WordPressVIPMinimum/Sniffs/Functions/RestrictedFunctionsSniff.php
@@ -3,6 +3,8 @@
  * WordPressVIPMinimum Coding Standard.
  *
  * @package VIPCS\WordPressVIPMinimum
+ * @link https://github.com/Automattic/VIP-Coding-Standards
+ * @license https://opensource.org/license/gpl-2-0 GPL-2.0
  */
 
 namespace WordPressVIPMinimum\Sniffs\Functions;

--- a/WordPressVIPMinimum/Sniffs/Functions/StripTagsSniff.php
+++ b/WordPressVIPMinimum/Sniffs/Functions/StripTagsSniff.php
@@ -3,6 +3,8 @@
  * WordPressVIPMinimum Coding Standard.
  *
  * @package VIPCS\WordPressVIPMinimum
+ * @link https://github.com/Automattic/VIP-Coding-Standards
+ * @license https://opensource.org/license/gpl-2-0 GPL-2.0
  */
 
 namespace WordPressVIPMinimum\Sniffs\Functions;

--- a/WordPressVIPMinimum/Sniffs/Hooks/AlwaysReturnInFilterSniff.php
+++ b/WordPressVIPMinimum/Sniffs/Hooks/AlwaysReturnInFilterSniff.php
@@ -3,6 +3,8 @@
  * WordPressVIPMinimum Coding Standard.
  *
  * @package VIPCS\WordPressVIPMinimum
+ * @link https://github.com/Automattic/VIP-Coding-Standards
+ * @license https://opensource.org/license/gpl-2-0 GPL-2.0
  */
 
 namespace WordPressVIPMinimum\Sniffs\Hooks;

--- a/WordPressVIPMinimum/Sniffs/Hooks/PreGetPostsSniff.php
+++ b/WordPressVIPMinimum/Sniffs/Hooks/PreGetPostsSniff.php
@@ -3,6 +3,8 @@
  * WordPressVIPMinimum Coding Standard.
  *
  * @package VIPCS\WordPressVIPMinimum
+ * @link https://github.com/Automattic/VIP-Coding-Standards
+ * @license https://opensource.org/license/gpl-2-0 GPL-2.0
  */
 
 namespace WordPressVIPMinimum\Sniffs\Hooks;

--- a/WordPressVIPMinimum/Sniffs/Hooks/RestrictedHooksSniff.php
+++ b/WordPressVIPMinimum/Sniffs/Hooks/RestrictedHooksSniff.php
@@ -3,6 +3,8 @@
  * WordPressVIPMinimum Coding Standard.
  *
  * @package VIPCS\WordPressVIPMinimum
+ * @link https://github.com/Automattic/VIP-Coding-Standards
+ * @license https://opensource.org/license/gpl-2-0 GPL-2.0
  */
 
 namespace WordPressVIPMinimum\Sniffs\Hooks;

--- a/WordPressVIPMinimum/Sniffs/JS/DangerouslySetInnerHTMLSniff.php
+++ b/WordPressVIPMinimum/Sniffs/JS/DangerouslySetInnerHTMLSniff.php
@@ -1,8 +1,10 @@
 <?php
 /**
- * WordPressVIPMinimum_Sniffs_JS_DangerouslySetInnerHTMLSniff.
+ * WordPressVIPMinimum Coding Standard.
  *
  * @package VIPCS\WordPressVIPMinimum
+ * @link https://github.com/Automattic/VIP-Coding-Standards
+ * @license https://opensource.org/license/gpl-2-0 GPL-2.0
  */
 
 namespace WordPressVIPMinimum\Sniffs\JS;

--- a/WordPressVIPMinimum/Sniffs/JS/HTMLExecutingFunctionsSniff.php
+++ b/WordPressVIPMinimum/Sniffs/JS/HTMLExecutingFunctionsSniff.php
@@ -1,8 +1,10 @@
 <?php
 /**
- * WordPressVIPMinimum_Sniffs_Files_IncludingFileSniff.
+ * WordPressVIPMinimum Coding Standard.
  *
  * @package VIPCS\WordPressVIPMinimum
+ * @link https://github.com/Automattic/VIP-Coding-Standards
+ * @license https://opensource.org/license/gpl-2-0 GPL-2.0
  */
 
 namespace WordPressVIPMinimum\Sniffs\JS;

--- a/WordPressVIPMinimum/Sniffs/JS/InnerHTMLSniff.php
+++ b/WordPressVIPMinimum/Sniffs/JS/InnerHTMLSniff.php
@@ -1,8 +1,10 @@
 <?php
 /**
- * WordPressVIPMinimum_Sniffs_Files_IncludingFileSniff.
+ * WordPressVIPMinimum Coding Standard.
  *
  * @package VIPCS\WordPressVIPMinimum
+ * @link https://github.com/Automattic/VIP-Coding-Standards
+ * @license https://opensource.org/license/gpl-2-0 GPL-2.0
  */
 
 namespace WordPressVIPMinimum\Sniffs\JS;

--- a/WordPressVIPMinimum/Sniffs/JS/StringConcatSniff.php
+++ b/WordPressVIPMinimum/Sniffs/JS/StringConcatSniff.php
@@ -1,8 +1,10 @@
 <?php
 /**
- * WordPressVIPMinimum_Sniffs_Files_IncludingFileSniff.
+ * WordPressVIPMinimum Coding Standard.
  *
  * @package VIPCS\WordPressVIPMinimum
+ * @link https://github.com/Automattic/VIP-Coding-Standards
+ * @license https://opensource.org/license/gpl-2-0 GPL-2.0
  */
 
 namespace WordPressVIPMinimum\Sniffs\JS;

--- a/WordPressVIPMinimum/Sniffs/JS/StrippingTagsSniff.php
+++ b/WordPressVIPMinimum/Sniffs/JS/StrippingTagsSniff.php
@@ -1,8 +1,10 @@
 <?php
 /**
- * WordPressVIPMinimum_Sniffs_Files_IncludingFileSniff.
+ * WordPressVIPMinimum Coding Standard.
  *
  * @package VIPCS\WordPressVIPMinimum
+ * @link https://github.com/Automattic/VIP-Coding-Standards
+ * @license https://opensource.org/license/gpl-2-0 GPL-2.0
  */
 
 namespace WordPressVIPMinimum\Sniffs\JS;

--- a/WordPressVIPMinimum/Sniffs/JS/WindowSniff.php
+++ b/WordPressVIPMinimum/Sniffs/JS/WindowSniff.php
@@ -1,8 +1,10 @@
 <?php
 /**
- * WordPressVIPMinimum_Sniffs_JS_WindowSniff.
+ * WordPressVIPMinimum Coding Standard.
  *
  * @package VIPCS\WordPressVIPMinimum
+ * @link https://github.com/Automattic/VIP-Coding-Standards
+ * @license https://opensource.org/license/gpl-2-0 GPL-2.0
  */
 
 namespace WordPressVIPMinimum\Sniffs\JS;

--- a/WordPressVIPMinimum/Sniffs/Performance/CacheValueOverrideSniff.php
+++ b/WordPressVIPMinimum/Sniffs/Performance/CacheValueOverrideSniff.php
@@ -3,6 +3,8 @@
  * WordPressVIPMinimum Coding Standard.
  *
  * @package VIPCS\WordPressVIPMinimum
+ * @link https://github.com/Automattic/VIP-Coding-Standards
+ * @license https://opensource.org/license/gpl-2-0 GPL-2.0
  */
 
 namespace WordPressVIPMinimum\Sniffs\Performance;

--- a/WordPressVIPMinimum/Sniffs/Performance/FetchingRemoteDataSniff.php
+++ b/WordPressVIPMinimum/Sniffs/Performance/FetchingRemoteDataSniff.php
@@ -4,6 +4,7 @@
  *
  * @package VIPCS\WordPressVIPMinimum
  * @link https://github.com/Automattic/VIP-Coding-Standards
+ * @license https://opensource.org/license/gpl-2-0 GPL-2.0
  */
 
 namespace WordPressVIPMinimum\Sniffs\Performance;

--- a/WordPressVIPMinimum/Sniffs/Performance/LowExpiryCacheTimeSniff.php
+++ b/WordPressVIPMinimum/Sniffs/Performance/LowExpiryCacheTimeSniff.php
@@ -3,6 +3,8 @@
  * WordPressVIPMinimum Coding Standard.
  *
  * @package VIPCS\WordPressVIPMinimum
+ * @link https://github.com/Automattic/VIP-Coding-Standards
+ * @license https://opensource.org/license/gpl-2-0 GPL-2.0
  */
 
 namespace WordPressVIPMinimum\Sniffs\Performance;

--- a/WordPressVIPMinimum/Sniffs/Performance/NoPagingSniff.php
+++ b/WordPressVIPMinimum/Sniffs/Performance/NoPagingSniff.php
@@ -4,6 +4,7 @@
  *
  * @package VIPCS\WordPressVIPMinimum
  * @link https://github.com/Automattic/VIP-Coding-Standards
+ * @license https://opensource.org/license/gpl-2-0 GPL-2.0
  * @license https://opensource.org/licenses/MIT MIT
  */
 

--- a/WordPressVIPMinimum/Sniffs/Performance/OrderByRandSniff.php
+++ b/WordPressVIPMinimum/Sniffs/Performance/OrderByRandSniff.php
@@ -4,6 +4,7 @@
  *
  * @package VIPCS\WordPressVIPMinimum
  * @link https://github.com/Automattic/VIP-Coding-Standards
+ * @license https://opensource.org/license/gpl-2-0 GPL-2.0
  * @license https://opensource.org/licenses/MIT MIT
  */
 

--- a/WordPressVIPMinimum/Sniffs/Performance/RegexpCompareSniff.php
+++ b/WordPressVIPMinimum/Sniffs/Performance/RegexpCompareSniff.php
@@ -3,6 +3,8 @@
  * WordPressVIPMinimum Coding Standard.
  *
  * @package VIPCS\WordPressVIPMinimum
+ * @link https://github.com/Automattic/VIP-Coding-Standards
+ * @license https://opensource.org/license/gpl-2-0 GPL-2.0
  */
 
 namespace WordPressVIPMinimum\Sniffs\Performance;

--- a/WordPressVIPMinimum/Sniffs/Performance/RemoteRequestTimeoutSniff.php
+++ b/WordPressVIPMinimum/Sniffs/Performance/RemoteRequestTimeoutSniff.php
@@ -3,6 +3,8 @@
  * WordPressVIPMinimum Coding Standard.
  *
  * @package VIPCS\WordPressVIPMinimum
+ * @link https://github.com/Automattic/VIP-Coding-Standards
+ * @license https://opensource.org/license/gpl-2-0 GPL-2.0
  */
 
 namespace WordPressVIPMinimum\Sniffs\Performance;

--- a/WordPressVIPMinimum/Sniffs/Performance/TaxonomyMetaInOptionsSniff.php
+++ b/WordPressVIPMinimum/Sniffs/Performance/TaxonomyMetaInOptionsSniff.php
@@ -4,6 +4,7 @@
  *
  * @package VIPCS\WordPressVIPMinimum
  * @link https://github.com/Automattic/VIP-Coding-Standards
+ * @license https://opensource.org/license/gpl-2-0 GPL-2.0
  */
 
 namespace WordPressVIPMinimum\Sniffs\Performance;

--- a/WordPressVIPMinimum/Sniffs/Performance/WPQueryParamsSniff.php
+++ b/WordPressVIPMinimum/Sniffs/Performance/WPQueryParamsSniff.php
@@ -4,6 +4,7 @@
  *
  * @package VIPCS\WordPressVIPMinimum
  * @link https://github.com/Automattic/VIP-Coding-Standards
+ * @license https://opensource.org/license/gpl-2-0 GPL-2.0
  */
 
 namespace WordPressVIPMinimum\Sniffs\Performance;

--- a/WordPressVIPMinimum/Sniffs/Security/EscapingVoidReturnFunctionsSniff.php
+++ b/WordPressVIPMinimum/Sniffs/Security/EscapingVoidReturnFunctionsSniff.php
@@ -4,6 +4,7 @@
  *
  * @package VIPCS\WordPressVIPMinimum
  * @link https://github.com/Automattic/VIP-Coding-Standards
+ * @license https://opensource.org/license/gpl-2-0 GPL-2.0
  */
 
 namespace WordPressVIPMinimum\Sniffs\Security;

--- a/WordPressVIPMinimum/Sniffs/Security/ExitAfterRedirectSniff.php
+++ b/WordPressVIPMinimum/Sniffs/Security/ExitAfterRedirectSniff.php
@@ -4,6 +4,7 @@
  *
  * @package VIPCS\WordPressVIPMinimum
  * @link https://github.com/Automattic/VIP-Coding-Standards
+ * @license https://opensource.org/license/gpl-2-0 GPL-2.0
  */
 
 namespace WordPressVIPMinimum\Sniffs\Security;

--- a/WordPressVIPMinimum/Sniffs/Security/MustacheSniff.php
+++ b/WordPressVIPMinimum/Sniffs/Security/MustacheSniff.php
@@ -4,6 +4,7 @@
  *
  * @package VIPCS\WordPressVIPMinimum
  * @link https://github.com/Automattic/VIP-Coding-Standards
+ * @license https://opensource.org/license/gpl-2-0 GPL-2.0
  */
 
 namespace WordPressVIPMinimum\Sniffs\Security;

--- a/WordPressVIPMinimum/Sniffs/Security/PHPFilterFunctionsSniff.php
+++ b/WordPressVIPMinimum/Sniffs/Security/PHPFilterFunctionsSniff.php
@@ -3,6 +3,8 @@
  * WordPressVIPMinimum Coding Standard.
  *
  * @package VIPCS\WordPressVIPMinimum
+ * @link https://github.com/Automattic/VIP-Coding-Standards
+ * @license https://opensource.org/license/gpl-2-0 GPL-2.0
  */
 
 namespace WordPressVIPMinimum\Sniffs\Security;

--- a/WordPressVIPMinimum/Sniffs/Security/ProperEscapingFunctionSniff.php
+++ b/WordPressVIPMinimum/Sniffs/Security/ProperEscapingFunctionSniff.php
@@ -4,6 +4,7 @@
  *
  * @package VIPCS\WordPressVIPMinimum
  * @link https://github.com/Automattic/VIP-Coding-Standards
+ * @license https://opensource.org/license/gpl-2-0 GPL-2.0
  */
 
 namespace WordPressVIPMinimum\Sniffs\Security;

--- a/WordPressVIPMinimum/Sniffs/Security/StaticStrreplaceSniff.php
+++ b/WordPressVIPMinimum/Sniffs/Security/StaticStrreplaceSniff.php
@@ -4,6 +4,7 @@
  *
  * @package VIPCS\WordPressVIPMinimum
  * @link https://github.com/Automattic/VIP-Coding-Standards
+ * @license https://opensource.org/license/gpl-2-0 GPL-2.0
  */
 
 namespace WordPressVIPMinimum\Sniffs\Security;

--- a/WordPressVIPMinimum/Sniffs/Security/TwigSniff.php
+++ b/WordPressVIPMinimum/Sniffs/Security/TwigSniff.php
@@ -4,6 +4,7 @@
  *
  * @package VIPCS\WordPressVIPMinimum
  * @link https://github.com/Automattic/VIP-Coding-Standards
+ * @license https://opensource.org/license/gpl-2-0 GPL-2.0
  */
 
 namespace WordPressVIPMinimum\Sniffs\Security;

--- a/WordPressVIPMinimum/Sniffs/Security/UnderscorejsSniff.php
+++ b/WordPressVIPMinimum/Sniffs/Security/UnderscorejsSniff.php
@@ -4,6 +4,7 @@
  *
  * @package VIPCS\WordPressVIPMinimum
  * @link https://github.com/Automattic/VIP-Coding-Standards
+ * @license https://opensource.org/license/gpl-2-0 GPL-2.0
  */
 
 namespace WordPressVIPMinimum\Sniffs\Security;

--- a/WordPressVIPMinimum/Sniffs/Sniff.php
+++ b/WordPressVIPMinimum/Sniffs/Sniff.php
@@ -4,6 +4,7 @@
  *
  * @package VIPCS\WordPressVIPMinimum
  * @link https://github.com/Automattic/VIP-Coding-Standards
+ * @license https://opensource.org/license/gpl-2-0 GPL-2.0
  * @license https://opensource.org/licenses/MIT MIT
  */
 

--- a/WordPressVIPMinimum/Sniffs/UserExperience/AdminBarRemovalSniff.php
+++ b/WordPressVIPMinimum/Sniffs/UserExperience/AdminBarRemovalSniff.php
@@ -4,6 +4,7 @@
  *
  * @package VIPCS\WordPressVIPMinimum
  * @link https://github.com/Automattic/VIP-Coding-Standards
+ * @license https://opensource.org/license/gpl-2-0 GPL-2.0
  * @license https://opensource.org/licenses/MIT MIT
  */
 

--- a/WordPressVIPMinimum/Sniffs/Variables/RestrictedVariablesSniff.php
+++ b/WordPressVIPMinimum/Sniffs/Variables/RestrictedVariablesSniff.php
@@ -4,6 +4,7 @@
  *
  * @package VIPCS\WordPressVIPMinimum
  * @link https://github.com/Automattic/VIP-Coding-Standards
+ * @license https://opensource.org/license/gpl-2-0 GPL-2.0
  * @license https://opensource.org/licenses/MIT MIT
  */
 

--- a/WordPressVIPMinimum/Sniffs/Variables/ServerVariablesSniff.php
+++ b/WordPressVIPMinimum/Sniffs/Variables/ServerVariablesSniff.php
@@ -1,9 +1,10 @@
 <?php
 /**
- * WordPress-VIP-Minimum Coding Standard.
+ * WordPressVIPMinimum Coding Standard.
  *
  * @package VIPCS\WordPressVIPMinimum
  * @link https://github.com/Automattic/VIP-Coding-Standards
+ * @license https://opensource.org/license/gpl-2-0 GPL-2.0
  */
 
 namespace WordPressVIPMinimum\Sniffs\Variables;


### PR DESCRIPTION
### LICENSE: update information about included projects

### Docs: standardize the sniff file docblocks 

Ensuring that all (sniff) files which are distributed contain a link back to the repo and license information.

### Docs/Imported sniffs: add `@license` tag for the GPL v2 license 

These sniffs already contained the standardized file docblock, but with a `@license` tag for the MIT license as these sniffs were originally created in the WordPressCS project, which is licensed under MIT.

This commit adds an extra `@license` tag for the GPL v2 license under which VIPCS is licensed.