### PR TITLE
Classes/RestrictedExtendClasses: various minor improvements

### DIFF
--- a/WordPressVIPMinimum/Sniffs/Classes/RestrictedExtendClassesSniff.php
+++ b/WordPressVIPMinimum/Sniffs/Classes/RestrictedExtendClassesSniff.php
@@ -9,6 +9,7 @@
 
 namespace WordPressVIPMinimum\Sniffs\Classes;
 
+use PHPCSUtils\Utils\MessageHelper;
 use WordPressCS\WordPress\AbstractClassRestrictionsSniff;
 
 /**
@@ -61,7 +62,8 @@ class RestrictedExtendClassesSniff extends AbstractClassRestrictionsSniff {
 	 */
 	public function process_matched_token( $stackPtr, $group_name, $matched_content ) {
 		foreach ( $this->getGroups() as $group => $group_args ) {
-			$this->phpcsFile->{ 'add' . $group_args['type'] }( $group_args['message'], $stackPtr, $group );
+			$isError = ( $group_args['type'] === 'error' );
+			MessageHelper::addMessage( $this->phpcsFile, $group_args['message'], $stackPtr, $isError, $group );
 		}
 	}
 }

--- a/WordPressVIPMinimum/Sniffs/Classes/RestrictedExtendClassesSniff.php
+++ b/WordPressVIPMinimum/Sniffs/Classes/RestrictedExtendClassesSniff.php
@@ -36,6 +36,20 @@ class RestrictedExtendClassesSniff extends AbstractClassRestrictionsSniff {
 	}
 
 	/**
+	 * Returns an array of tokens this test wants to listen for.
+	 *
+	 * @return array<int|string>
+	 */
+	public function register() {
+		$targets = parent::register();
+		if ( empty( $targets ) ) {
+			return $targets;
+		}
+
+		return [ T_EXTENDS ];
+	}
+
+	/**
 	 * Process a matched token.
 	 *
 	 * @param int    $stackPtr        The position of the current token in the stack.
@@ -46,13 +60,6 @@ class RestrictedExtendClassesSniff extends AbstractClassRestrictionsSniff {
 	 * @return void
 	 */
 	public function process_matched_token( $stackPtr, $group_name, $matched_content ) {
-		$tokens = $this->phpcsFile->getTokens();
-
-		if ( $tokens[ $stackPtr ]['code'] !== T_EXTENDS ) {
-			// If not extending, bail.
-			return;
-		}
-
 		foreach ( $this->getGroups() as $group => $group_args ) {
 			$this->phpcsFile->{ 'add' . $group_args['type'] }( $group_args['message'], $stackPtr, $group );
 		}

--- a/WordPressVIPMinimum/Tests/Classes/RestrictedExtendClassesUnitTest.inc
+++ b/WordPressVIPMinimum/Tests/Classes/RestrictedExtendClassesUnitTest.inc
@@ -2,11 +2,21 @@
 
 class OkTestClass extends WPCOM_VIP_CLI_Command { } // Ok - correct class.
 class  AnotherOkTestClass  extends   WPC__CLI_Command { } // Ok - spacing + similar class.
-class Ok_TestClass extends wpcom_vip_cli_command { } // Ok - lowercase correct class.
-class Ok_Test_Class extends WpCoM_VIP_cli_command { } // Ok - mixed case correct class.
+class Ok_TestClass extends \wpcom_vip_cli_command { } // Ok - lowercase correct class.
+$ok = new class extends WpCoM_VIP_cli_command { }; // Ok - mixed case correct class.
 class WP_CLI_Command { } // Ok - not extending.
 
 class BadTestClass extends WP_CLI_Command { } // Warning - wrong class.
-class AnotherBadTestClass extends wp_CLI_comMand { } // Warning - mixed case wrong class.
-class AnotherBad_TestClass   extends   WP_CLI_comMand { } // Warning - spacing + mixed case wrong class.
+class AnotherBadTestClass extends \wp_CLI_comMand { } // Warning - mixed case wrong class.
+$bad = new class()   extends   WP_CLI_comMand { }; // Warning - spacing + mixed case wrong class.
 class Bad_Test_Class extends wp_cli_command { } // Warning - lowercase wrong class.
+
+// phpcs:set WordPressVIPMinimum.Classes.RestrictedExtendClasses exclude[] wp_cli
+class IgnoredClass extends WP_CLI_Command { } // OK, group is excluded.
+
+// Reset to the default value.
+// phpcs:set WordPressVIPMinimum.Classes.RestrictedExtendClasses exclude[]
+
+class Ok_NotTheTargetFQN extends \Fully\Qualified\WP_CLI_Command { } // Ok - not the right namespace.
+class Ok_NotTheTargetPQN extends Partially\Qualified\WP_CLI_Command { } // Ok - not the right namespace.
+class Bad_NamespaceRelative extends namespace\WP_CLI_Command { } // Warning - this is not a namespaced file, so "namespace" resolves to the global namespace.

--- a/WordPressVIPMinimum/Tests/Classes/RestrictedExtendClassesUnitTest.php
+++ b/WordPressVIPMinimum/Tests/Classes/RestrictedExtendClassesUnitTest.php
@@ -36,6 +36,7 @@ class RestrictedExtendClassesUnitTest extends AbstractSniffUnitTest {
 			10 => 1,
 			11 => 1,
 			12 => 1,
+			22 => 1,
 		];
 	}
 }


### PR DESCRIPTION
### Classes/RestrictedExtendClasses: improve the tests 

Add tests with:
* Variations of namespaced class names.
* Anonymous classes extending.
* Group exclusion, as supported via the extended abstract.

### Classes/RestrictedExtendClasses: efficiency fix 

The `AbstractClassRestrictionsSniff` class does quite a lot of processing before passing off to the `process_matched_token()` method, which can cause quite some overhead for a sniff like this, which is only interested in a class being extended, so let's make it so this sniff only listens to the `T_EXTENDS` token.

This should make the sniff significantly faster.

### Classes/RestrictedExtendClasses: minor tweak 

Not strictly necessary, but improves the code readability a little.

Closes #510