### PR TITLE
Fix CI and bump minimum PHP to 7.4

### DIFF
--- a/.github/workflows/basics.yml
+++ b/.github/workflows/basics.yml
@@ -74,17 +74,8 @@ jobs:
           pattern: ".phpcs.xml.dist"
           xsd-file: "vendor/squizlabs/php_codesniffer/phpcs.xsd"
 
-      # Notes:
-      # - PHPUnit 9.5 (which will be installed in this job) doesn't ship XSD files further back than 8.5.
-      # - PHPUnit 9.3 introduced some new configuration options and deprecated the old versions of those.
-      #   For cross-version compatibility with older PHPUnit versions, those new config options cannot be used yet,
-      #   which is why the PHPUnit 9 validation is done against the PHPUnit 9.2 schema.
-      - name: "Validate PHPUnit config for use with PHPUnit 8"
-        uses: phpcsstandards/xmllint-validate@v1
-        with:
-          pattern: "phpunit.xml.dist"
-          xsd-file: "vendor/phpunit/phpunit/schema/8.5.xsd"
-
+      # Note: PHPUnit 9.3 introduced some new configuration options and deprecated the old versions of those.
+      # For cross-version compatibility, the validation is done against the PHPUnit 9.2 schema.
       - name: "Validate PHPUnit config for use with PHPUnit 9"
         uses: phpcsstandards/xmllint-validate@v1
         with:

--- a/.github/workflows/basics.yml
+++ b/.github/workflows/basics.yml
@@ -42,8 +42,8 @@ jobs:
         run: composer validate --no-check-all --strict
 
       - name: 'Composer: adjust dependencies'
-        # Using PHPCS `master` as an early detection system for bugs upstream.
-        run: composer require --no-update --no-scripts squizlabs/php_codesniffer:"dev-master" --no-interaction
+        # Using PHPCS `3.x` as an early detection system for bugs upstream.
+        run: composer require --no-update --no-scripts squizlabs/php_codesniffer:"3.x-dev" --no-interaction
 
       # Install dependencies and handle caching in one go.
       # @link https://github.com/marketplace/actions/install-php-dependencies-with-composer

--- a/.github/workflows/quicktest.yml
+++ b/.github/workflows/quicktest.yml
@@ -26,9 +26,9 @@ jobs:
     strategy:
       matrix:
         include:
-          - php: '5.4'
+          - php: '7.4'
             dependencies: 'stable'
-          - php: '5.4'
+          - php: '7.4'
             dependencies: 'lowest'
 
           - php: 'latest'

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -117,7 +117,7 @@ jobs:
         if: ${{ matrix.dependencies == 'dev' }}
         run: >
           composer require --no-update --no-scripts --no-interaction
-          squizlabs/php_codesniffer:"dev-master"
+          squizlabs/php_codesniffer:"3.x-dev"
           phpcsstandards/phpcsutils:"dev-develop"
           phpcsstandards/phpcsextra:"dev-develop"
           sirbrillig/phpcs-variable-analysis:"2.x"

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -28,7 +28,7 @@ jobs:
 
     strategy:
       matrix:
-        php: ['5.4', 'latest', '8.5']
+        php: ['7.4', 'latest', '8.5']
 
     name: "Lint: PHP ${{ matrix.php }}"
     continue-on-error: ${{ matrix.php == '8.5' }}
@@ -64,20 +64,13 @@ jobs:
       # - php: The PHP versions to test against.
       # - dependencies: The PHPCS dependencies versions to test against.
       #   IMPORTANT: test runs shouldn't fail because of PHPCS being incompatible with a PHP version.
-      #   - PHPCS will run without errors on PHP 5.4 - 7.4 on any supported version.
-      #   - PHP 8.0 needs PHPCS 3.5.7+ to run without errors, and we require a higher minimum version.
-      #   - PHP 8.1 needs PHPCS 3.6.1+ to run without errors, but works best with 3.7.1+, and we require at least this minimum version.
       #   - PHP 8.2, 8.3 and 8.4 need PHPCS 3.8.0+ to run without errors (though the errors don't affect the tests).
       matrix:
-        php: ['5.4', '5.5', '5.6', '7.0', '7.1', '7.2', '7.3', '7.4', '8.0', '8.1', '8.2', '8.3', '8.4']
+        php: ['7.4', '8.0', '8.1', '8.2', '8.3', '8.4']
         dependencies: ['lowest', 'stable']
 
         include:
           # Test against dev versions of all dependencies with select PHP versions for early detection of issues.
-          - php: '5.4'
-            dependencies: 'dev'
-          - php: '7.0'
-            dependencies: 'dev'
           - php: '7.4'
             dependencies: 'dev'
           - php: '8.4'

--- a/composer.json
+++ b/composer.json
@@ -16,7 +16,7 @@
 		}
 	],
 	"require": {
-		"php": ">=5.4",
+		"php": ">=7.4",
 		"phpcsstandards/phpcsextra": "^1.4.0",
 		"phpcsstandards/phpcsutils": "^1.1.0",
 		"sirbrillig/phpcs-variable-analysis": "^2.12.0",
@@ -28,7 +28,7 @@
 		"php-parallel-lint/php-console-highlighter": "^1.0.0",
 		"phpcompatibility/php-compatibility": "^9",
 		"phpcsstandards/phpcsdevtools": "^1.2.3",
-		"phpunit/phpunit": "^4 || ^5 || ^6 || ^7 || ^8 || ^9"
+		"phpunit/phpunit": "^8 || ^9"
 	},
 	"config": {
 		"allow-plugins": {

--- a/composer.json
+++ b/composer.json
@@ -28,7 +28,7 @@
 		"php-parallel-lint/php-console-highlighter": "^1.0.0",
 		"phpcompatibility/php-compatibility": "^9",
 		"phpcsstandards/phpcsdevtools": "^1.2.3",
-		"phpunit/phpunit": "^8 || ^9"
+		"phpunit/phpunit": "^9"
 	},
 	"config": {
 		"allow-plugins": {


### PR DESCRIPTION
## Summary

The CI workflows testing against development versions of PHPCS dependencies have been failing because they referenced `dev-master` for `squizlabs/php_codesniffer`, but that branch no longer exists — the repository moved to `phpcsstandards/php_codesniffer` and the development branch is now `3.x`. The correct Composer constraint for a version-like branch is `3.x-dev` (suffix form), not `dev-3.x`.

Fixing the PHPCS branch reference then exposed a second issue: WPCS `develop` now requires PHP 7.2+, causing the PHP 5.4 and 7.0 "dev" matrix entries to fail on dependency resolution. Rather than simply adjusting the dev matrix, this raises the minimum PHP version to 7.4. The VIP platform requires PHP 8.3, and consuming plugins typically require 7.4+, so PHP 5.4 support was purely theoretical at this point.

With PHP 7.4 as the floor, PHPUnit 8 (which supports PHP 7.2+) is no longer needed — PHPUnit 9 (PHP 7.3+) covers the entire supported range. This removes PHPUnit 8 from the Composer constraint and drops the PHPUnit 8 schema validation step from the BasicQA workflow.

### Changes

- **PHPCS dev branch**: `dev-master` → `3.x-dev` in `basics.yml` and `test.yml`
- **Minimum PHP**: 5.4 → 7.4 in `composer.json`, lint matrix, test matrix, quicktest matrix
- **PHPUnit**: `^4 || ^5 || ^6 || ^7 || ^8 || ^9` → `^9`; removed PHPUnit 8 schema validation step

## Test plan

- [ ] CI passes — specifically the "Basic CS and QA checks" and "PHPCS dev" test matrix entries
- [ ] Quicktest matrix runs against PHP 7.4 (lowest) and latest
- [ ] Full test matrix covers PHP 7.4–8.4 with lowest/stable, plus 7.4/8.4/8.5 with dev dependencies