### PR TITLE
Composer: raise the minimum supported versions of all CS dependencies 

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,11 +16,11 @@ The rulesets use rules from the [WordPress Coding Standards](https://github.com/
 ## Minimal requirements
 
 * PHP 5.4+
-* [PHPCS 3.8.0+](https://github.com/PHPCSStandards/PHP_CodeSniffer/releases)
-* [PHPCSUtils 1.0.9+](https://github.com/PHPCSStandards/PHPCSUtils)
-* [PHPCSExtra 1.2.1+](https://github.com/PHPCSStandards/PHPCSExtra)
-* [WPCS 3.0.0+](https://github.com/WordPress-Coding-Standards/WordPress-Coding-Standards/releases)
-* [VariableAnalysis 2.11.17+](https://github.com/sirbrillig/phpcs-variable-analysis/releases)
+* [PHPCS 3.13.2+](https://github.com/PHPCSStandards/PHP_CodeSniffer/releases)
+* [PHPCSUtils 1.1.0+](https://github.com/PHPCSStandards/PHPCSUtils)
+* [PHPCSExtra 1.4.0+](https://github.com/PHPCSStandards/PHPCSExtra)
+* [WPCS 3.1.0+](https://github.com/WordPress-Coding-Standards/WordPress-Coding-Standards/releases)
+* [VariableAnalysis 2.12.0+](https://github.com/sirbrillig/phpcs-variable-analysis/releases)
 
 ## Installation
 

--- a/WordPressVIPMinimum/Sniffs/Performance/FetchingRemoteDataSniff.php
+++ b/WordPressVIPMinimum/Sniffs/Performance/FetchingRemoteDataSniff.php
@@ -95,40 +95,6 @@ class FetchingRemoteDataSniff extends AbstractFunctionParameterSniff {
 	}
 
 	/**
-	 * Process the function if no parameters were found.
-	 *
-	 * {@internal This method is only needed for handling PHP 8.1+ first class callables on WPCS < 3.2.0.
-	 * Once the minimum supported WPCS is 3.2.0 or higher, this method should be removed.}
-	 *
-	 * @param int    $stackPtr        The position of the current token in the stack.
-	 * @param string $group_name      The name of the group which was matched.
-	 * @param string $matched_content The token content (function name) which was matched
-	 *                                in lowercase.
-	 *
-	 * @return void
-	 */
-	public function process_no_parameters( $stackPtr, $group_name, $matched_content ) {
-		// Check if this is a first class callable.
-		$next = $this->phpcsFile->findNext( Tokens::$emptyTokens, ( $stackPtr + 1 ), null, true );
-		if ( $next === false
-			|| $this->tokens[ $next ]['code'] !== T_OPEN_PARENTHESIS
-			|| isset( $this->tokens[ $next ]['parenthesis_closer'] ) === false
-		) {
-			// Live coding/parse error. Ignore.
-			return;
-		}
-
-		// First class callable.
-		$firstNonEmpty = $this->phpcsFile->findNext( Tokens::$emptyTokens, ( $next + 1 ), null, true );
-		if ( $this->tokens[ $firstNonEmpty ]['code'] === T_ELLIPSIS ) {
-			$secondNonEmpty = $this->phpcsFile->findNext( Tokens::$emptyTokens, ( $firstNonEmpty + 1 ), null, true );
-			if ( $this->tokens[ $secondNonEmpty ]['code'] === T_CLOSE_PARENTHESIS ) {
-				$this->add_contents_unknown_warning( $stackPtr, [ $matched_content ] );
-			}
-		}
-	}
-
-	/**
 	 * Process the function if it is used as a first class callable.
 	 *
 	 * @param int    $stackPtr        The position of the current token in the stack.

--- a/composer.json
+++ b/composer.json
@@ -17,17 +17,17 @@
 	],
 	"require": {
 		"php": ">=5.4",
-		"phpcsstandards/phpcsextra": "^1.2.1",
-		"phpcsstandards/phpcsutils": "^1.0.11",
-		"sirbrillig/phpcs-variable-analysis": "^2.11.18",
-		"squizlabs/php_codesniffer": "^3.9.2",
-		"wp-coding-standards/wpcs": "^3.1.0"
+		"phpcsstandards/phpcsextra": "^1.4.0",
+		"phpcsstandards/phpcsutils": "^1.1.0",
+		"sirbrillig/phpcs-variable-analysis": "^2.12.0",
+		"squizlabs/php_codesniffer": "^3.13.2",
+		"wp-coding-standards/wpcs": "^3.2.0"
 	},
 	"require-dev": {
 		"php-parallel-lint/php-parallel-lint": "^1.4.0",
 		"php-parallel-lint/php-console-highlighter": "^1.0.0",
 		"phpcompatibility/php-compatibility": "^9",
-		"phpcsstandards/phpcsdevtools": "^1.0",
+		"phpcsstandards/phpcsdevtools": "^1.2.3",
 		"phpunit/phpunit": "^4 || ^5 || ^6 || ^7 || ^8 || ^9"
 	},
 	"config": {


### PR DESCRIPTION
### Composer: raise the minimum supported versions of all CS dependencies 

... to benefit from new functionality and to ensure all minimum versions are versions compatible with PHPCS 4.0 (in so far as currently available - VariableAnalysis, WordPressCS and PHPCompatibility are not yet compatible with PHPCS 4.0).

Includes updating the README which was missed for the previous Composer update.

Refs:
* https://github.com/PHPCSStandards/PHPCSUtils/releases
* https://github.com/PHPCSStandards/PHP_CodeSniffer/releases
* https://github.com/PHPCSStandards/PHPCSExtra/releases
* https://github.com/sirbrillig/phpcs-variable-analysis/releases
* https://github.com/PHPCSStandards/PHPCSDevTools/releases
* https://github.com/WordPress/WordPress-Coding-Standards/releases

### Performance/FetchingRemoteData: remove redundant method 

This method was introduced in PR #855 as a temporary stop-gap to allow for supporting PHP 8.1+ first class callables.

As of WPCS 3.2.0, first class callables are no longer passed to the `process_no_parameters()` method, but to the new dedicated `process_first_class_callable()` method, so this method is no longer needed.