### PR TITLE
Warn instead of error for exit/die/throw in filter callbacks

### DIFF
--- a/WordPressVIPMinimum/Sniffs/Hooks/AlwaysReturnInFilterSniff.php
+++ b/WordPressVIPMinimum/Sniffs/Hooks/AlwaysReturnInFilterSniff.php
@@ -246,9 +246,15 @@ class AlwaysReturnInFilterSniff extends Sniff {
 		}
 
 		if ( $outsideConditionalReturn === 0 ) {
-			$message = 'Please, make sure that a callback to `%s` filter is always returning some value.';
-			$data    = [ $filterName ];
-			$this->phpcsFile->addError( $message, $functionBodyScopeStart, 'MissingReturnStatement', $data );
+			if ( $this->hasTerminatingStatement( $functionBodyScopeStart, $functionBodyScopeEnd ) ) {
+				$message = 'The callback for the `%s` filter uses a terminating statement (`exit`, `die`, or `throw`) instead of returning a value. Filter callbacks should always return a value.';
+				$data    = [ $filterName ];
+				$this->phpcsFile->addWarning( $message, $functionBodyScopeStart, 'TerminatingInsteadOfReturn', $data );
+			} else {
+				$message = 'Please, make sure that a callback to `%s` filter is always returning some value.';
+				$data    = [ $filterName ];
+				$this->phpcsFile->addError( $message, $functionBodyScopeStart, 'MissingReturnStatement', $data );
+			}
 		}
 	}
 
@@ -286,6 +292,25 @@ class AlwaysReturnInFilterSniff extends Sniff {
 			}
 		}
 		return false;
+	}
+
+	/**
+	 * Check whether the function body contains an exit, die, or throw statement.
+	 *
+	 * @param int $scopeStart The scope opener of the function body.
+	 * @param int $scopeEnd   The scope closer of the function body.
+	 *
+	 * @return bool
+	 */
+	private function hasTerminatingStatement( $scopeStart, $scopeEnd ) {
+
+		$terminatingPtr = $this->phpcsFile->findNext(
+			[ T_EXIT, T_THROW ],
+			$scopeStart + 1,
+			$scopeEnd
+		);
+
+		return $terminatingPtr !== false;
 	}
 
 	/**

--- a/WordPressVIPMinimum/Tests/Hooks/AlwaysReturnInFilterUnitTest.inc
+++ b/WordPressVIPMinimum/Tests/Hooks/AlwaysReturnInFilterUnitTest.inc
@@ -197,6 +197,51 @@ add_filter( 'bad_void_return_with_space', function() { // Error.
 	return ;
 } );
 
+// === exit/die/throw in filter callbacks (issue #719) ===
+
+// Exit used as unconditional termination path — warning, not error.
+function exit_in_filter( $redirect_url ) { // Warning.
+	if ( some_condition() ) {
+		return $redirect_url;
+	}
+	wp_redirect( $redirect_url );
+	exit;
+}
+add_filter( 'redirect_canonical', 'exit_in_filter' );
+
+// Die used as unconditional termination path — warning, not error.
+add_filter( 'die_in_filter', function( $url ) { // Warning.
+	if ( some_condition() ) {
+		return $url;
+	}
+	die( 'Terminated' );
+} );
+
+// Throw used as unconditional termination path — warning, not error.
+class throw_in_filter_class {
+	public function __construct() {
+		add_filter( 'throw_in_filter', [ $this, 'validate' ] );
+	}
+
+	public function validate( $value ) { // Warning.
+		if ( is_valid( $value ) ) {
+			return $value;
+		}
+		throw new \RuntimeException( 'Invalid value' );
+	}
+}
+
+// Exit with no return at all — warning, not error.
+add_filter( 'exit_no_return', function( $input ) { // Warning.
+	do_something( $input );
+	exit;
+} );
+
+// No return and no exit/die/throw — remains an error.
+add_filter( 'still_missing_return', function( $input ) { // Error.
+	do_something( $input );
+} );
+
 // Intentional parse error. This has to be the last test in the file!
 class parse_error_test {
 	public function __construct() {

--- a/WordPressVIPMinimum/Tests/Hooks/AlwaysReturnInFilterUnitTest.php
+++ b/WordPressVIPMinimum/Tests/Hooks/AlwaysReturnInFilterUnitTest.php
@@ -32,6 +32,7 @@ class AlwaysReturnInFilterUnitTest extends AbstractSniffUnitTest {
 			163 => 1,
 			188 => 1,
 			196 => 1,
+			241 => 1,
 		];
 	}
 
@@ -43,6 +44,10 @@ class AlwaysReturnInFilterUnitTest extends AbstractSniffUnitTest {
 	public function getWarningList() {
 		return [
 			180 => 1,
+			203 => 1,
+			213 => 1,
+			226 => 1,
+			235 => 1,
 		];
 	}
 }


### PR DESCRIPTION
## Summary

When a filter callback uses `exit`, `die`, or `throw` instead of returning a value, the `AlwaysReturnInFilter` sniff previously flagged it with the `MissingReturnStatement` error code. While technically correct — the function doesn't return a value to the filter chain — this is misleading in practice. Developers who use `exit` or `throw` in a filter callback have made a deliberate choice to terminate execution; they haven't accidentally forgotten a `return`.

The canonical example is a redirect filter that either returns the URL or calls `wp_redirect()` followed by `exit`. The current sniff treats this identically to a callback that simply forgot to return, which makes the error message unhelpful and forces developers to suppress a generic code that might mask genuine issues elsewhere.

This PR introduces a `hasTerminatingStatement()` check that scans the function body for `T_EXIT` (covering both `exit` and `die`) and `T_THROW` tokens. When the sniff finds no unconditional return but does find a terminating statement, it now emits a `TerminatingInsteadOfReturn` **warning** with a specific message, rather than the generic `MissingReturnStatement` **error**. Callbacks with genuinely missing returns (no terminating statements either) continue to receive the original error.

This gives users a distinct, suppressible code (`WordPressVIPMinimum.Hooks.AlwaysReturnInFilter.TerminatingInsteadOfReturn`) for cases where the pattern is intentional, without silently ignoring potentially problematic code.

Refs #719.

## Test plan

- [ ] `composer test` passes
- [ ] Filter callbacks with `exit`/`die`/`throw` receive the `TerminatingInsteadOfReturn` warning (not error)
- [ ] Filter callbacks with no return and no terminating statement still receive the `MissingReturnStatement` error
- [ ] Existing test cases remain unaffected