### PR TITLE
PHPCS ruleset: fix PHPCompatibility exclusions

### DIFF
--- a/.phpcs.xml.dist
+++ b/.phpcs.xml.dist
@@ -47,18 +47,29 @@
 	<config name="testVersion" value="5.4-"/>
 	<rule ref="PHPCompatibility">
 		<!-- Exclude PHP constants back-filled by PHPCS. -->
-		<exclude name="PHPCompatibility.PHP.NewConstants.t_finallyFound"/>
-		<exclude name="PHPCompatibility.PHP.NewConstants.t_yieldFound"/>
-		<exclude name="PHPCompatibility.PHP.NewConstants.t_ellipsisFound"/>
-		<exclude name="PHPCompatibility.PHP.NewConstants.t_powFound"/>
-		<exclude name="PHPCompatibility.PHP.NewConstants.t_pow_equalFound"/>
-		<exclude name="PHPCompatibility.PHP.NewConstants.t_spaceshipFound"/>
-		<exclude name="PHPCompatibility.PHP.NewConstants.t_coalesceFound"/>
-		<exclude name="PHPCompatibility.PHP.NewConstants.t_coalesce_equalFound"/>
-		<exclude name="PHPCompatibility.PHP.NewConstants.t_yield_fromFound"/>
-
-		<!-- Unclear how, but appears to be back-filled anyhow, could be that PHP did so before the token was in use. -->
-		<exclude name="PHPCompatibility.PHP.NewConstants.t_traitFound"/>
+		<exclude name="PHPCompatibility.Constants.NewConstants.t_finallyFound"/>
+		<exclude name="PHPCompatibility.Constants.NewConstants.t_yieldFound"/>
+		<exclude name="PHPCompatibility.Constants.NewConstants.t_ellipsisFound"/>
+		<exclude name="PHPCompatibility.Constants.NewConstants.t_powFound"/>
+		<exclude name="PHPCompatibility.Constants.NewConstants.t_pow_equalFound"/>
+		<exclude name="PHPCompatibility.Constants.NewConstants.t_spaceshipFound"/>
+		<exclude name="PHPCompatibility.Constants.NewConstants.t_coalesceFound"/>
+		<exclude name="PHPCompatibility.Constants.NewConstants.t_coalesce_equalFound"/>
+		<exclude name="PHPCompatibility.Constants.NewConstants.t_yield_fromFound"/>
+		<exclude name="PHPCompatibility.Constants.NewConstants.t_bad_characterFound"/>
+		<exclude name="PHPCompatibility.Constants.NewConstants.t_fnFound"/>
+		<exclude name="PHPCompatibility.Constants.NewConstants.t_attributeFound"/>
+		<exclude name="PHPCompatibility.Constants.NewConstants.t_matchFound"/>
+		<exclude name="PHPCompatibility.Constants.NewConstants.t_nullsafe_object_operatorFound"/>
+		<exclude name="PHPCompatibility.Constants.NewConstants.t_name_fully_qualifiedFound"/>
+		<exclude name="PHPCompatibility.Constants.NewConstants.t_name_qualifiedFound"/>
+		<exclude name="PHPCompatibility.Constants.NewConstants.t_name_relativeFound"/>
+		<exclude name="PHPCompatibility.Constants.NewConstants.t_readonlyFound"/>
+		<exclude name="PHPCompatibility.Constants.NewConstants.t_enumFound"/>
+		<exclude name="PHPCompatibility.Constants.NewConstants.t_public_setFound"/>
+		<exclude name="PHPCompatibility.Constants.NewConstants.t_protected_setFound"/>
+		<exclude name="PHPCompatibility.Constants.NewConstants.t_private_setFound"/>
+		<exclude name="PHPCompatibility.Constants.RemovedConstants.t_bad_characterFound"/>
 	</rule>
 
 </ruleset>


### PR DESCRIPTION
The sniffs which trigger these errors were renamed in PHPCompatibility 9.0.0. Clearly, these constants have so far not been used in VIPCS ;-)

Includes making the list complete for the tokens currently back-filled by PHPCS for forward-compatibility with PHPCompatibility `dev-develop`/next release.

Ref: https://github.com/PHPCompatibility/PHPCompatibility/releases/tag/9.0.0