### PR TITLE
Security/Underscorejs: start using the PHPCSUtils `FilePath` utility

### DIFF
--- a/WordPressVIPMinimum/Sniffs/Security/UnderscorejsSniff.php
+++ b/WordPressVIPMinimum/Sniffs/Security/UnderscorejsSniff.php
@@ -10,6 +10,7 @@
 namespace WordPressVIPMinimum\Sniffs\Security;
 
 use PHP_CodeSniffer\Util\Tokens;
+use PHPCSUtils\Utils\FilePath;
 use PHPCSUtils\Utils\TextStrings;
 use WordPressVIPMinimum\Sniffs\Sniff;
 
@@ -72,7 +73,7 @@ class UnderscorejsSniff extends Sniff {
 		/*
 		 * Ignore Gruntfile.js files as they are configuration, not code.
 		 */
-		$file_name = TextStrings::stripQuotes( $this->phpcsFile->getFileName() );
+		$file_name = FilePath::getName( $this->phpcsFile );
 		$file_name = strtolower( basename( $file_name ) );
 
 		if ( $file_name === 'gruntfile.js' ) {


### PR DESCRIPTION
The `FilePath::getName()` method will strip quotes from the file name, as well as normalize the slashes to forward (*nix) slashes.

This allows for a minor simplication in the code and improves code readability.