### PR TITLE
Remove obsolete doc-link TODO from RestrictedHooks

### DIFF
--- a/WordPressVIPMinimum/Sniffs/Hooks/RestrictedHooksSniff.php
+++ b/WordPressVIPMinimum/Sniffs/Hooks/RestrictedHooksSniff.php
@@ -46,7 +46,6 @@ class RestrictedHooksSniff extends AbstractFunctionParameterSniff {
 	 */
 	private $restricted_hook_groups = [
 		'upload_mimes' => [
-			// TODO: This error message needs a link to the VIP Documentation, see https://github.com/Automattic/VIP-Coding-Standards/issues/235.
 			'type'  => 'warning',
 			'msg'   => 'Please ensure that the mimes being filtered do not include insecure types (i.e. SVG, SWF, etc.). Manual inspection required.',
 			'hooks' => [


### PR DESCRIPTION
## Summary

The `upload_mimes` group in `RestrictedHooksSniff` carried a `// TODO` asking for a VIP documentation link to be added to its warning, tracked in #235. That issue has since been closed without adding a link: docs.wpvip.com documents general topics rather than individual sniffs, and no page covers safely customising `upload_mimes` or the risk of allowing insecure upload types, so there was nothing suitable to point at.

Left in place, the comment references a closed, decided-against issue and would only prompt someone to repeat the same investigation. The warning itself ("Please ensure that the mimes being filtered do not include insecure types…") is self-explanatory, so this simply drops the comment. Comment-only change, no behaviour difference.

Follows on from the #235 triage.