### PR TITLE
Fix bugs and adopt PHPCSUtils in AlwaysReturnInFilterSniff

### DIFF
--- a/WordPressVIPMinimum/Sniffs/Hooks/AlwaysReturnInFilterSniff.php
+++ b/WordPressVIPMinimum/Sniffs/Hooks/AlwaysReturnInFilterSniff.php
@@ -12,6 +12,7 @@ namespace WordPressVIPMinimum\Sniffs\Hooks;
 use PHP_CodeSniffer\Util\Tokens;
 use PHPCSUtils\Utils\Arrays;
 use PHPCSUtils\Utils\FunctionDeclarations;
+use PHPCSUtils\Utils\TextStrings;
 use WordPressVIPMinimum\Sniffs\Sniff;
 
 /**
@@ -80,6 +81,9 @@ class AlwaysReturnInFilterSniff extends Sniff {
 
 		if ( $this->tokens[ $callbackPtr ]['code'] === T_CLOSURE ) {
 			$this->processFunctionBody( $callbackPtr );
+		} elseif ( $this->tokens[ $callbackPtr ]['code'] === T_FN ) {
+			// Arrow functions always return a value implicitly. No check needed.
+			return;
 		} elseif ( $this->tokens[ $callbackPtr ]['code'] === T_ARRAY
 			|| $this->tokens[ $callbackPtr ]['code'] === T_OPEN_SHORT_ARRAY
 		) {
@@ -133,7 +137,7 @@ class AlwaysReturnInFilterSniff extends Sniff {
 	 */
 	private function processString( $stackPtr, $start = 0, $end = null ) {
 
-		$callbackFunctionName = substr( $this->tokens[ $stackPtr ]['content'], 1, -1 );
+		$callbackFunctionName = TextStrings::stripQuotes( $this->tokens[ $stackPtr ]['content'] );
 
 		$callbackFunctionPtr = $this->phpcsFile->findNext(
 			T_STRING,
@@ -165,10 +169,10 @@ class AlwaysReturnInFilterSniff extends Sniff {
 		$functionName = $this->tokens[ $stackPtr ]['content'];
 
 		$offset = $start;
-		while ( $this->phpcsFile->findNext( [ T_FUNCTION ], $offset, $end ) !== false ) {
-			$functionStackPtr = $this->phpcsFile->findNext( [ T_FUNCTION ], $offset, $end );
-			$functionNamePtr  = $this->phpcsFile->findNext( Tokens::$emptyTokens, $functionStackPtr + 1, null, true, null, true );
-			if ( $this->tokens[ $functionNamePtr ]['code'] === T_STRING && $this->tokens[ $functionNamePtr ]['content'] === $functionName ) {
+		// phpcs:ignore Generic.CodeAnalysis.AssignmentInCondition.FoundInWhileCondition -- Valid usage.
+		while ( ( $functionStackPtr = $this->phpcsFile->findNext( T_FUNCTION, $offset, $end ) ) !== false ) {
+			$declaredName = FunctionDeclarations::getName( $this->phpcsFile, $functionStackPtr );
+			if ( $declaredName === $functionName ) {
 				$this->processFunctionBody( $functionStackPtr );
 				return;
 			}
@@ -294,7 +298,7 @@ class AlwaysReturnInFilterSniff extends Sniff {
 	private function isReturningVoid( $stackPtr ) {
 
 		$nextToReturnTokenPtr = $this->phpcsFile->findNext(
-			[ Tokens::$emptyTokens ],
+			Tokens::$emptyTokens,
 			$stackPtr + 1,
 			null,
 			true

--- a/WordPressVIPMinimum/Tests/Hooks/AlwaysReturnInFilterUnitTest.inc
+++ b/WordPressVIPMinimum/Tests/Hooks/AlwaysReturnInFilterUnitTest.inc
@@ -188,6 +188,15 @@ class tokenizer_bug_test {
 	public function tokenizer_bug( $param ): namespace\Foo {} // Error.
 }
 
+// Arrow function callbacks always return implicitly. Ok.
+add_filter( 'good_arrow_function', fn( $x ) => $x . ' suffix' );
+
+add_filter( 'good_arrow_function_null', fn( $x ) => null ); // Ok, still returns a value (null).
+
+add_filter( 'bad_void_return_with_space', function() { // Error.
+	return ;
+} );
+
 // Intentional parse error. This has to be the last test in the file!
 class parse_error_test {
 	public function __construct() {

--- a/WordPressVIPMinimum/Tests/Hooks/AlwaysReturnInFilterUnitTest.php
+++ b/WordPressVIPMinimum/Tests/Hooks/AlwaysReturnInFilterUnitTest.php
@@ -31,6 +31,7 @@ class AlwaysReturnInFilterUnitTest extends AbstractSniffUnitTest {
 			129 => 1,
 			163 => 1,
 			188 => 1,
+			196 => 1,
 		];
 	}
 


### PR DESCRIPTION
## Summary

The `AlwaysReturnInFilterSniff` had a subtle bug in `isReturningVoid()` where `Tokens::$emptyTokens` was wrapped in an extra array (`[ Tokens::$emptyTokens ]`). Since PHPCS's `findNext` compares each value in the exclusion array against token codes using `===`, the nested array never matched anything, meaning no tokens were skipped. This caused `return ;` (with whitespace before the semicolon) to go undetected as a void return, while `return;` worked by accident because the next token happened to be `T_SEMICOLON`.

This PR fixes that bug and makes several related quality improvements:

The duplicate `findNext` call in `processFunction()` — where the while condition called it and discarded the result, then the next line called it identically — is collapsed into a single assignment-in-condition pattern, matching the style used elsewhere in the codebase.

Manual name resolution via `findNext(Tokens::$emptyTokens, ...)` followed by a string content check is replaced with `FunctionDeclarations::getName()` from PHPCSUtils, and `substr($content, 1, -1)` for quote stripping is replaced with `TextStrings::stripQuotes()`.

Arrow function (`T_FN`) callbacks are now handled: since they always implicitly return a value, they are safe as filter callbacks and the sniff now returns early rather than falling through to flag them.

New test cases cover the void return with whitespace bug fix and both arrow function scenarios.

## Test plan

- [ ] `composer test` passes (specifically `AlwaysReturnInFilterUnitTest`)
- [ ] `return ;` with whitespace is now correctly detected as a void return
- [ ] Arrow function callbacks (`fn($x) => ...`) do not trigger false positives