### PR TITLE
Docs: remove `@since` tags which are related to WPCS

### DIFF
--- a/WordPressVIPMinimum/Sniffs/Performance/NoPagingSniff.php
+++ b/WordPressVIPMinimum/Sniffs/Performance/NoPagingSniff.php
@@ -15,8 +15,6 @@ use WordPressCS\WordPress\AbstractArrayAssignmentRestrictionsSniff;
  * Flag returning high or infinite posts_per_page.
  *
  * @link https://docs.wpvip.com/technical-references/code-review/#no-limit-queries
- *
- * @since 0.5.0
  */
 class NoPagingSniff extends AbstractArrayAssignmentRestrictionsSniff {
 

--- a/WordPressVIPMinimum/Sniffs/Performance/OrderByRandSniff.php
+++ b/WordPressVIPMinimum/Sniffs/Performance/OrderByRandSniff.php
@@ -16,8 +16,6 @@ use WordPressCS\WordPress\AbstractArrayAssignmentRestrictionsSniff;
  * Flag using orderby => rand.
  *
  * @link https://docs.wpvip.com/technical-references/code-review/vip-errors/#h-order-by-rand
- *
- * @since 0.5.0
  */
 class OrderByRandSniff extends AbstractArrayAssignmentRestrictionsSniff {
 

--- a/WordPressVIPMinimum/Sniffs/UserExperience/AdminBarRemovalSniff.php
+++ b/WordPressVIPMinimum/Sniffs/UserExperience/AdminBarRemovalSniff.php
@@ -18,8 +18,6 @@ use WordPressCS\WordPress\AbstractFunctionParameterSniff;
  * Discourages removal of the admin bar.
  *
  * @link https://docs.wpvip.com/technical-references/code-review/vip-warnings/#h-removing-the-admin-bar
- *
- * @since 0.5.0
  */
 class AdminBarRemovalSniff extends AbstractFunctionParameterSniff {
 

--- a/WordPressVIPMinimum/Sniffs/Variables/RestrictedVariablesSniff.php
+++ b/WordPressVIPMinimum/Sniffs/Variables/RestrictedVariablesSniff.php
@@ -13,8 +13,6 @@ use WordPressVIPMinimum\Sniffs\AbstractVariableRestrictionsSniff;
 
 /**
  * Restricts usage of some variables in VIP context.
- *
- * @since 0.5.0
  */
 class RestrictedVariablesSniff extends AbstractVariableRestrictionsSniff {
 

--- a/WordPressVIPMinimum/Tests/Performance/NoPagingUnitTest.php
+++ b/WordPressVIPMinimum/Tests/Performance/NoPagingUnitTest.php
@@ -12,8 +12,6 @@ use PHP_CodeSniffer\Tests\Standards\AbstractSniffUnitTest;
 /**
  * Unit test class for the NoPaging sniff.
  *
- * @since 0.5.0
- *
  * @covers \WordPressVIPMinimum\Sniffs\Performance\NoPagingSniff
  */
 class NoPagingUnitTest extends AbstractSniffUnitTest {

--- a/WordPressVIPMinimum/Tests/Performance/OrderByRandUnitTest.php
+++ b/WordPressVIPMinimum/Tests/Performance/OrderByRandUnitTest.php
@@ -12,8 +12,6 @@ use PHP_CodeSniffer\Tests\Standards\AbstractSniffUnitTest;
 /**
  * Unit test class for the OrderByRand sniff.
  *
- * @since 0.5.0
- *
  * @covers \WordPressVIPMinimum\Sniffs\Performance\OrderByRandSniff
  */
 class OrderByRandUnitTest extends AbstractSniffUnitTest {

--- a/WordPressVIPMinimum/Tests/UserExperience/AdminBarRemovalUnitTest.php
+++ b/WordPressVIPMinimum/Tests/UserExperience/AdminBarRemovalUnitTest.php
@@ -12,8 +12,6 @@ use PHP_CodeSniffer\Tests\Standards\AbstractSniffUnitTest;
 /**
  * Unit test class for the AdminBarRemoval sniff.
  *
- * @since 0.5.0
- *
  * @covers \WordPressVIPMinimum\Sniffs\UserExperience\AdminBarRemovalSniff
  */
 class AdminBarRemovalUnitTest extends AbstractSniffUnitTest {

--- a/WordPressVIPMinimum/Tests/Variables/RestrictedVariablesUnitTest.php
+++ b/WordPressVIPMinimum/Tests/Variables/RestrictedVariablesUnitTest.php
@@ -12,9 +12,6 @@ use PHP_CodeSniffer\Tests\Standards\AbstractSniffUnitTest;
 /**
  * Unit test class for the VIP_RestrictedVariables sniff.
  *
- * @since 0.3.0
- * @since 0.13.0 Class name changed: this class is now namespaced.
- *
  * @covers \WordPressVIPMinimum\Sniffs\Variables\RestrictedVariablesSniff
  */
 class RestrictedVariablesUnitTest extends AbstractSniffUnitTest {


### PR DESCRIPTION
Some sniffs were originally hosted in the WordPressCS project and later moved to VIPCS. In that move, the WPCS `@since` tags were not scrubbed/updated. This is misleading as the `@since` tags now refer to versions which never existed for VIPCS.

Note: `@since` tags which do refer to VIPCS versions have been left untouched.