### PR TITLE
UserExperience/AdminBarRemoval: various improvements

### DIFF
--- a/WordPressVIPMinimum/Sniffs/UserExperience/AdminBarRemovalSniff.php
+++ b/WordPressVIPMinimum/Sniffs/UserExperience/AdminBarRemovalSniff.php
@@ -201,19 +201,21 @@ class AdminBarRemovalSniff extends AbstractFunctionParameterSniff {
 		switch ( $matched_content ) {
 			case 'show_admin_bar':
 				$error = true;
-				if ( $this->remove_only === true && $parameters[1]['raw'] === 'true' ) {
+				if ( $this->remove_only === true && $parameters[1]['clean'] === 'true' ) {
 					$error = false;
 				}
 				break;
 
 			case 'add_filter':
-				$filter_name = TextStrings::stripQuotes( $parameters[1]['raw'] );
+				$filter_name = TextStrings::stripQuotes( $parameters[1]['clean'] );
 				if ( $filter_name !== 'show_admin_bar' ) {
 					break;
 				}
 
 				$error = true;
-				if ( $this->remove_only === true && isset( $parameters[2]['raw'] ) && TextStrings::stripQuotes( $parameters[2]['raw'] ) === '__return_true' ) {
+				if ( $this->remove_only === true && isset( $parameters[2]['clean'] )
+					&& TextStrings::stripQuotes( $parameters[2]['clean'] ) === '__return_true'
+				) {
 					$error = false;
 				}
 				break;

--- a/WordPressVIPMinimum/Sniffs/UserExperience/AdminBarRemovalSniff.php
+++ b/WordPressVIPMinimum/Sniffs/UserExperience/AdminBarRemovalSniff.php
@@ -11,6 +11,7 @@
 namespace WordPressVIPMinimum\Sniffs\UserExperience;
 
 use PHP_CodeSniffer\Util\Tokens;
+use PHPCSUtils\Utils\FilePath;
 use PHPCSUtils\Utils\GetTokensAsString;
 use PHPCSUtils\Utils\PassedParameters;
 use PHPCSUtils\Utils\TextStrings;
@@ -158,7 +159,7 @@ class AdminBarRemovalSniff extends AbstractFunctionParameterSniff {
 	 */
 	public function process_token( $stackPtr ) {
 
-		$file_name      = $this->phpcsFile->getFilename();
+		$file_name      = FilePath::getName( $this->phpcsFile );
 		$file_extension = substr( strrchr( $file_name, '.' ), 1 );
 
 		if ( $file_extension === 'css' ) {

--- a/WordPressVIPMinimum/Sniffs/UserExperience/AdminBarRemovalSniff.php
+++ b/WordPressVIPMinimum/Sniffs/UserExperience/AdminBarRemovalSniff.php
@@ -12,6 +12,7 @@ namespace WordPressVIPMinimum\Sniffs\UserExperience;
 
 use PHP_CodeSniffer\Util\Tokens;
 use PHPCSUtils\Utils\GetTokensAsString;
+use PHPCSUtils\Utils\PassedParameters;
 use PHPCSUtils\Utils\TextStrings;
 use WordPressCS\WordPress\AbstractFunctionParameterSniff;
 
@@ -200,21 +201,32 @@ class AdminBarRemovalSniff extends AbstractFunctionParameterSniff {
 		$error = false;
 		switch ( $matched_content ) {
 			case 'show_admin_bar':
+				$show_param = PassedParameters::getParameterFromStack( $parameters, 1, 'show' );
+				if ( $show_param === false ) {
+					break;
+				}
+
 				$error = true;
-				if ( $this->remove_only === true && $parameters[1]['clean'] === 'true' ) {
+				if ( $this->remove_only === true && $show_param['clean'] === 'true' ) {
 					$error = false;
 				}
 				break;
 
 			case 'add_filter':
-				$filter_name = TextStrings::stripQuotes( $parameters[1]['clean'] );
+				$hook_name_param = PassedParameters::getParameterFromStack( $parameters, 1, 'hook_name' );
+				if ( $hook_name_param === false ) {
+					break;
+				}
+
+				$filter_name = TextStrings::stripQuotes( $hook_name_param['clean'] );
 				if ( $filter_name !== 'show_admin_bar' ) {
 					break;
 				}
 
-				$error = true;
-				if ( $this->remove_only === true && isset( $parameters[2]['clean'] )
-					&& TextStrings::stripQuotes( $parameters[2]['clean'] ) === '__return_true'
+				$callback_param = PassedParameters::getParameterFromStack( $parameters, 2, 'callback' );
+				$error          = true;
+				if ( $this->remove_only === true && $callback_param !== false
+					&& TextStrings::stripQuotes( $callback_param['clean'] ) === '__return_true'
 				) {
 					$error = false;
 				}

--- a/WordPressVIPMinimum/Sniffs/UserExperience/AdminBarRemovalSniff.php
+++ b/WordPressVIPMinimum/Sniffs/UserExperience/AdminBarRemovalSniff.php
@@ -160,7 +160,7 @@ class AdminBarRemovalSniff extends AbstractFunctionParameterSniff {
 	public function process_token( $stackPtr ) {
 
 		$file_name      = FilePath::getName( $this->phpcsFile );
-		$file_extension = substr( strrchr( $file_name, '.' ), 1 );
+		$file_extension = pathinfo( $file_name, \PATHINFO_EXTENSION );
 
 		if ( $file_extension === 'css' ) {
 			if ( $this->tokens[ $stackPtr ]['code'] === \T_STYLE ) {

--- a/WordPressVIPMinimum/Sniffs/UserExperience/AdminBarRemovalSniff.php
+++ b/WordPressVIPMinimum/Sniffs/UserExperience/AdminBarRemovalSniff.php
@@ -228,7 +228,7 @@ class AdminBarRemovalSniff extends AbstractFunctionParameterSniff {
 				$callback_param = PassedParameters::getParameterFromStack( $parameters, 2, 'callback' );
 				$error          = true;
 				if ( $this->remove_only === true && $callback_param !== false ) {
-					$clean_param = TextStrings::stripQuotes( $callback_param['clean'] );
+					$clean_param = strtolower( TextStrings::stripQuotes( $callback_param['clean'] ) );
 
 					$expected           = Tokens::$emptyTokens + Tokens::$stringTokens;
 					$has_non_textstring = $this->phpcsFile->findNext( $expected, $callback_param['start'], ( $callback_param['end'] + 1 ), true );

--- a/WordPressVIPMinimum/Sniffs/UserExperience/AdminBarRemovalSniff.php
+++ b/WordPressVIPMinimum/Sniffs/UserExperience/AdminBarRemovalSniff.php
@@ -53,6 +53,7 @@ class AdminBarRemovalSniff extends AbstractFunctionParameterSniff {
 	protected $target_functions = [
 		'show_admin_bar' => true,
 		'add_filter'     => true,
+		'add_action'     => true, // Alias of add_filter().
 	];
 
 	/**
@@ -212,6 +213,7 @@ class AdminBarRemovalSniff extends AbstractFunctionParameterSniff {
 				}
 				break;
 
+			case 'add_action':
 			case 'add_filter':
 				$hook_name_param = PassedParameters::getParameterFromStack( $parameters, 1, 'hook_name' );
 				if ( $hook_name_param === false ) {

--- a/WordPressVIPMinimum/Sniffs/UserExperience/AdminBarRemovalSniff.php
+++ b/WordPressVIPMinimum/Sniffs/UserExperience/AdminBarRemovalSniff.php
@@ -227,10 +227,17 @@ class AdminBarRemovalSniff extends AbstractFunctionParameterSniff {
 
 				$callback_param = PassedParameters::getParameterFromStack( $parameters, 2, 'callback' );
 				$error          = true;
-				if ( $this->remove_only === true && $callback_param !== false
-					&& TextStrings::stripQuotes( $callback_param['clean'] ) === '__return_true'
-				) {
-					$error = false;
+				if ( $this->remove_only === true && $callback_param !== false ) {
+					$clean_param = TextStrings::stripQuotes( $callback_param['clean'] );
+
+					$expected           = Tokens::$emptyTokens + Tokens::$stringTokens;
+					$has_non_textstring = $this->phpcsFile->findNext( $expected, $callback_param['start'], ( $callback_param['end'] + 1 ), true );
+					if ( ( $has_non_textstring === false && $clean_param === '__return_true' )
+						|| ( $has_non_textstring !== false
+						&& preg_match( '`^\\\\?__return_true\s*\(\s*\.\.\.\s*\)$`', $clean_param ) === 1 )
+					) {
+						$error = false;
+					}
 				}
 				break;
 		}

--- a/WordPressVIPMinimum/Tests/UserExperience/AdminBarRemovalUnitTest.inc
+++ b/WordPressVIPMinimum/Tests/UserExperience/AdminBarRemovalUnitTest.inc
@@ -177,3 +177,7 @@ add_filter( 'show_admin_bar', \__return_true( ... ) ); // OK.
 add_action( 'show_admin_bar', __return_false  (   ...   )  , ); // Bad.
 add_filter( 'show_admin_bar', \__return_false(...) ); // Bad.
 add_filter( 'show_admin_bar', "__return_true(...)" ); // Bad. Invalid callback.
+
+// Bug fix: function names are case-insensitive.
+\add_filter( "show_admin_bar", '__Return_TRUE' ); // OK.
+add_filter( 'show_admin_bar', __Return_True(...) ); // OK.

--- a/WordPressVIPMinimum/Tests/UserExperience/AdminBarRemovalUnitTest.inc
+++ b/WordPressVIPMinimum/Tests/UserExperience/AdminBarRemovalUnitTest.inc
@@ -107,3 +107,39 @@ EOT;
 </style>
 <?php
 /* phpcs:set WordPressVIPMinimum.UserExperience.AdminBarRemoval remove_only true */
+
+/*
+ * Safeguard against false positives for method calls and namespaced function calls
+ * and various other syntaxes.
+ */
+my\ns\show_admin_bar( false ); // OK.
+$this->show_admin_bar( false ); // OK.
+$this?->show_admin_bar( false ); // OK.
+MyClass::add_filter( 'show_admin_bar', '__return_false' ); // OK.
+echo ADD_FILTER; // OK.
+namespace\add_filter( 'show_admin_bar', '__return_false' ); // OK.
+
+#[Show_Admin_Bar(false)] // OK. PHP 8.0+ class instantiation via an attribute. Can't contain a nested function call anyway.
+function foo() {}
+
+array_walk($filters, \add_filter(...),); // OK. PHP 8.1 first class callable.
+
+// Incomplete function calls, should be ignored by the sniff.
+$incorrect_but_ok = show_admin_bar(); // OK.
+$incorrect_but_ok = add_filter(); // OK.
+
+// Safeguard that the sniff only flags the "show_admin_bar" filter.
+add_filter( 'not_show_admin_bar', '__return_false', ); // OK.
+
+// Document that dynamic values will be flagged.
+show_admin_bar( $unknown ); // Bad.
+add_filter( 'show_admin_bar', $callable, ); // Bad.
+add_filter('show_admin_bar', ...$params); // Bad. PHP 5.6 argument unpacking.
+
+// Document that fully qualified function calls and functions in unconventional case will correctly be recognized.
+\add_filter( "show_admin_bar", '__return_true' ); // OK.
+\Add_Filter( 'show_admin_bar', "__return_false", ); // Bad.
+
+\show_Admin_bar( true, ); // OK.
+\show_admin_bar( false ); // Bad.
+\SHOW_ADMIN_BAR( false, ); // Bad.

--- a/WordPressVIPMinimum/Tests/UserExperience/AdminBarRemovalUnitTest.inc
+++ b/WordPressVIPMinimum/Tests/UserExperience/AdminBarRemovalUnitTest.inc
@@ -170,3 +170,10 @@ add_filter( callback: '__return_true', hook_name: 'show_admin_bar', ); // Ok.
 
 // Bug: add_action() is an alias of add_filter.
 add_action( 'show_admin_bar', $callable, ); // Bad.
+
+// Safeguard handling of filter callback being passed as PHP 8.1+ first class callable.
+add_filter( 'show_admin_bar', __return_true(...) ); // OK.
+add_filter( 'show_admin_bar', \__return_true( ... ) ); // OK.
+add_action( 'show_admin_bar', __return_false  (   ...   )  , ); // Bad.
+add_filter( 'show_admin_bar', \__return_false(...) ); // Bad.
+add_filter( 'show_admin_bar', "__return_true(...)" ); // Bad. Invalid callback.

--- a/WordPressVIPMinimum/Tests/UserExperience/AdminBarRemovalUnitTest.inc
+++ b/WordPressVIPMinimum/Tests/UserExperience/AdminBarRemovalUnitTest.inc
@@ -167,3 +167,6 @@ add_filter(callback: '__return_false', priority: 10); // OK, well, not really, m
 add_filter(hookName: 'show_admin_bar', callback: '__return_false',); // OK, well, not really, typo in param name, but that's not the concern of the sniff.
 add_filter( callback: '__return_true', hook_name: 'show_admin_bar', ); // Ok.
 \add_filter( callback: '__return_false', hook_name: 'show_admin_bar', ); // Bad.
+
+// Bug: add_action() is an alias of add_filter.
+add_action( 'show_admin_bar', $callable, ); // Bad.

--- a/WordPressVIPMinimum/Tests/UserExperience/AdminBarRemovalUnitTest.inc
+++ b/WordPressVIPMinimum/Tests/UserExperience/AdminBarRemovalUnitTest.inc
@@ -156,3 +156,14 @@ add_filter(
 	// Turn it on.
 	'__return_true'
 ); // OK.
+
+// Safeguard handling of function calls using PHP 8.0+ named parameters.
+show_admin_bar( shown: false ); // OK, well not really, typo in param name, but that's not the concern of the sniff.
+\show_admin_bar( show: true ); // OK.
+show_admin_bar( show: $toggle ); // Bad.
+
+add_filter(callback: '__return_false', priority: 10); // OK, well, not really, missing required $hook_name param, but that's not the concern of this sniff.
+\add_filter(callback: '__return_false', hook_name: 'not_our_target'); // OK.
+add_filter(hookName: 'show_admin_bar', callback: '__return_false',); // OK, well, not really, typo in param name, but that's not the concern of the sniff.
+add_filter( callback: '__return_true', hook_name: 'show_admin_bar', ); // Ok.
+\add_filter( callback: '__return_false', hook_name: 'show_admin_bar', ); // Bad.

--- a/WordPressVIPMinimum/Tests/UserExperience/AdminBarRemovalUnitTest.inc
+++ b/WordPressVIPMinimum/Tests/UserExperience/AdminBarRemovalUnitTest.inc
@@ -143,3 +143,16 @@ add_filter('show_admin_bar', ...$params); // Bad. PHP 5.6 argument unpacking.
 \show_Admin_bar( true, ); // OK.
 \show_admin_bar( false ); // Bad.
 \SHOW_ADMIN_BAR( false, ); // Bad.
+
+// Comments in parameters should be ignored.
+show_admin_bar( true /* turn it on */ ); // OK.
+add_filter(
+	// Admin bar gives access to admin for users with the right permissions.
+	'show_admin_bar',
+	'__return_false'
+); // Bad.
+add_filter(
+	'show_admin_bar',
+	// Turn it on.
+	'__return_true'
+); // OK.

--- a/WordPressVIPMinimum/Tests/UserExperience/AdminBarRemovalUnitTest.php
+++ b/WordPressVIPMinimum/Tests/UserExperience/AdminBarRemovalUnitTest.php
@@ -57,6 +57,7 @@ class AdminBarRemovalUnitTest extends AbstractSniffUnitTest {
 					141 => 1,
 					144 => 1,
 					145 => 1,
+					149 => 1,
 				];
 
 			case 'AdminBarRemovalUnitTest.css':

--- a/WordPressVIPMinimum/Tests/UserExperience/AdminBarRemovalUnitTest.php
+++ b/WordPressVIPMinimum/Tests/UserExperience/AdminBarRemovalUnitTest.php
@@ -58,6 +58,8 @@ class AdminBarRemovalUnitTest extends AbstractSniffUnitTest {
 					144 => 1,
 					145 => 1,
 					149 => 1,
+					163 => 1,
+					169 => 1,
 				];
 
 			case 'AdminBarRemovalUnitTest.css':

--- a/WordPressVIPMinimum/Tests/UserExperience/AdminBarRemovalUnitTest.php
+++ b/WordPressVIPMinimum/Tests/UserExperience/AdminBarRemovalUnitTest.php
@@ -51,6 +51,12 @@ class AdminBarRemovalUnitTest extends AbstractSniffUnitTest {
 					103 => 1,
 					104 => 1,
 					105 => 1,
+					135 => 1,
+					136 => 1,
+					137 => 1,
+					141 => 1,
+					144 => 1,
+					145 => 1,
 				];
 
 			case 'AdminBarRemovalUnitTest.css':

--- a/WordPressVIPMinimum/Tests/UserExperience/AdminBarRemovalUnitTest.php
+++ b/WordPressVIPMinimum/Tests/UserExperience/AdminBarRemovalUnitTest.php
@@ -61,6 +61,9 @@ class AdminBarRemovalUnitTest extends AbstractSniffUnitTest {
 					163 => 1,
 					169 => 1,
 					172 => 1,
+					177 => 1,
+					178 => 1,
+					179 => 1,
 				];
 
 			case 'AdminBarRemovalUnitTest.css':

--- a/WordPressVIPMinimum/Tests/UserExperience/AdminBarRemovalUnitTest.php
+++ b/WordPressVIPMinimum/Tests/UserExperience/AdminBarRemovalUnitTest.php
@@ -60,6 +60,7 @@ class AdminBarRemovalUnitTest extends AbstractSniffUnitTest {
 					149 => 1,
 					163 => 1,
 					169 => 1,
+					172 => 1,
 				];
 
 			case 'AdminBarRemovalUnitTest.css':

--- a/WordPressVIPMinimum/Tests/UserExperience/AdminBarRemovalUnitTest.php
+++ b/WordPressVIPMinimum/Tests/UserExperience/AdminBarRemovalUnitTest.php
@@ -98,15 +98,6 @@ class AdminBarRemovalUnitTest extends AbstractSniffUnitTest {
 	 * @return array<int, int> Key is the line number, value is the number of expected warnings.
 	 */
 	public function getWarningList( $testFile = '' ) {
-		switch ( $testFile ) {
-			case 'AdminBarRemovalUnitTest.css':
-				return [];
-
-			case 'AdminBarRemovalUnitTest.inc':
-				return [];
-
-			default:
-				return [];
-		}
+		return [];
 	}
 }


### PR DESCRIPTION
### UserExperience/AdminBarRemoval: add additional tests 

* Testing against false positives for calls to methods or namespaced function calls (= the issue being addressed in this PR).
* Safeguarding that function calls using PHP 5.6+ argument unpacking are flagged.
* Safeguarding handling of PHP 8.0+ attribute class using the same name as a target function.
* Safeguarding that the function is not flagged when used as a PHP 8.1+ first class callable.
* Adding tests with more variations:
    - Non-lowercase function call(s).
    - Fully qualified function calls for the escaping functions.
    - Use PHP 7.3+ trailing comma's in a few function calls.
    - Text strings using single quotes and double quotes.

### UserExperience/AdminBarRemoval: bug fix - disregard comments in parameter values

The PHPCSUtils `PassedParameters::getParameters()` return value includes a `'clean'` array index, which contains the contents of the parameter stripped of surrounding whitespace and comments.

The `AdminBarRemoval` sniff uses the parameter contents in a couple of places to compare against a specific text string, but would break if the parameter value would contain a comment.

Fixed now. Includes tests.

### UserExperience/AdminBarRemoval: add support for handling PHP 8.0+ function calls using named parameters

Includes tests.

### UserExperience/AdminBarRemoval: bug fix - recognize add_action() as alias

... for `add_filter()`.

Includes test.

### UserExperience/AdminBarRemoval: add support for recognizing PHP 8.1+ first class callables

... when used as the `$callback` parameter for `add_filter()`/`add_action()`.

Includes tests.

### UserExperience/AdminBarRemoval: bug fix - function names are case-insensitive

... even when passed as callbacks.

Includes test.

### UserExperience/AdminBarRemoval: remove some redundant logic 

No need for a `switch` here.

### UserExperience/AdminBarRemoval: bug fix - CSS file might be handled as PHP file

A number of IDEs will use STDIN to run PHPCS and will pass the `stdin_path` to PHPCS to set the file name, which often results in the filename being quoted.

In that case, the original logic in this sniff would break as the `$file_extension` would end up being `'css"'`, which doesn't match the expected `'css'`.

The new PHPCSUtils 1.1.0 `FilePath::getName()` method will strip quotes from the file name, as well as normalize the slashes to forward (*nix) slashes.

Applying that method fixes the bug.

### UserExperience/AdminBarRemoval: minor simplification 

Let PHP sort out splitting the extension off the file name.