### PR TITLE
Constants/RestrictedConstants: minor improvements

### DIFF
--- a/WordPressVIPMinimum/Sniffs/Constants/RestrictedConstantsSniff.php
+++ b/WordPressVIPMinimum/Sniffs/Constants/RestrictedConstantsSniff.php
@@ -126,7 +126,7 @@ class RestrictedConstantsSniff extends Sniff {
 			return;
 		}
 
-		if ( in_array( $this->tokens[ $previous ]['code'], Tokens::$functionNameTokens, true ) === true ) {
+		if ( $this->tokens[ $previous ]['code'] === T_STRING ) {
 			$data = [ $constantName ];
 			if ( $this->tokens[ $previous ]['content'] === 'define' ) {
 				$message = 'The definition of `%s` constant is prohibited. Please use a different name.';

--- a/WordPressVIPMinimum/Sniffs/Constants/RestrictedConstantsSniff.php
+++ b/WordPressVIPMinimum/Sniffs/Constants/RestrictedConstantsSniff.php
@@ -10,6 +10,7 @@
 namespace WordPressVIPMinimum\Sniffs\Constants;
 
 use PHP_CodeSniffer\Util\Tokens;
+use PHPCSUtils\Utils\TextStrings;
 use WordPressVIPMinimum\Sniffs\Sniff;
 
 /**
@@ -87,7 +88,7 @@ class RestrictedConstantsSniff extends Sniff {
 		if ( $this->tokens[ $stackPtr ]['code'] === T_STRING ) {
 			$constantName = $this->tokens[ $stackPtr ]['content'];
 		} else {
-			$constantName = trim( $this->tokens[ $stackPtr ]['content'], "\"'" );
+			$constantName = TextStrings::stripQuotes( $this->tokens[ $stackPtr ]['content'] );
 		}
 
 		if ( isset( $this->restrictedConstants[ $constantName ] ) === false

--- a/WordPressVIPMinimum/Sniffs/Constants/RestrictedConstantsSniff.php
+++ b/WordPressVIPMinimum/Sniffs/Constants/RestrictedConstantsSniff.php
@@ -37,11 +37,38 @@ class RestrictedConstantsSniff extends Sniff {
 	];
 
 	/**
+	 * List of (global) constant names, which should not be referenced in userland code, nor (re-)declared.
+	 *
+	 * {@internal The `public` versions of these properties can't be removed until the next major,
+	 * though a decision is still needed whether they should be removed at all.
+	 * Also see: Automattic/VIP-Coding-Standards#234 for more context and discussion about this.}
+	 *
+	 * @var array<string, int> Key is the constant name, value is irrelevant.
+	 */
+	private $restrictedConstants = [];
+
+	/**
+	 * List of (global) constants, which should not be (re-)declared, but may be referenced.
+	 *
+	 * {@internal The `public` versions of these properties can't be removed until the next major,
+	 * though a decision is still needed whether they should be removed at all.
+	 * Also see: Automattic/VIP-Coding-Standards#234 for more context and discussion about this.}
+	 *
+	 * @var array<string, int> Key is the constant name, value is irrelevant.
+	 */
+	private $restrictedRedeclaration = [];
+
+	/**
 	 * Returns an array of tokens this test wants to listen for.
 	 *
 	 * @return array<int|string>
 	 */
 	public function register() {
+		// For now, set the `private` properties based on the values of the `public` properties.
+		// This should be revisited when Automattic/VIP-Coding-Standards#234 gets actioned.
+		$this->restrictedConstants     = array_flip( $this->restrictedConstantNames );
+		$this->restrictedRedeclaration = array_flip( $this->restrictedConstantDeclaration );
+
 		return [
 			T_CONSTANT_ENCAPSED_STRING,
 			T_STRING,
@@ -63,12 +90,14 @@ class RestrictedConstantsSniff extends Sniff {
 			$constantName = trim( $this->tokens[ $stackPtr ]['content'], "\"'" );
 		}
 
-		if ( in_array( $constantName, $this->restrictedConstantNames, true ) === false && in_array( $constantName, $this->restrictedConstantDeclaration, true ) === false ) {
+		if ( isset( $this->restrictedConstants[ $constantName ] ) === false
+			&& isset( $this->restrictedRedeclaration[ $constantName ] ) === false
+		) {
 			// Not the constant we are looking for.
 			return;
 		}
 
-		if ( $this->tokens[ $stackPtr ]['code'] === T_STRING && in_array( $constantName, $this->restrictedConstantNames, true ) === true ) {
+		if ( $this->tokens[ $stackPtr ]['code'] === T_STRING && isset( $this->restrictedConstants[ $constantName ] ) === true ) {
 			$message = 'Code is touching the `%s` constant. Make sure it\'s used appropriately.';
 			$data    = [ $constantName ];
 			$this->phpcsFile->addWarning( $message, $stackPtr, 'UsingRestrictedConstant', $data );
@@ -102,7 +131,7 @@ class RestrictedConstantsSniff extends Sniff {
 			if ( $this->tokens[ $previous ]['content'] === 'define' ) {
 				$message = 'The definition of `%s` constant is prohibited. Please use a different name.';
 				$this->phpcsFile->addError( $message, $previous, 'DefiningRestrictedConstant', $data );
-			} elseif ( in_array( $constantName, $this->restrictedConstantNames, true ) === true ) {
+			} elseif ( isset( $this->restrictedConstants[ $constantName ] ) === true ) {
 				$message = 'Code is touching the `%s` constant. Make sure it\'s used appropriately.';
 				$this->phpcsFile->addWarning( $message, $previous, 'UsingRestrictedConstant', $data );
 			}

--- a/WordPressVIPMinimum/Tests/Constants/RestrictedConstantsUnitTest.inc
+++ b/WordPressVIPMinimum/Tests/Constants/RestrictedConstantsUnitTest.inc
@@ -21,3 +21,5 @@ if ( defined( 'JETPACK_DEV_DEBUG' ) ) { // Okay. Can touch.
 if ( constant( 'WP_CRON_CONTROL_SECRET' ) ) { // Okay. Can touch.
 
 }
+
+define( '"A8C_PROXIED_REQUEST"', false ); // Okay, well not really as the name is not a valid PHP constant name, but that's not our concern.


### PR DESCRIPTION
### Constants/RestrictedConstants: minor efficiency fix 

This commit introduces `private` property versions of the pre-existing `public` properties, where the array format is different.
The `private` properties have the target constant names as the array key, not as the value.

This allows for using `isset()` instead of `in_array()`.

### Constants/RestrictedConstants: fix nonsensical comparison 

The only token this sniff needs to check for (at this time) is the `T_STRING` token, which is used for both constant names as well as function names.

Any other token in the `Tokens::$functionNameTokens` token array will never match the subsequent contents comparison anyhow.

### Constants/RestrictedConstants: use PHPCSUtils `TextStrings::stripQuotes()`

... to only strip the wrapping quotes and not remove any quotes inside the wrapping quotes, which are part of the actual text string.

Includes test.