### PR TITLE
Require WordPressCS 3.4.1 and align dependency floors

### DIFF
--- a/.phpcs.xml.dist
+++ b/.phpcs.xml.dist
@@ -44,7 +44,7 @@
 	<rule ref="Generic.ControlStructures.DisallowYodaConditions"/>
 
 	<!-- Check code for cross-version PHP compatibility. -->
-	<config name="testVersion" value="5.4-"/>
+	<config name="testVersion" value="7.4-"/>
 	<rule ref="PHPCompatibility">
 		<!-- Exclude PHP constants back-filled by PHPCS. -->
 		<exclude name="PHPCompatibility.Constants.NewConstants.t_finallyFound"/>

--- a/README.md
+++ b/README.md
@@ -15,12 +15,12 @@ The rulesets use rules from the [WordPress Coding Standards](https://github.com/
 
 ## Minimal requirements
 
-* PHP 5.4+
-* [PHPCS 3.13.2+](https://github.com/PHPCSStandards/PHP_CodeSniffer/releases)
-* [PHPCSUtils 1.1.0+](https://github.com/PHPCSStandards/PHPCSUtils)
-* [PHPCSExtra 1.4.0+](https://github.com/PHPCSStandards/PHPCSExtra)
-* [WPCS 3.1.0+](https://github.com/WordPress-Coding-Standards/WordPress-Coding-Standards/releases)
-* [VariableAnalysis 2.12.0+](https://github.com/sirbrillig/phpcs-variable-analysis/releases)
+* PHP 7.4+
+* [PHPCS 3.13.5+](https://github.com/PHPCSStandards/PHP_CodeSniffer/releases)
+* [PHPCSUtils 1.2.3+](https://github.com/PHPCSStandards/PHPCSUtils)
+* [PHPCSExtra 1.5.1+](https://github.com/PHPCSStandards/PHPCSExtra)
+* [WPCS 3.4.1+](https://github.com/WordPress-Coding-Standards/WordPress-Coding-Standards/releases)
+* [VariableAnalysis 2.13.0+](https://github.com/sirbrillig/phpcs-variable-analysis/releases)
 
 ## Installation
 

--- a/composer.json
+++ b/composer.json
@@ -17,11 +17,11 @@
 	],
 	"require": {
 		"php": ">=7.4",
-		"phpcsstandards/phpcsextra": "^1.4.0",
-		"phpcsstandards/phpcsutils": "^1.1.0",
-		"sirbrillig/phpcs-variable-analysis": "^2.12.0",
-		"squizlabs/php_codesniffer": "^3.13.2",
-		"wp-coding-standards/wpcs": "^3.2.0"
+		"phpcsstandards/phpcsextra": "^1.5.1",
+		"phpcsstandards/phpcsutils": "^1.2.3",
+		"sirbrillig/phpcs-variable-analysis": "^2.13.0",
+		"squizlabs/php_codesniffer": "^3.13.5",
+		"wp-coding-standards/wpcs": "^3.4.1"
 	},
 	"require-dev": {
 		"php-parallel-lint/php-parallel-lint": "^1.4.0",


### PR DESCRIPTION
## Summary

WordPressCS 3.4.1 is a security release (advisory [GHSA-3pwp-g2mj-5p3v](https://github.com/WordPress/WordPress-Coding-Standards/security/advisories/GHSA-3pwp-g2mj-5p3v)), and the 3.3.0–3.4.1 line also brings a number of accuracy improvements to WordPressCS sniffs that VIPCS bundles and runs. Raising the minimum requirement passes both on to VIPCS users.

The vulnerability itself is in the `WordPress.WP.EnqueuedResourceParameters` sniff, which neither VIPCS ruleset enables, so this does not change VIPCS' own behaviour. It is a dependency-hygiene bump: it removes the affected WordPressCS releases from users' dependency trees and protects anyone who additionally runs the `WordPress` or `WordPress-Extra` standards.

The remaining coding-standard floors are raised in step to match what WordPressCS 3.4.1 itself requires — PHP_CodeSniffer 3.13.5, PHPCSUtils 1.2.3 and PHPCSExtra 1.5.1 — along with VariableAnalysis 2.13.0. The README "Minimal requirements" and the PHPCompatibility `testVersion` (now `7.4-`, matching the existing PHP floor) are brought back into sync, as both had drifted from `composer.json`.

This is the dependency portion of the 3.1.0 release; the changelog will follow on the release branch.

## Test plan

- [ ] `composer update` resolves WordPressCS 3.4.1, PHP_CodeSniffer 3.13.5, PHPCSUtils 1.2.3, PHPCSExtra 1.5.1 and VariableAnalysis 2.13.0
- [ ] `composer test-ruleset`, `composer test`, `composer feature-completeness` and `composer cs` all pass
- [ ] `composer audit` reports no advisories