### PR TITLE
Ruleset: improve include/exclude patterns

### DIFF
--- a/WordPressVIPMinimum/ruleset.xml
+++ b/WordPressVIPMinimum/ruleset.xml
@@ -28,7 +28,7 @@
 	</rule>
 
 	<rule ref="WordPressVIPMinimum.Security.Twig">
-		<include-pattern>*.twig</include-pattern>
+		<include-pattern>*\.twig</include-pattern>
 	</rule>
 
 	<rule ref="WordPress.Security.EscapeOutput"/>
@@ -67,10 +67,10 @@
 	<rule ref="Squiz.WhiteSpace.SuperfluousWhitespace">
 		<exclude name="Squiz.WhiteSpace.SuperfluousWhitespace.EmptyLines"/>
 		<exclude name="Squiz.WhiteSpace.SuperfluousWhitespace.EndLine"/>
-		<include-pattern>*.php</include-pattern>
-		<include-pattern>*.inc</include-pattern>
-		<exclude-pattern>*.js</exclude-pattern>
-		<exclude-pattern>*.css</exclude-pattern>
+		<include-pattern>*\.php</include-pattern>
+		<include-pattern>*\.inc</include-pattern>
+		<exclude-pattern>*\.js</exclude-pattern>
+		<exclude-pattern>*\.css</exclude-pattern>
 	</rule>
 	<rule ref="Squiz.PHP.CommentedOutCode"/>
 


### PR DESCRIPTION
`include-pattern` and `exclude-pattern` directives are a special flavour of regular expressions.

From the documentation:
> Important
>
> The ignore patterns are treated as regular expressions. If you do specify a regular expression, be aware that `*` is converted to `.*` for convenience in simple patterns, like those used in the example above. So use `*` anywhere you would normally use `.*`. Also ensure you escape any `.` characters that you want treated as a literal dot, such as when checking file extensions. So if you are checking for `.inc` in your ignore pattern, use `\.inc` instead.

This commit fixes unescaped characters which have special meaning in regular expressions to ensure they are interpreted as literals.

Ref: https://github.com/PHPCSStandards/PHP_CodeSniffer/wiki/Advanced-Usage#ignoring-files-and-folders