### PR TITLE
Security/StaticStrreplace: various sniff improvements

### DIFF
--- a/WordPressVIPMinimum/Sniffs/Security/StaticStrreplaceSniff.php
+++ b/WordPressVIPMinimum/Sniffs/Security/StaticStrreplaceSniff.php
@@ -10,9 +10,10 @@
 namespace WordPressVIPMinimum\Sniffs\Security;
 
 use PHP_CodeSniffer\Util\Tokens;
-use PHPCSUtils\Exceptions\UnexpectedTokenType;
 use PHPCSUtils\Tokens\Collections;
+use PHPCSUtils\Utils\Arrays;
 use PHPCSUtils\Utils\PassedParameters;
+use PHPCSUtils\Utils\TextStrings;
 use WordPressCS\WordPress\AbstractFunctionParameterSniff;
 
 /**
@@ -61,40 +62,83 @@ class StaticStrreplaceSniff extends AbstractFunctionParameterSniff {
 			return;
 		}
 
-		$static_text_tokens                               = Tokens::$emptyTokens;
-		$static_text_tokens[ T_CONSTANT_ENCAPSED_STRING ] = T_CONSTANT_ENCAPSED_STRING;
-
 		foreach ( [ $search_param, $replace_param, $subject_param ] as $param ) {
-			$has_non_static_text = $this->phpcsFile->findNext( $static_text_tokens, $param['start'], ( $param['end'] + 1 ), true );
-			if ( $has_non_static_text === false ) {
-				// The parameter contained only tokens which could be considered static text.
-				continue;
+			if ( $this->is_parameter_static_text( $param ) === false ) {
+				// Non-static text token found. Not what we're looking for.
+				return;
 			}
-
-			if ( isset( Collections::arrayOpenTokensBC()[ $this->tokens[ $has_non_static_text ]['code'] ] ) ) {
-				try {
-					$array_items = PassedParameters::getParameters( $this->phpcsFile, $has_non_static_text );
-				} catch ( UnexpectedTokenType $e ) {
-					// Short list, parse error or live coding, bow out.
-					return;
-				}
-
-				foreach ( $array_items as $array_item ) {
-					$has_non_static_text = $this->phpcsFile->findNext( $static_text_tokens, $array_item['start'], $array_item['end'], true );
-					if ( $has_non_static_text !== false ) {
-						return;
-					}
-				}
-
-				// The array only contained items with tokens which could be considered static text.
-				continue;
-			}
-
-			// Non-static text token found. Not what we're looking for.
-			return;
 		}
 
 		$message = 'This code pattern is often used to run a very dangerous shell programs on your server. The code in these files needs to be reviewed, and possibly cleaned.';
 		$this->phpcsFile->addError( $message, $stackPtr, 'StaticStrreplace' );
+	}
+
+	/**
+	 * Check whether the current parameter, or array item, only contains tokens which should be regarded
+	 * as a valid part of a static text string.
+	 *
+	 * @param array<string, int|string> $param_info Array with information about a single parameter or array item.
+	 *                                              Must be an array as returned via the PassedParameters class.
+	 *
+	 * @return bool
+	 */
+	private function is_parameter_static_text( $param_info ) {
+		// List of tokens which can be skipped over without further examination.
+		$static_tokens  = [
+			T_CONSTANT_ENCAPSED_STRING => T_CONSTANT_ENCAPSED_STRING,
+			T_PLUS                     => T_PLUS,
+			T_STRING_CONCAT            => T_STRING_CONCAT,
+		];
+		$static_tokens += Tokens::$emptyTokens;
+
+		for ( $i = $param_info['start']; $i <= $param_info['end']; $i++ ) {
+			$next_to_examine = $this->phpcsFile->findNext( $static_tokens, $i, ( $param_info['end'] + 1 ), true );
+			if ( $next_to_examine === false ) {
+				// The parameter contained only tokens which could be considered static text.
+				return true;
+			}
+
+			if ( isset( Collections::arrayOpenTokensBC()[ $this->tokens[ $next_to_examine ]['code'] ] ) ) {
+				$arrayOpenClose = Arrays::getOpenClose( $this->phpcsFile, $next_to_examine );
+				if ( $arrayOpenClose === false ) {
+					// Short list, parse error or live coding, bow out.
+					return false;
+				}
+
+				$array_items = PassedParameters::getParameters( $this->phpcsFile, $next_to_examine );
+				foreach ( $array_items as $array_item ) {
+					if ( $this->is_parameter_static_text( $array_item ) === false ) {
+						return false;
+					}
+				}
+
+				// The array only contained items with tokens which could be considered static text.
+				$i = $arrayOpenClose['closer'];
+				continue;
+			}
+
+			if ( $this->tokens[ $next_to_examine ]['code'] === T_START_HEREDOC ) {
+				$heredoc_text  = TextStrings::getCompleteTextString( $this->phpcsFile, $next_to_examine );
+				$stripped_text = TextStrings::stripEmbeds( $heredoc_text );
+				if ( $heredoc_text !== $stripped_text ) {
+					// Heredoc with interpolated expression(s). Not a static text.
+					return false;
+				}
+			}
+
+			if ( ( $this->tokens[ $next_to_examine ]['code'] === T_START_HEREDOC
+				|| $this->tokens[ $next_to_examine ]['code'] === T_START_NOWDOC )
+				&& isset( $this->tokens[ $next_to_examine ]['scope_closer'] )
+			) {
+				// No interpolation. Skip to end of a heredoc/nowdoc.
+				$i = $this->tokens[ $next_to_examine ]['scope_closer'];
+				continue;
+			}
+
+			// Any other token means this parameter should be regarded as non-static text. Not what we're looking for.
+			return false;
+		}
+
+		return true;
 	}
 }

--- a/WordPressVIPMinimum/Sniffs/Security/StaticStrreplaceSniff.php
+++ b/WordPressVIPMinimum/Sniffs/Security/StaticStrreplaceSniff.php
@@ -12,6 +12,7 @@ namespace WordPressVIPMinimum\Sniffs\Security;
 use PHP_CodeSniffer\Util\Tokens;
 use PHPCSUtils\Tokens\Collections;
 use PHPCSUtils\Utils\Arrays;
+use PHPCSUtils\Utils\PassedParameters;
 use WordPressCS\WordPress\AbstractFunctionParameterSniff;
 
 /**
@@ -54,6 +55,9 @@ class StaticStrreplaceSniff extends AbstractFunctionParameterSniff {
 			return;
 		}
 
+		$static_text_tokens                               = Tokens::$emptyTokens;
+		$static_text_tokens[ T_CONSTANT_ENCAPSED_STRING ] = T_CONSTANT_ENCAPSED_STRING;
+
 		$next_start_ptr = $openBracket + 1;
 		for ( $i = 0; $i < 3; $i++ ) {
 			$param_ptr = $this->phpcsFile->findNext( array_merge( Tokens::$emptyTokens, [ T_COMMA ] ), $next_start_ptr, null, true );
@@ -69,21 +73,16 @@ class StaticStrreplaceSniff extends AbstractFunctionParameterSniff {
 					return;
 				}
 
-				$openBracket  = $arrayOpenClose['opener'];
-				$closeBracket = $arrayOpenClose['closer'];
-
-				$array_item_ptr = $this->phpcsFile->findNext( array_merge( Tokens::$emptyTokens, [ T_COMMA ] ), $openBracket + 1, $closeBracket, true );
-				while ( $array_item_ptr !== false ) {
-
-					if ( $this->tokens[ $array_item_ptr ]['code'] !== T_CONSTANT_ENCAPSED_STRING ) {
+				$array_items = PassedParameters::getParameters( $this->phpcsFile, $param_ptr );
+				foreach ( $array_items as $array_item ) {
+					$has_non_static_text = $this->phpcsFile->findNext( $static_text_tokens, $array_item['start'], $array_item['end'], true );
+					if ( $has_non_static_text !== false ) {
 						return;
 					}
-					$array_item_ptr = $this->phpcsFile->findNext( array_merge( Tokens::$emptyTokens, [ T_COMMA ] ), $array_item_ptr + 1, $closeBracket, true );
 				}
 
-				$next_start_ptr = $closeBracket + 1;
+				$next_start_ptr = $arrayOpenClose['closer'] + 1;
 				continue;
-
 			}
 
 			if ( $this->tokens[ $param_ptr ]['code'] !== T_CONSTANT_ENCAPSED_STRING ) {

--- a/WordPressVIPMinimum/Sniffs/Security/StaticStrreplaceSniff.php
+++ b/WordPressVIPMinimum/Sniffs/Security/StaticStrreplaceSniff.php
@@ -10,8 +10,8 @@
 namespace WordPressVIPMinimum\Sniffs\Security;
 
 use PHP_CodeSniffer\Util\Tokens;
+use PHPCSUtils\Exceptions\UnexpectedTokenType;
 use PHPCSUtils\Tokens\Collections;
-use PHPCSUtils\Utils\Arrays;
 use PHPCSUtils\Utils\PassedParameters;
 use WordPressCS\WordPress\AbstractFunctionParameterSniff;
 
@@ -48,32 +48,37 @@ class StaticStrreplaceSniff extends AbstractFunctionParameterSniff {
 	 * @return void
 	 */
 	public function process_parameters( $stackPtr, $group_name, $matched_content, $parameters ) {
+		$search_param  = PassedParameters::getParameterFromStack( $parameters, 1, 'search' );
+		$replace_param = PassedParameters::getParameterFromStack( $parameters, 2, 'replace' );
+		$subject_param = PassedParameters::getParameterFromStack( $parameters, 3, 'subject' );
 
-		$openBracket = $this->phpcsFile->findNext( Tokens::$emptyTokens, $stackPtr + 1, null, true );
-
-		if ( $this->tokens[ $openBracket ]['code'] !== T_OPEN_PARENTHESIS ) {
+		if ( $search_param === false || $replace_param === false || $subject_param === false ) {
+			/*
+			 * Either an invalid function call (missing PHP required parameter); or function call
+			 * with argument unpacking; or live coding.
+			 * In all these cases, this is not the code pattern this sniff is looking for, so bow out.
+			 */
 			return;
 		}
 
 		$static_text_tokens                               = Tokens::$emptyTokens;
 		$static_text_tokens[ T_CONSTANT_ENCAPSED_STRING ] = T_CONSTANT_ENCAPSED_STRING;
 
-		$next_start_ptr = $openBracket + 1;
-		for ( $i = 0; $i < 3; $i++ ) {
-			$param_ptr = $this->phpcsFile->findNext( array_merge( Tokens::$emptyTokens, [ T_COMMA ] ), $next_start_ptr, null, true );
-			if ( $param_ptr === false ) {
-				// Live coding or parse error. Ignore.
-				return;
+		foreach ( [ $search_param, $replace_param, $subject_param ] as $param ) {
+			$has_non_static_text = $this->phpcsFile->findNext( $static_text_tokens, $param['start'], ( $param['end'] + 1 ), true );
+			if ( $has_non_static_text === false ) {
+				// The parameter contained only tokens which could be considered static text.
+				continue;
 			}
 
-			if ( isset( Collections::arrayOpenTokensBC()[ $this->tokens[ $param_ptr ]['code'] ] ) ) {
-				$arrayOpenClose = Arrays::getOpenClose( $this->phpcsFile, $param_ptr );
-				if ( $arrayOpenClose === false ) {
+			if ( isset( Collections::arrayOpenTokensBC()[ $this->tokens[ $has_non_static_text ]['code'] ] ) ) {
+				try {
+					$array_items = PassedParameters::getParameters( $this->phpcsFile, $has_non_static_text );
+				} catch ( UnexpectedTokenType $e ) {
 					// Short list, parse error or live coding, bow out.
 					return;
 				}
 
-				$array_items = PassedParameters::getParameters( $this->phpcsFile, $param_ptr );
 				foreach ( $array_items as $array_item ) {
 					$has_non_static_text = $this->phpcsFile->findNext( $static_text_tokens, $array_item['start'], $array_item['end'], true );
 					if ( $has_non_static_text !== false ) {
@@ -81,16 +86,12 @@ class StaticStrreplaceSniff extends AbstractFunctionParameterSniff {
 					}
 				}
 
-				$next_start_ptr = $arrayOpenClose['closer'] + 1;
+				// The array only contained items with tokens which could be considered static text.
 				continue;
 			}
 
-			if ( $this->tokens[ $param_ptr ]['code'] !== T_CONSTANT_ENCAPSED_STRING ) {
-				return;
-			}
-
-			$next_start_ptr = $param_ptr + 1;
-
+			// Non-static text token found. Not what we're looking for.
+			return;
 		}
 
 		$message = 'This code pattern is often used to run a very dangerous shell programs on your server. The code in these files needs to be reviewed, and possibly cleaned.';

--- a/WordPressVIPMinimum/Sniffs/Security/StaticStrreplaceSniff.php
+++ b/WordPressVIPMinimum/Sniffs/Security/StaticStrreplaceSniff.php
@@ -10,34 +10,41 @@
 namespace WordPressVIPMinimum\Sniffs\Security;
 
 use PHP_CodeSniffer\Util\Tokens;
-use WordPressVIPMinimum\Sniffs\Sniff;
+use WordPressCS\WordPress\AbstractFunctionParameterSniff;
 
 /**
  * Restricts usage of str_replace with all 3 params being static.
  */
-class StaticStrreplaceSniff extends Sniff {
+class StaticStrreplaceSniff extends AbstractFunctionParameterSniff {
 
 	/**
-	 * Returns an array of tokens this test wants to listen for.
+	 * The group name for this group of functions.
 	 *
-	 * @return array<int|string>
+	 * @var string
 	 */
-	public function register() {
-		return [ T_STRING ];
-	}
+	protected $group_name = 'str_replace';
 
 	/**
-	 * Process this test when one of its tokens is encountered
+	 * Functions this sniff is looking for.
 	 *
-	 * @param int $stackPtr The position of the current token in the stack passed in $tokens.
+	 * @var array<string, bool> Key is the function name, value irrelevant.
+	 */
+	protected $target_functions = [
+		'str_replace' => true,
+	];
+
+	/**
+	 * Process the parameters of a matched function.
+	 *
+	 * @param int    $stackPtr        The position of the current token in the stack.
+	 * @param string $group_name      The name of the group which was matched.
+	 * @param string $matched_content The token content (function name) which was matched
+	 *                                in lowercase.
+	 * @param array  $parameters      Array with information about the parameters.
 	 *
 	 * @return void
 	 */
-	public function process_token( $stackPtr ) {
-
-		if ( $this->tokens[ $stackPtr ]['content'] !== 'str_replace' ) {
-			return;
-		}
+	public function process_parameters( $stackPtr, $group_name, $matched_content, $parameters ) {
 
 		$openBracket = $this->phpcsFile->findNext( Tokens::$emptyTokens, $stackPtr + 1, null, true );
 

--- a/WordPressVIPMinimum/Sniffs/Security/StaticStrreplaceSniff.php
+++ b/WordPressVIPMinimum/Sniffs/Security/StaticStrreplaceSniff.php
@@ -10,6 +10,8 @@
 namespace WordPressVIPMinimum\Sniffs\Security;
 
 use PHP_CodeSniffer\Util\Tokens;
+use PHPCSUtils\Tokens\Collections;
+use PHPCSUtils\Utils\Arrays;
 use WordPressCS\WordPress\AbstractFunctionParameterSniff;
 
 /**
@@ -55,15 +57,20 @@ class StaticStrreplaceSniff extends AbstractFunctionParameterSniff {
 		$next_start_ptr = $openBracket + 1;
 		for ( $i = 0; $i < 3; $i++ ) {
 			$param_ptr = $this->phpcsFile->findNext( array_merge( Tokens::$emptyTokens, [ T_COMMA ] ), $next_start_ptr, null, true );
+			if ( $param_ptr === false ) {
+				// Live coding or parse error. Ignore.
+				return;
+			}
 
-			if ( $this->tokens[ $param_ptr ]['code'] === T_ARRAY ) {
-				$openBracket = $this->phpcsFile->findNext( Tokens::$emptyTokens, $param_ptr + 1, null, true );
-				if ( $this->tokens[ $openBracket ]['code'] !== T_OPEN_PARENTHESIS ) {
+			if ( isset( Collections::arrayOpenTokensBC()[ $this->tokens[ $param_ptr ]['code'] ] ) ) {
+				$arrayOpenClose = Arrays::getOpenClose( $this->phpcsFile, $param_ptr );
+				if ( $arrayOpenClose === false ) {
+					// Short list, parse error or live coding, bow out.
 					return;
 				}
 
-				// Find the closing bracket.
-				$closeBracket = $this->tokens[ $openBracket ]['parenthesis_closer'];
+				$openBracket  = $arrayOpenClose['opener'];
+				$closeBracket = $arrayOpenClose['closer'];
 
 				$array_item_ptr = $this->phpcsFile->findNext( array_merge( Tokens::$emptyTokens, [ T_COMMA ] ), $openBracket + 1, $closeBracket, true );
 				while ( $array_item_ptr !== false ) {

--- a/WordPressVIPMinimum/Tests/Security/StaticStrreplaceUnitTest.inc
+++ b/WordPressVIPMinimum/Tests/Security/StaticStrreplaceUnitTest.inc
@@ -61,3 +61,11 @@ str_replace( 'foo', 'bar', 'foobar', $count ); // Bad.
 
 // Don't confuse PHP 7.1+ short list with short array.
 str_replace( [ $a, $b ] = $search, [ 'bar', 'foo' ], 'foobar', ); // OK.
+
+// Safeguard support for PHP 8.0+ named parameters.
+str_replace( search: [ 'foo', 'bar' ], replace: 'baz', count: $count ); // OK, well not really, missing required $subject param, but not our concern.
+str_replace( search: 'foo', replace: 'baz', subjects: [ 'foobar', 'foobar' ] ); // OK, well not really, typo in $subject param name, not our concern.
+str_replace( subject: $subject, count: $count, replace: 'baz', search: 'foo', ); // OK, different parameter order.
+
+str_replace( count: $count, subject: [ 'foobar', 'foobar' ], search: 'foo', replace: 'baz', ); // Bad with different parameter order.
+str_replace( [ 'foo', 'bar' ], 'baz', count: $count, subject: 'foobar' ); // Bad, with mixed named and unnamed params.

--- a/WordPressVIPMinimum/Tests/Security/StaticStrreplaceUnitTest.inc
+++ b/WordPressVIPMinimum/Tests/Security/StaticStrreplaceUnitTest.inc
@@ -1,13 +1,56 @@
 <?php
 
+/*
+ * Not the sniff target.
+ */
+use str_replace;
+
+my\ns\str_replace('foo', 'bar', 'foobar');
+$this->str_replace('foo', 'bar', 'foobar');
+$this?->str_replace('foo', 'bar', 'foobar');
+MyClass::str_replace('foo', 'bar', 'foobar');
+echo STR_REPLACE;
+namespace\str_replace('foo', 'bar', 'foobar');
+
+// Looks like a function call, but is a PHP 8.0+ class instantiation via an attribute.
+#[Str_Replace('foo', 'bar', 'foobar')]
+function foo() {}
+
+// Ignore PHP 5.6 argument unpacking.
+str_replace('foo', 'bar', ...$params);
+
+// Ignore PHP 8.1 first class callable.
+add_filter('my_filter', str_replace(...));
+
+// Incomplete function calls, should be ignored by the sniff.
+str_replace();
+str_replace('foo', 'bar');
+
+
+/*
+ * These should all be okay.
+ */
+str_replace( $foo->getSearch(), 'bar', 'foobar' );
+\str_replace( 'foo', $bar, 'foobar' );
+str_replace( 'foo', 'bar', $foobar, );
+STR_REPLACE( $foo, $bar, 'foobar' );
+str_replace( 'foo', get_replacements(), $foobar );
+
+str_replace( array( 'foo', "$bar" ), $bar, 'foobar' );
+
+str_replace( array( $foo, $bar ), array( 'bar', 'foo' ), array( 'foobar', 'foobar' ) );
+\Str_Replace( [ 'foo', 'bar' ], array( $foo, SOME_CONSTANT ), 'foobar' );
+str_replace( array( 'foo', "bar" ), [ 'bar', 'foo' ], $foobar, );
+str_replace( [ $foo, $bar->prop ], /*comment*/ [ 'bar', 'foo' ], $foobar );
+
+
+/*
+ * These should all be flagged with a warning.
+ */
 str_replace( 'foo', 'bar', 'foobar' ); // Bad.
-
-str_replace( 'foo', 'bar', $foobar ); // Ok.
-
-str_replace( array( 'foo', 'bar' ), array( 'bar', 'foo' ), 'foobar' ); // Bad.
-
-str_replace( array( 'foo', 'bar' ), array( 'bar', 'foo' ), $foobar ); // Ok.
-
-str_replace( array( 'foo', 'bar' ), array( $foo, $bar ), $foobar ); // Ok.
-
-str_replace( array( $foo, $bar ), array( 'bar', 'foo' ), $foobar ); // Ok.
+Str_replace(
+	'foo', // Comment.
+	'bar', /* comment */
+	'foobar'
+); // Bad.
+str_replace( array( 'foo', 'bar' ), array( 'bar', 'foo' ), array( 'foobar', 'foobar' ) ); // Bad.

--- a/WordPressVIPMinimum/Tests/Security/StaticStrreplaceUnitTest.inc
+++ b/WordPressVIPMinimum/Tests/Security/StaticStrreplaceUnitTest.inc
@@ -10,7 +10,7 @@ $this->str_replace('foo', 'bar', 'foobar');
 $this?->str_replace('foo', 'bar', 'foobar');
 MyClass::str_replace('foo', 'bar', 'foobar');
 echo STR_REPLACE;
-namespace\str_replace('foo', 'bar', 'foobar');
+namespace\str_replace('foo', 'bar', 'foobar', $count);
 
 // Looks like a function call, but is a PHP 8.0+ class instantiation via an attribute.
 #[Str_Replace('foo', 'bar', 'foobar')]
@@ -34,7 +34,7 @@ str_replace( $foo->getSearch(), 'bar', 'foobar' );
 \str_replace( 'foo', $bar, 'foobar' );
 str_replace( 'foo', 'bar', $foobar, );
 STR_REPLACE( $foo, $bar, 'foobar' );
-str_replace( 'foo', get_replacements(), $foobar );
+str_replace( 'foo', get_replacements(), $foobar, $count );
 
 str_replace( array( 'foo', "$bar" ), $bar, 'foobar' );
 
@@ -54,3 +54,4 @@ Str_replace(
 	'foobar'
 ); // Bad.
 str_replace( array( 'foo', 'bar' ), array( 'bar', 'foo' ), array( 'foobar', 'foobar' ) ); // Bad.
+str_replace( 'foo', 'bar', 'foobar', $count ); // Bad.

--- a/WordPressVIPMinimum/Tests/Security/StaticStrreplaceUnitTest.inc
+++ b/WordPressVIPMinimum/Tests/Security/StaticStrreplaceUnitTest.inc
@@ -69,3 +69,33 @@ str_replace( subject: $subject, count: $count, replace: 'baz', search: 'foo', );
 
 str_replace( count: $count, subject: [ 'foobar', 'foobar' ], search: 'foo', replace: 'baz', ); // Bad with different parameter order.
 str_replace( [ 'foo', 'bar' ], 'baz', count: $count, subject: 'foobar' ); // Bad, with mixed named and unnamed params.
+
+// Make sure some variations of how plain strings can be passed are handled.
+str_replace( 'fo' . 'o', 'bar', 'foobar' ); // Bad.
+str_replace( array( 'foo', 'bar' ) + array( 'baz', 'fop' ), array( 'bar', 'foo' ), 'foobar' ); // Bad.
+
+// Safeguard correct handling of PHP 5.3+ nowdocs.
+str_replace(
+	'foo',
+	'bar',
+	<<<'EOD'
+foobar
+EOD
+); // Bad.
+
+// Safeguard correct handling of heredocs without interpolation.
+str_replace( array(<<<EOD
+foo
+EOD
+	),
+	'bar',
+	<<<"EOD"
+foobar
+EOD
+); // Bad.
+
+// Ensure heredocs with interpolation are ignored.
+str_replace( 'foo', 'bar', <<<EOD
+Some text and $foobar
+EOD
+); // OK.

--- a/WordPressVIPMinimum/Tests/Security/StaticStrreplaceUnitTest.inc
+++ b/WordPressVIPMinimum/Tests/Security/StaticStrreplaceUnitTest.inc
@@ -55,3 +55,9 @@ Str_replace(
 ); // Bad.
 str_replace( array( 'foo', 'bar' ), array( 'bar', 'foo' ), array( 'foobar', 'foobar' ) ); // Bad.
 str_replace( 'foo', 'bar', 'foobar', $count ); // Bad.
+
+// Handle PHP 5.4+ short array syntax correctly.
+\str_replace( [ 'foo', 'bar' ], [ 'bar', 'foo' ], [ 'foobar', 'foobar' ], ); // Bad.
+
+// Don't confuse PHP 7.1+ short list with short array.
+str_replace( [ $a, $b ] = $search, [ 'bar', 'foo' ], 'foobar', ); // OK.

--- a/WordPressVIPMinimum/Tests/Security/StaticStrreplaceUnitTest.php
+++ b/WordPressVIPMinimum/Tests/Security/StaticStrreplaceUnitTest.php
@@ -27,6 +27,7 @@ class StaticStrreplaceUnitTest extends AbstractSniffUnitTest {
 			51 => 1,
 			56 => 1,
 			57 => 1,
+			60 => 1,
 		];
 	}
 

--- a/WordPressVIPMinimum/Tests/Security/StaticStrreplaceUnitTest.php
+++ b/WordPressVIPMinimum/Tests/Security/StaticStrreplaceUnitTest.php
@@ -26,6 +26,7 @@ class StaticStrreplaceUnitTest extends AbstractSniffUnitTest {
 			50 => 1,
 			51 => 1,
 			56 => 1,
+			57 => 1,
 		];
 	}
 

--- a/WordPressVIPMinimum/Tests/Security/StaticStrreplaceUnitTest.php
+++ b/WordPressVIPMinimum/Tests/Security/StaticStrreplaceUnitTest.php
@@ -23,8 +23,9 @@ class StaticStrreplaceUnitTest extends AbstractSniffUnitTest {
 	 */
 	public function getErrorList() {
 		return [
-			3 => 1,
-			7 => 1,
+			50 => 1,
+			51 => 1,
+			56 => 1,
 		];
 	}
 

--- a/WordPressVIPMinimum/Tests/Security/StaticStrreplaceUnitTest.php
+++ b/WordPressVIPMinimum/Tests/Security/StaticStrreplaceUnitTest.php
@@ -30,6 +30,10 @@ class StaticStrreplaceUnitTest extends AbstractSniffUnitTest {
 			60 => 1,
 			70 => 1,
 			71 => 1,
+			74 => 1,
+			75 => 1,
+			78 => 1,
+			87 => 1,
 		];
 	}
 

--- a/WordPressVIPMinimum/Tests/Security/StaticStrreplaceUnitTest.php
+++ b/WordPressVIPMinimum/Tests/Security/StaticStrreplaceUnitTest.php
@@ -28,6 +28,8 @@ class StaticStrreplaceUnitTest extends AbstractSniffUnitTest {
 			56 => 1,
 			57 => 1,
 			60 => 1,
+			70 => 1,
+			71 => 1,
 		];
 	}
 


### PR DESCRIPTION
### Security/StaticStrreplace: extend AbstractFunctionParameterSniff 

As things were, the determination of whether or not a `T_STRING` is a call to the global PHP native `str_replace()` function was severely flawed.

By switching the sniff over to be based on the WordPressCS `AbstractFunctionParameterSniff` class, this flaw is mitigated.

Includes adding a slew of additional tests, some of which (line 8 - 13) are specific to the flaw being addressed in this commit.

Additionally, the tests have been made more comprehensive and varied by:
* Testing against false positives for calls to methods or namespaced function calls (= the issue being addressed in this PR).
* Testing against false positives for attribute class using the same name as the function.
* Ensure function import `use` statements are not flagged. We're not interested in those.
* Safeguarding that function calls using PHP 5.6+ argument unpacking are not flagged.
* Safeguarding that the function is not flagged when used as a PHP 8.1+ first class callable.
* Adding more variations to the pre-existing tests:
    - Non-lowercase function call(s).
    - Fully qualified function calls.
    - Use PHP 7.3+ trailing comma's in a few function calls.
    - Use both single quoted as well as double quoted text strings.
    - Use other non-plain-text tokens in the passed parameters.
    - Multi-line function call.
    - Comments in function call.
    - `$subject` parameter passed as array.

### Security/StaticStrreplace: add tests with optional fourth parameter 

... to ensure and safeguard the sniff does not get confused over that parameter.

Ref: https://www.php.net/manual/en/function.str-replace.php

### Security/StaticStrreplace: bug fix - false negatives for PHP 5.4+ short array parameters

Fixed now. Includes tests.
Note: some of the "should not be flagged" tests already use short arrays since the tests were expanded.

### Security/StaticStrreplace: use PHPCSUtils for array parsing 

As things were, the sniff walked the tokens in an array and expected a comma to always belong to the array, i.e. `[ 'text', 'text' ]`.
This falls foul as soon as the code being walked gets slightly more complex, like using nested arrays or dynamic values in the array: `[ 'text', [ $a, $b ], fnc( 'text', 'next' ) ]`.

Now, at this time, this is not strictly problematic for this sniff as it will bow out for any token which is not a `T_CONSTANT_ENCAPSED_STRING`, so would bow out for nested arrays and dynamic values.

Having said this, using the PHPCSUtils `PassedParameters::getParameters()` for parsing an array to it's individual items should still make the code more stable and also benefits from the PHPCSUtils build-in caching.

### Security/StaticStrreplace: use pre-parsed function call argument information / support PHP 8.0+ named arguments

As things were, the sniff walked the tokens in the function call itself, but what with the switch to extending the `AbstractFunctionParameterSniff` class, we already have the start and end pointers of each passed parameter available, so let's start using that information instead of doing the token walking within the sniff.

By using the pre-parsed information, the sniff automatically will start supporting the use of PHP 8.0+ named arguments in function calls.

Includes tests.

### Security/StaticStrreplace: handle more "static" tokens 

This commit primarily addresses that the sniff did not take PHP 5.3 nowdocs into account as "static text" tokens.

However, heredocs can also be "static text" if there is no interpolation and there are some other variants of valid code which would still make the code effectively "static text".

Fixed now by checking the code more thoroughly.

The actual checking has been moved to a new `is_parameter_static_text()` method as if the passed parameter is an array, the same checks would need to be done again for each array item. By having the check in a separate method, the method can recursively call itself for array items.

Includes tests.

Closes #544