### PR TITLE
Don't flag php:// stream wrappers as remote requests

### DIFF
--- a/WordPressVIPMinimum/Sniffs/Performance/FetchingRemoteDataSniff.php
+++ b/WordPressVIPMinimum/Sniffs/Performance/FetchingRemoteDataSniff.php
@@ -66,7 +66,18 @@ class FetchingRemoteDataSniff extends AbstractFunctionParameterSniff {
 		$search_start = $param_start;
 		// phpcs:ignore Generic.CodeAnalysis.AssignmentInCondition.FoundInWhileCondition -- Valid usage.
 		while ( ( $has_text_string = $this->phpcsFile->findNext( Tokens::$stringTokens, $search_start, $search_end ) ) !== false ) {
-			if ( strpos( $this->tokens[ $has_text_string ]['content'], '://' ) !== false ) {
+			$string_content = $this->tokens[ $has_text_string ]['content'];
+			if ( strpos( $string_content, '://' ) !== false ) {
+				/*
+				 * The `php://` stream wrappers (php://input, php://stdin, php://memory,
+				 * php://temp, etc.) are local, in-process streams rather than remote
+				 * requests, so should not be flagged. The scheme is case-insensitive.
+				 */
+				if ( preg_match( '`^["\']?php://`i', $string_content ) === 1 ) {
+					$search_start = ( $has_text_string + 1 );
+					continue;
+				}
+
 				$isRemoteFile = true;
 				break;
 			}

--- a/WordPressVIPMinimum/Tests/Performance/FetchingRemoteDataUnitTest.inc
+++ b/WordPressVIPMinimum/Tests/Performance/FetchingRemoteDataUnitTest.inc
@@ -86,3 +86,13 @@ $result = file_get_contents(( is_ssl() ? 'http' : 'https' ) . '://example.com');
 
 // Bug: don't presume if the parameter contains a text string token, that will be the only token.
 \file_get_contents( $url . '/filename.css' ); // Warning FileGetContentsUnknown.
+
+// Bug #506: the `php://` stream wrappers are local, in-process streams, not remote requests, so should not be flagged.
+$webhook_body     = file_get_contents( 'php://input' ); // OK.
+$std_input        = \file_get_contents( 'php://stdin' ); // OK.
+$in_memory        = file_get_contents( "php://memory" ); // OK.
+$temp_stream      = file_get_contents( 'php://temp/maxmemory:1048576' ); // OK.
+$case_insensitive = file_get_contents( 'PHP://input' ); // OK. The scheme is case-insensitive.
+
+// Bug #506: a `php://` substring which is not the URL scheme must still be flagged as remote.
+$masked_remote = file_get_contents( 'https://example.com/?redirect=php://input' ); // Warning FileGetContentsRemoteFile.

--- a/WordPressVIPMinimum/Tests/Performance/FetchingRemoteDataUnitTest.php
+++ b/WordPressVIPMinimum/Tests/Performance/FetchingRemoteDataUnitTest.php
@@ -45,6 +45,7 @@ class FetchingRemoteDataUnitTest extends AbstractSniffUnitTest {
 			79 => 1,
 			85 => 1,
 			88 => 1,
+			98 => 1,
 		];
 	}
 }


### PR DESCRIPTION
## Summary

The `WordPressVIPMinimum.Performance.FetchingRemoteData` sniff discourages remote requests made through `file_get_contents()`, pointing developers towards `wpcom_vip_file_get_contents()` or `vip_safe_wp_remote_get()` instead. It decided a call was remote by looking for `://` anywhere in the string argument.

That heuristic misfires on PHP's `php://` stream wrappers. `php://input`, `php://stdin`, `php://memory`, `php://temp` and friends are local, in-process streams, not remote HTTP requests, so neither suggested alternative applies. `php://input` is especially awkward: it is the canonical (and effectively unavoidable) way to read a raw request body, for example when handling an incoming webhook, and there is no VIP helper that replaces it. The result was a warning the developer could only silence with an ignore annotation.

This change exempts the `php://` scheme from the remote-file check. Matching is anchored to the start of the string and is case-insensitive, so `PHP://input` is also recognised, while a `php://` substring that is *not* the URL scheme (such as a query-string value on an `https://` URL) continues to be flagged as remote.

Fixes #506.

## Test plan

Unit tests are included in `FetchingRemoteDataUnitTest.inc`/`.php` covering the exempted wrappers, the case-insensitive scheme, and the regression guard that a masked `php://` substring on a genuine remote URL is still flagged.

- [ ] `composer test -- --filter FetchingRemoteData`